### PR TITLE
fix(embed): shift-register time-travel — restore engine + environment…

### DIFF
--- a/apps/sandbox/src/main.ts
+++ b/apps/sandbox/src/main.ts
@@ -23,7 +23,9 @@ import {
   elaborate,
 } from '@simten/core';
 import type { Circuit, BitValue, BusValue } from '@simten/core';
+import type { SimulatorSnapshot } from '@simten/core';
 import { registerCircuitEval } from '@simten/core/circuit';
+import { captureEnvironmentalState, type EnvironmentalStateValue } from '@simten/core/simulator';
 
 /** Serialized eval entry — source strings reconstructed via new Function() */
 interface EvalSource {
@@ -41,13 +43,16 @@ interface EvalSource {
 /** Each simulation lives in a named slot. Slots are independent (own simulator, library, source). */
 type SandboxRequest =
   | { id: string; type: 'compile'; source: string; slot?: string }
-  | { id: string; type: 'compile-ir'; circuit: Circuit; libraryCircuits: Circuit[]; slot: string; evalSources?: Record<string, EvalSource> }
-  | { id: string; type: 'tick'; inputs?: Record<string, number | boolean>; slot?: string }
-  | { id: string; type: 'tick-n'; n: number; inputs?: Record<string, number | boolean>; slot?: string }
+  | { id: string; type: 'compile-ir'; circuit: Circuit; libraryCircuits: Circuit[]; slot: string; evalSources?: Record<string, EvalSource>; snapshot?: boolean }
+  | { id: string; type: 'tick'; inputs?: Record<string, number | boolean>; slot?: string; snapshot?: boolean }
+  | { id: string; type: 'tick-n'; n: number; inputs?: Record<string, number | boolean>; slot?: string; snapshot?: boolean }
   | { id: string; type: 'scan-port'; addrNodeId: string; valuePortKey: string; count: number; slot?: string }
   | { id: string; type: 'simulate'; source?: string; ticks: number; inputs?: Record<string, number | boolean>; memoryData?: Record<string, Record<string, number>>; slot?: string }
   | { id: string; type: 'reset'; slot?: string }
-  | { id: string; type: 'set-node'; nodeId: string; value: number | boolean | Map<number, number>; slot?: string }
+  | { id: string; type: 'set-node'; nodeId: string; value: number | boolean | Map<number, number>; slot?: string; snapshot?: boolean }
+  | { id: string; type: 'snapshot'; slot?: string }
+  | { id: string; type: 'restore'; slot?: string; snapshotId: number }
+  | { id: string; type: 'prune-snapshots'; slot?: string; keepAfterId: number }
   | { id: string; type: 'dispose'; slot: string };
 
 // ============================================================================
@@ -111,10 +116,31 @@ function delegateToWorker(msg: object & { id: string }): Promise<object> {
 
 // Each slot has its own simulator + library + source — fully independent.
 // Slot IDs are supplied by the client. Legacy clients (no slot) use 'default'.
+/**
+ * A full time-travel snapshot is (simulator engine state) + (environmental
+ * state). The engine captures sequential registers + port values, but
+ * combinational primitives driven by `node.arguments` (Switch, Button, Input —
+ * anything with metadata.interactiveArg) are NOT part of engine state. They
+ * live as arguments on the circuit's nodes, which the engine doesn't touch on
+ * snapshot/restore. The host expects rewind to restore what the user saw —
+ * including switch positions — so we must capture and restore both halves.
+ * See packages/core/src/simulator/environmental-state.ts.
+ */
+interface FullSnapshot {
+  sim: SimulatorSnapshot;
+  env: Map<string, EnvironmentalStateValue>;
+}
+
 interface SlotState {
   simulator: ReturnType<typeof createSimulator> | null;
   library: { resolveCircuit(name: string): Circuit | undefined; addCircuit?(c: Circuit): void } | null;
   source: string;
+  /**
+   * The elaborated flat circuit. Kept so we can capture/restore environmental
+   * state (node.arguments for Switch/Button/Input) on snapshot/restore —
+   * environmental-state.ts walks these nodes to find interactive args.
+   */
+  flatCircuit: { nodes: Array<{ id: string; primitiveType: string; arguments: Record<string, unknown> }> } | null;
   /**
    * Set of nodeIds whose simulation state is exposed across the sandbox
    * boundary every tick. A node qualifies if it has at least one direct
@@ -125,6 +151,15 @@ interface SlotState {
    * Computed once at compile time; iterated each tick.
    */
   peripheralBusNodes: Set<string>;
+  /**
+   * Saved simulator snapshots for time-travel. Keyed by an auto-incrementing
+   * ID handed back to the host; the host stores only the IDs and passes them
+   * back to restore. Kept inside the sandbox so snapshots never need to cross
+   * the postMessage boundary (saves ~all serialization cost per tick).
+   * Pruned by the host via 'prune-snapshots' when its cap is reached.
+   */
+  snapshots: Map<number, FullSnapshot>;
+  nextSnapshotId: number;
 }
 
 const slots = new Map<string, SlotState>();
@@ -133,10 +168,51 @@ const DEFAULT_SLOT = 'default';
 function getSlot(id: string): SlotState {
   let s = slots.get(id);
   if (!s) {
-    s = { simulator: null, library: null, source: '', peripheralBusNodes: new Set() };
+    s = {
+      simulator: null,
+      library: null,
+      source: '',
+      flatCircuit: null,
+      peripheralBusNodes: new Set(),
+      snapshots: new Map(),
+      nextSnapshotId: 1,
+    };
     slots.set(id, s);
   }
   return s;
+}
+
+/**
+ * Take a full snapshot of the slot: simulator engine state (sequential regs +
+ * port values) plus environmental state (Switch/Button/Input `node.arguments`
+ * for any primitive tagged `metadata.interactiveArg`). Returns the generated
+ * ID. No-op + undefined for circuits with no snapshotable state (purely
+ * combinational with no interactive nodes — sim.snapshot() throws and env
+ * capture is harmlessly empty).
+ */
+function takeSnapshot(slot: SlotState): number | undefined {
+  if (!slot.simulator) return undefined;
+  try {
+    const sim = slot.simulator.snapshot();
+    // Walk the FlatCircuit for interactive args. We can't use core's
+    // captureEnvironmentalState directly: it reads `node.componentRef` on a
+    // pre-elaboration Circuit, but post-elaboration FlatNode has `primitiveType`.
+    const env = new Map<string, EnvironmentalStateValue>();
+    if (slot.flatCircuit && slot.library) {
+      for (const node of slot.flatCircuit.nodes) {
+        const def = slot.library.resolveCircuit(node.primitiveType);
+        const interactiveArg = (def as { metadata?: { interactiveArg?: string } } | undefined)?.metadata?.interactiveArg;
+        if (!interactiveArg) continue;
+        env.set(node.id, node.arguments[interactiveArg] as EnvironmentalStateValue);
+      }
+    }
+    const id = slot.nextSnapshotId++;
+    slot.snapshots.set(id, { sim, env });
+    return id;
+  } catch {
+    // Combinational-only + no interactive: nothing to snapshot.
+    return undefined;
+  }
 }
 
 /**
@@ -306,7 +382,10 @@ async function handleCompile(id: string, source: string, slotId: string = DEFAUL
     slot.simulator = sim;
     slot.library = library;
     slot.source = source;
+    slot.flatCircuit = flatCircuit;
     slot.peripheralBusNodes = computePeripheralBusNodes(flatCircuit, library);
+    // Recompile is a fresh timeline — prior snapshots refer to the old sim.
+    slot.snapshots.clear();
 
     const portValues = portValuesToObject(sim.getPortValues());
 
@@ -322,7 +401,7 @@ async function handleCompile(id: string, source: string, slotId: string = DEFAUL
   }
 }
 
-function handleTick(id: string, inputs?: Record<string, number | boolean>, slotId: string = DEFAULT_SLOT) {
+function handleTick(id: string, inputs?: Record<string, number | boolean>, slotId: string = DEFAULT_SLOT, snapshot?: boolean) {
   const slot = slots.get(slotId);
   const sim = slot?.simulator;
   if (!sim || !slot) {
@@ -332,11 +411,13 @@ function handleTick(id: string, inputs?: Record<string, number | boolean>, slotI
   try {
     if (inputs) applyInputs(sim, inputs);
     const result = sim.tick();
+    const snapshotId = snapshot ? takeSnapshot(slot) : undefined;
     respond(id, {
       type: 'ticked',
       portValues: portValuesToObject(result.portValues),
       cycle: sim.getMetrics().totalTicks,
       peripheralState: snapshotPeripheralState(slot),
+      snapshotId,
     });
   } catch (e) {
     respondError(id, e instanceof Error ? e.message : String(e));
@@ -377,7 +458,7 @@ function handleScanPort(id: string, addrNodeId: string, valuePortKey: string, co
 // Advance the simulator by N cycles in one round-trip. Returns only the final
 // port values and one peripheral-state snapshot. Used by demos that need high
 // tick rates (raster frames) — one postMessage instead of N.
-function handleTickN(id: string, n: number, inputs?: Record<string, number | boolean>, slotId: string = DEFAULT_SLOT) {
+function handleTickN(id: string, n: number, inputs?: Record<string, number | boolean>, slotId: string = DEFAULT_SLOT, snapshot?: boolean) {
   const slot = slots.get(slotId);
   const sim = slot?.simulator;
   if (!sim || !slot) {
@@ -389,11 +470,13 @@ function handleTickN(id: string, n: number, inputs?: Record<string, number | boo
     let last: ReturnType<typeof sim.tick> | null = null;
     const count = Math.max(0, n | 0);
     for (let i = 0; i < count; i++) last = sim.tick();
+    const snapshotId = snapshot ? takeSnapshot(slot) : undefined;
     respond(id, {
       type: 'ticked-n',
       portValues: last ? portValuesToObject(last.portValues) : portValuesToObject(sim.getPortValues()),
       cycle: sim.getMetrics().totalTicks,
       peripheralState: snapshotPeripheralState(slot),
+      snapshotId,
     });
   } catch (e) {
     respondError(id, e instanceof Error ? e.message : String(e));
@@ -436,6 +519,9 @@ function handleReset(id: string, slotId: string = DEFAULT_SLOT) {
   }
   try {
     sim.reset();
+    // Reset is a user-visible "start over" — drop all history so time-travel
+    // begins fresh from the post-reset state.
+    slot.snapshots.clear();
     const portValues = portValuesToObject(sim.getPortValues());
     respond(id, { type: 'reset', portValues, peripheralState: snapshotPeripheralState(slot) });
   } catch (e) {
@@ -443,7 +529,7 @@ function handleReset(id: string, slotId: string = DEFAULT_SLOT) {
   }
 }
 
-function handleSetNode(id: string, nodeId: string, value: number | boolean | Map<number, number>, slotId: string = DEFAULT_SLOT) {
+function handleSetNode(id: string, nodeId: string, value: number | boolean | Map<number, number>, slotId: string = DEFAULT_SLOT, snapshot?: boolean) {
   const slot = slots.get(slotId);
   const sim = slot?.simulator;
   if (!sim || !slot) {
@@ -455,7 +541,8 @@ function handleSetNode(id: string, nodeId: string, value: number | boolean | Map
     sim.setNode(nodeId, value as any);
     sim.runCombinational();
     const portValues = portValuesToObject(sim.getPortValues());
-    respond(id, { type: 'set-node', portValues, peripheralState: snapshotPeripheralState(slot) });
+    const snapshotId = snapshot ? takeSnapshot(slot) : undefined;
+    respond(id, { type: 'set-node', portValues, peripheralState: snapshotPeripheralState(slot), snapshotId });
   } catch (e) {
     respondError(id, e instanceof Error ? e.message : String(e));
   }
@@ -466,13 +553,93 @@ function handleDispose(id: string, slotId: string) {
   respond(id, { type: 'disposed' });
 }
 
+// ============================================================================
+// Time-travel snapshot / restore / prune handlers
+// ============================================================================
+
+function handleSnapshot(id: string, slotId: string = DEFAULT_SLOT) {
+  const slot = slots.get(slotId);
+  const sim = slot?.simulator;
+  if (!sim || !slot) {
+    respondError(id, `No circuit compiled for slot '${slotId}'.`);
+    return;
+  }
+  const snapshotId = takeSnapshot(slot);
+  respond(id, { type: 'snapshot', snapshotId });
+}
+
+function handleRestore(id: string, snapshotId: number, slotId: string = DEFAULT_SLOT) {
+  const slot = slots.get(slotId);
+  const sim = slot?.simulator;
+  if (!sim || !slot) {
+    respondError(id, `No circuit compiled for slot '${slotId}'.`);
+    return;
+  }
+  const full = slot.snapshots.get(snapshotId);
+  if (!full) {
+    respondError(id, `Snapshot ${snapshotId} not found for slot '${slotId}'.`);
+    return;
+  }
+  try {
+    // Restore the engine's sequential + port state first, then re-apply the
+    // environmental state (Switch/Button/Input values).
+    //
+    // Why we can't just call `restoreEnvironmentalState` from core and be
+    // done: the simulator keeps a numeric cache of node-argument values that
+    // it reads at eval time. Mutating `node.arguments` directly updates the
+    // circuit object but NOT the numeric cache — subsequent evals would still
+    // use the stale value. The only API that invalidates both is `sim.setNode`.
+    //
+    // Also: `captureEnvironmentalState` produces `undefined` for primitives
+    // whose interactive arg was never explicitly set (e.g. a Switch at its
+    // implicit default). We can't pass `undefined` to `sim.setNode`, so we
+    // fall back to 0 — the universal "off" for Switch/Button/Input.
+    sim.restore(full.sim);
+    if (slot.flatCircuit && slot.library) {
+      for (const node of slot.flatCircuit.nodes) {
+        const def = slot.library.resolveCircuit(node.primitiveType);
+        const interactiveArg = (def as { metadata?: { interactiveArg?: string } } | undefined)?.metadata?.interactiveArg;
+        if (!interactiveArg) continue;
+        const saved = full.env.get(node.id);
+        const value = saved === undefined ? 0 : saved;
+        sim.setNode(node.id, value as number | boolean);
+      }
+    }
+    sim.runCombinational();
+    respond(id, {
+      type: 'restored',
+      portValues: portValuesToObject(sim.getPortValues()),
+      cycle: full.sim.cycleCount,
+      peripheralState: snapshotPeripheralState(slot),
+    });
+  } catch (e) {
+    respondError(id, e instanceof Error ? e.message : String(e));
+  }
+}
+
+function handlePruneSnapshots(id: string, keepAfterId: number, slotId: string = DEFAULT_SLOT) {
+  const slot = slots.get(slotId);
+  if (!slot) {
+    // Silently succeed — host may prune a slot that was never touched.
+    respond(id, { type: 'pruned' });
+    return;
+  }
+  // Drop every snapshot with id <= keepAfterId. Callers use this to cap
+  // history at N entries on the host side; anything older than the oldest
+  // ID the host is still referencing can safely go.
+  for (const key of [...slot.snapshots.keys()]) {
+    if (key <= keepAfterId) slot.snapshots.delete(key);
+  }
+  respond(id, { type: 'pruned' });
+}
+
 /**
  * Compile from Circuit IR (not source code).
  * Used for the auto-harnessed circuit — the harness is built client-side
  * as Circuit IR and sent here for simulation.
  * Uses the library from the last executeCircuitCode (has eval functions).
  */
-function handleCompileIR(id: string, circuit: Circuit, libraryCircuits: Circuit[], slotId: string, evalSources?: Record<string, EvalSource>) {
+function handleCompileIR(id: string, circuit: Circuit, libraryCircuits: Circuit[], slotId: string, evalSources?: Record<string, EvalSource>, snapshot?: boolean) {
   try {
     // If evalSources are provided, reconstruct the functions and register them.
     // This is how the embed transfers eval functions from the main frame to the sandbox.
@@ -523,10 +690,15 @@ function handleCompileIR(id: string, circuit: Circuit, libraryCircuits: Circuit[
     const slot = getSlot(slotId);
     slot.simulator = sim;
     slot.library = lib;
+    slot.flatCircuit = flatCircuit;
     slot.peripheralBusNodes = computePeripheralBusNodes(flatCircuit, lib);
+    // Recompile is a fresh timeline — any prior history is meaningless against
+    // the new simulator instance.
+    slot.snapshots.clear();
 
     const portValues = portValuesToObject(sim.getPortValues());
-    respond(id, { type: 'compiled-ir', portValues, peripheralState: snapshotPeripheralState(slot) });
+    const snapshotId = snapshot ? takeSnapshot(slot) : undefined;
+    respond(id, { type: 'compiled-ir', portValues, peripheralState: snapshotPeripheralState(slot), snapshotId });
   } catch (e) {
     respondError(id, e instanceof Error ? e.message : String(e));
   }
@@ -554,13 +726,13 @@ self.addEventListener('message', (event: MessageEvent) => {
       handleCompile(req.id, req.source, req.slot);
       break;
     case 'compile-ir':
-      handleCompileIR(req.id, req.circuit, req.libraryCircuits, req.slot, req.evalSources);
+      handleCompileIR(req.id, req.circuit, req.libraryCircuits, req.slot, req.evalSources, req.snapshot);
       break;
     case 'tick':
-      handleTick(req.id, req.inputs, req.slot);
+      handleTick(req.id, req.inputs, req.slot, req.snapshot);
       break;
     case 'tick-n':
-      handleTickN(req.id, req.n, req.inputs, req.slot);
+      handleTickN(req.id, req.n, req.inputs, req.slot, req.snapshot);
       break;
     case 'scan-port':
       handleScanPort(req.id, req.addrNodeId, req.valuePortKey, req.count, req.slot);
@@ -572,7 +744,16 @@ self.addEventListener('message', (event: MessageEvent) => {
       handleReset(req.id, req.slot);
       break;
     case 'set-node':
-      handleSetNode(req.id, req.nodeId, req.value, req.slot);
+      handleSetNode(req.id, req.nodeId, req.value, req.slot, req.snapshot);
+      break;
+    case 'snapshot':
+      handleSnapshot(req.id, req.slot);
+      break;
+    case 'restore':
+      handleRestore(req.id, req.snapshotId, req.slot);
+      break;
+    case 'prune-snapshots':
+      handlePruneSnapshots(req.id, req.keepAfterId, req.slot);
       break;
     case 'dispose':
       handleDispose(req.id, req.slot);

--- a/packages/core/src/circuit/circuit.ts
+++ b/packages/core/src/circuit/circuit.ts
@@ -329,6 +329,10 @@ export function circuit<
     author: config.meta?.author,
     version: config.meta?.version,
     synthesizable: config.meta?.synthesizable,
+    // Needed for time-travel to restore Switch/Button/Input values alongside
+    // engine state — captureEnvironmentalState reads this to know which
+    // node.arguments key to snapshot. Omitting it silently broke rewind.
+    interactiveArg: config.meta?.interactiveArg,
   };
 
   const circuitIR: Circuit = {

--- a/packages/core/src/simulator/__tests__/environmental-time-travel.test.ts
+++ b/packages/core/src/simulator/__tests__/environmental-time-travel.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Environmental State Time-Travel
+ *
+ * The simulator engine's `snapshot()` / `restore()` round-trips SEQUENTIAL
+ * state (registers, flip-flops, memory) and port values — but it does NOT
+ * revert `node.arguments`. Switch / Button / Input primitives drive their
+ * outputs from `node.arguments.value`, which mutates on `setNode`. So a
+ * naive time-travel that only restores the engine leaves stale switch
+ * positions, and the next tick would use the wrong input.
+ *
+ * The complete host-side recipe is engine restore + `captureEnvironmentalState`
+ * / `restoreEnvironmentalState` (walks `metadata.interactiveArg` to find
+ * which node args to snapshot). This test locks in both halves:
+ *
+ *   1. engine-only restore leaves switch ON when it should be OFF (the bug)
+ *   2. pairing engine restore with environmental restore reproduces the
+ *      original trace (the fix)
+ *
+ * The shift-register time-travel demo on the landing page relies on this
+ * invariant: if sandbox-side restore skips env state, the visible switch
+ * desyncs from actual circuit behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createSimulator, elaborate, captureEnvironmentalState } from '../index.js';
+import { circuit, bit } from '../../circuit/index.js';
+import { Switch, DFlipFlop } from '../../std/index.js';
+import type { Circuit, CircuitLibrary } from '../../types/circuit.js';
+import type { FlatCircuit } from '../../types/simulator.js';
+
+/**
+ * Walk a FlatCircuit's nodes and capture every interactive-arg value (Switch/
+ * Button/Input). Analogous to core's `captureEnvironmentalState` but works on
+ * post-elaboration FlatNode (`primitiveType`) instead of pre-elaboration Node
+ * (`componentRef`). This is the pattern the sandbox uses.
+ */
+function captureFlatEnv(flat: FlatCircuit, library: CircuitLibrary): Map<string, unknown> {
+  const result = new Map<string, unknown>();
+  for (const node of flat.nodes) {
+    const def = library.resolveCircuit(node.primitiveType);
+    const interactiveArg = def?.metadata?.interactiveArg;
+    if (!interactiveArg) continue;
+    result.set(node.id, node.arguments[interactiveArg]);
+  }
+  return result;
+}
+
+const SwitchedFF = circuit('SwitchedFF', {
+  out: { q: bit },
+  nodes: { sw: Switch, dff: DFlipFlop },
+  connect: ({ out, sw, dff }) => [
+    sw.out.to(dff.d),
+    dff.q.to(out.q),
+  ],
+});
+
+function buildSim() {
+  const circuitMap = new Map<string, Circuit>();
+  const library: CircuitLibrary & { addCircuit(c: Circuit): void } = {
+    resolveCircuit: (name) => circuitMap.get(name),
+    getAllPrimitiveNames: () =>
+      [...circuitMap.entries()]
+        .filter(([, c]) => c.implementation.kind === 'primitive')
+        .map(([n]) => n),
+    addCircuit: (c) => { circuitMap.set(c.name, c); },
+  };
+  library.addCircuit(SwitchedFF.circuit);
+  library.addCircuit(Switch.circuit);
+  library.addCircuit(DFlipFlop.circuit);
+  for (const [, dep] of SwitchedFF._dependencies) {
+    library.addCircuit(dep.circuit);
+  }
+
+  const flat = elaborate(SwitchedFF.circuit, library);
+  const sim = createSimulator(flat, { componentLibrary: library });
+  return { sim, flat, library };
+}
+
+function qOut(sim: ReturnType<typeof createSimulator>): boolean {
+  // Top-level output 'q' is wired to dff.q. The simulator exposes it via the
+  // top-level alias under __top__.
+  const v = sim.getOutput('__top__', 'q');
+  return Boolean(v);
+}
+
+describe('environmental state time-travel', () => {
+  // Regression: the sandbox (apps/sandbox/src/main.ts) previously fed its
+  // post-elaboration FlatCircuit into core's captureEnvironmentalState and
+  // walked FlatNodes as if they had `componentRef`. Silent failure mode: the
+  // returned map was empty, so restore re-applied nothing and the UI's Switch
+  // stayed stuck at whatever it was before rewind. This pins the mismatch.
+  it('captureEnvironmentalState on a FlatCircuit silently returns empty (regression)', () => {
+    const { sim, flat, library } = buildSim();
+    sim.setNode('sw', true);
+    sim.tick();
+
+    // FlatNode has primitiveType, not componentRef — captureEnvironmentalState
+    // reads componentRef and finds nothing. This is the behaviour that broke
+    // the sandbox; assert it so future refactors don't mistakenly believe the
+    // core helper works on FlatCircuits.
+    const wrongWay = captureEnvironmentalState(
+      flat as unknown as Circuit,
+      library,
+    );
+    expect(wrongWay.size).toBe(0);
+
+    // The correct walk (primitiveType, the pattern in our captureFlatEnv
+    // helper and now in the sandbox) captures the switch state.
+    const rightWay = captureFlatEnv(flat, library);
+    expect(rightWay.get('sw')).toBe(true);
+  });
+
+
+  it('engine-only restore leaves stale Switch value (the bug)', () => {
+    const { sim } = buildSim();
+    try {
+      // Tick once with switch at its default (OFF) — DFF latches 0.
+      sim.tick();
+      const snap = sim.snapshot();
+      expect(qOut(sim)).toBe(false);
+
+      // Flip switch ON, tick — DFF latches 1.
+      sim.setNode('sw', true);
+      sim.tick();
+      expect(qOut(sim)).toBe(true);
+
+      // Engine-only restore. DFF state reverts to 0, but Switch's node
+      // argument is still ON — the engine never touched it.
+      sim.restore(snap);
+      sim.runCombinational();
+      expect(qOut(sim)).toBe(false); // DFF reverted correctly
+
+      // Ticking again should (in a true rewind) reproduce the original
+      // trace: switch was OFF, DFF latches 0. But with the stale switch
+      // argument still ON, the DFF latches 1 — proving the bug.
+      sim.tick();
+      expect(qOut(sim)).toBe(true); // BUG: should be false if switch really reverted
+    } finally {
+      // SimulatorEngine has no dispose — it's a plain object.
+    }
+  });
+
+  it('engine + environmental restore reproduces the trace (the fix)', () => {
+    const { sim, flat, library } = buildSim();
+    try {
+      // Tick with switch OFF, capture BOTH halves.
+      sim.tick();
+      const simSnap = sim.snapshot();
+      const envSnap = captureFlatEnv(flat, library);
+      expect(qOut(sim)).toBe(false);
+
+      // Flip switch, tick — circuit follows a different trajectory.
+      sim.setNode('sw', true);
+      sim.tick();
+      expect(qOut(sim)).toBe(true);
+
+      // Full restore: engine THEN environmental state.
+      //
+      // Two subtleties the host must get right:
+      //   (a) The sim caches node-argument values in its numeric buffer at
+      //       eval time. Mutating `node.arguments` alone doesn't invalidate
+      //       that cache — only `sim.setNode` does. So the host must route
+      //       env restores through setNode, not through the default
+      //       callback `restoreEnvironmentalState` suggests.
+      //   (b) `captureEnvironmentalState` stores `undefined` when a node's
+      //       interactive arg was never set (initial Switch state). We
+      //       can't pass undefined to setNode — substitute 0 (universal
+      //       off for Switch/Button/Input primitives).
+      //
+      // These rules are replicated in apps/sandbox/src/main.ts handleRestore.
+      sim.restore(simSnap);
+      for (const node of flat.nodes) {
+        const def = library.resolveCircuit(node.primitiveType);
+        const interactiveArg = def?.metadata?.interactiveArg;
+        if (!interactiveArg) continue;
+        const saved = envSnap.get(node.id);
+        const value = saved === undefined ? 0 : saved;
+        sim.setNode(node.id, value as number | boolean);
+      }
+      sim.runCombinational();
+      expect(qOut(sim)).toBe(false);
+
+      // Now the ticks reproduce the original OFF trajectory.
+      sim.tick();
+      expect(qOut(sim)).toBe(false);
+
+      // And a subsequent flip + tick moves forward as expected.
+      sim.setNode('sw', true);
+      sim.tick();
+      expect(qOut(sim)).toBe(true);
+    } finally {
+      // SimulatorEngine has no dispose — it's a plain object.
+    }
+  });
+});

--- a/packages/embed/src/hooks/useCircuitSimulator.ts
+++ b/packages/embed/src/hooks/useCircuitSimulator.ts
@@ -190,7 +190,33 @@ export function useCircuitSimulator(
   const [isRunning, setIsRunning] = useState(false);
   const [speed, setSpeedState] = useState(5);
   const autoRunRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const historyRef = useRef<Array<{ engineSnapshot: unknown; metadata?: unknown }>>([]);
+
+  // ── Time-travel history ──
+  // Each entry stores:
+  //   - snapshotId: opaque handle to a simulator snapshot held in the sandbox
+  //   - cycle: clock cycle at that snapshot (for the UI counter)
+  //   - inputs: user-visible input values at that moment. The simulator's
+  //     snapshot only covers *simulation* state (flip-flops, memory). User
+  //     inputs (switch positions, etc.) are "environmental state" that lives
+  //     in React — see packages/core/src/simulator/environmental-state.ts.
+  //     On rewind we restore both so the UI is fully consistent with the
+  //     cycle being viewed (not just the logic outputs).
+  //
+  // historyIndex points at the snapshot currently reflected in portValues.
+  // At the "head" (live state) historyIndex === historyRef.current.length - 1.
+  // When the user steps back, historyIndex moves left without shrinking history.
+  // If they then make a state-mutating action (tick, setNode), we branch:
+  // history is truncated at historyIndex + 1, orphaned sandbox snapshots leak
+  // (GC'd by slot disposal or the next cap prune — acceptable for demo sizes).
+  type HistoryEntry = {
+    snapshotId: number;
+    cycle: number;
+    inputs: Record<string, boolean | number>;
+  };
+  const historyRef = useRef<HistoryEntry[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [historyLen, setHistoryLen] = useState(0); // duplicate of historyRef.length for re-renders
+  const HISTORY_CAP = 200;
 
   // Default inputs from the harnessed circuit's top-level inputs
   const defaultInputs = useMemo(() => {
@@ -204,6 +230,10 @@ export function useCircuitSimulator(
 
   const [outputs, setOutputs] = useState<Record<string, boolean | number>>({});
   const [inputs, setInputs] = useState<Record<string, boolean | number>>(defaultInputs);
+  // Mirror of inputs in a ref so tick/tickN can snapshot the latest value
+  // synchronously without waiting for setState → re-render.
+  const inputsRef = useRef(inputs);
+  useEffect(() => { inputsRef.current = inputs; }, [inputs]);
 
   // ── Compile to sandbox on mount / circuit change ──
   useEffect(() => {
@@ -248,7 +278,12 @@ export function useCircuitSimulator(
         if (c) addCircuit(c);
       }
 
-      const result = await sandbox.compileIR(harnessedCircuit, libCircuits, slotId, { evalSources });
+      // Only bother snapshotting if the circuit is sequential — combinational
+      // circuits don't have state worth rewinding to.
+      const result = await sandbox.compileIR(harnessedCircuit, libCircuits, slotId, {
+        evalSources,
+        snapshot: isSequential,
+      });
       if (cancelled) return;
 
       if ('error' in result) {
@@ -264,6 +299,16 @@ export function useCircuitSimulator(
       setPortValues(pvMap);
       if (result.peripheralState) setPeripheralState(result.peripheralState);
       setCycle(0);
+
+      // Seed history with the initial snapshot (if any). Fresh compile means
+      // the previous history (if any) is invalid anyway — sandbox already
+      // cleared its own snapshots on the recompile.
+      historyRef.current = result.snapshotId !== undefined
+        ? [{ snapshotId: result.snapshotId, cycle: 0, inputs: { ...defaultInputs } }]
+        : [];
+      setHistoryIndex(result.snapshotId !== undefined ? 0 : -1);
+      setHistoryLen(historyRef.current.length);
+
       setReady(true);
       // isSequential is computed synchronously via useMemo above — no need to set async
     }
@@ -274,7 +319,7 @@ export function useCircuitSimulator(
       cancelled = true;
       sandbox.dispose(slotId).catch(() => {});
     };
-  }, [circuit, harnessedCircuit, componentLibrary, sandbox, slotId]);
+  }, [circuit, harnessedCircuit, componentLibrary, sandbox, slotId, isSequential]);
 
   // Sync inputs when underlying circuit changes
   useEffect(() => {
@@ -295,10 +340,66 @@ export function useCircuitSimulator(
     setOutputs(newOutputs);
   }, [ready, portValues, harnessedCircuit]);
 
+  // ── History bookkeeping helper ──
+  //
+  // Called after any state-mutating sandbox operation that returns a snapshot.
+  // Handles branch-on-past-edit (truncates future), enforces the 200-entry cap,
+  // and updates React state so the UI re-renders with fresh ◀▶ counts.
+  //
+  // The `inputsSnapshot` is what the user-visible inputs (switches, buttons,
+  // etc.) looked like at this moment — used on rewind so the UI restores not
+  // just the simulator state but the user inputs too.
+  const recordSnapshot = useCallback((
+    snapshotId: number | undefined,
+    newCycle: number,
+    inputsSnapshot: Record<string, boolean | number>,
+  ) => {
+    if (snapshotId === undefined) return; // combinational circuit — nothing to record
+
+    const hist = historyRef.current;
+    const currentIdx = historyIndexRef.current;
+
+    // If the user was viewing the past and just made a mutating action,
+    // we branch: discard everything after their current position, then
+    // append the new snapshot as the new head. The orphaned sandbox
+    // snapshots leak until the next cap-prune or slot disposal.
+    if (currentIdx >= 0 && currentIdx < hist.length - 1) {
+      hist.length = currentIdx + 1;
+    }
+
+    hist.push({ snapshotId, cycle: newCycle, inputs: { ...inputsSnapshot } });
+
+    // Cap at HISTORY_CAP: drop oldest entries and tell the sandbox to
+    // free their snapshots. `keepAfterId` is the highest snapshotId we
+    // DO NOT want to keep — anything <= that gets freed in the sandbox.
+    if (hist.length > HISTORY_CAP) {
+      const drop = hist.length - HISTORY_CAP;
+      const keepAfterId = hist[drop - 1].snapshotId;
+      hist.splice(0, drop);
+      sandbox.pruneSnapshots(keepAfterId, slotId).catch(() => {});
+    }
+
+    historyIndexRef.current = hist.length - 1;
+    setHistoryIndex(hist.length - 1);
+    setHistoryLen(hist.length);
+  }, [sandbox, slotId]);
+
+  // Mirror historyIndex in a ref so the helper above can see its live value
+  // without recompiling on every change (avoids rebuilding every callback).
+  const historyIndexRef = useRef(-1);
+  useEffect(() => { historyIndexRef.current = historyIndex; }, [historyIndex]);
+
   // ── Actions ──
 
   const setNode = useCallback(async (name: string, value: boolean | number) => {
-    setInputs(prev => ({ ...prev, [name]: value }));
+    // Input changes (switch toggles, button presses) don't create a new
+    // history entry — history tracks CYCLES (post-tick states), not every
+    // input edit. The current cycle's "inputs" stay live: the next tick
+    // will snapshot them as part of its history entry. If the user is
+    // viewing the past when they toggle, the next tick branches from there.
+    const newInputs = { ...inputsRef.current, [name]: value };
+    inputsRef.current = newInputs;
+    setInputs(newInputs);
     if (!ready) return;
     const result = await sandbox.setNode(name, value, slotId);
     if ('error' in result) return;
@@ -319,6 +420,7 @@ export function useCircuitSimulator(
     const outKey = `${nodeId}.out`;
     const current = portValues.get(outKey);
     const newValue = typeof current === 'boolean' ? !current : (current === 1 ? 0 : 1);
+    // Same reasoning as setNode: no new history entry on input edit.
     const result = await sandbox.setNode(nodeId, newValue, slotId);
     if ('error' in result) return;
     const pvMap = new Map<string, BitValue | BusValue>();
@@ -330,6 +432,7 @@ export function useCircuitSimulator(
   const setNodeValue = useCallback(async (nodeId: string, value: number | boolean | Map<number, number>) => {
     if (!ready) return null;
     // Map values (for ROM/RAM loading) are supported via structured clone in postMessage.
+    // Same reasoning as setNode: no history entry on this path.
     const result = await sandbox.setNode(nodeId, value as any, slotId);
     if ('error' in result) return null;
     const pvMap = new Map<string, BitValue | BusValue>();
@@ -341,26 +444,32 @@ export function useCircuitSimulator(
 
   const tick = useCallback(async () => {
     if (!ready) return;
-    const result = await sandbox.tick(undefined, slotId);
+    const result = await sandbox.tick(undefined, slotId, { snapshot: isSequential });
     if ('error' in result) return;
     const pvMap = new Map<string, BitValue | BusValue>();
     for (const [k, v] of Object.entries(result.portValues)) pvMap.set(k, v);
     setPortValues(pvMap);
     setCycle(result.cycle);
     if (result.peripheralState) setPeripheralState(result.peripheralState);
-  }, [ready, sandbox, slotId]);
+    // tick() doesn't modify user inputs — the switch position at tick time
+    // is what goes into history.
+    recordSnapshot(result.snapshotId, result.cycle, inputsRef.current);
+  }, [ready, sandbox, slotId, isSequential, recordSnapshot]);
 
   // Batched tick — advances N cycles in one round-trip; one React update.
+  // Only snapshots the final state (not every intermediate cycle) — time-travel
+  // through a batched tick jumps straight to pre-batch.
   const tickN = useCallback(async (n: number) => {
     if (!ready || n <= 0) return;
-    const result = await sandbox.tickN(n, undefined, slotId);
+    const result = await sandbox.tickN(n, undefined, slotId, { snapshot: isSequential });
     if ('error' in result) return;
     const pvMap = new Map<string, BitValue | BusValue>();
     for (const [k, v] of Object.entries(result.portValues)) pvMap.set(k, v);
     setPortValues(pvMap);
     setCycle(result.cycle);
     if (result.peripheralState) setPeripheralState(result.peripheralState);
-  }, [ready, sandbox, slotId]);
+    recordSnapshot(result.snapshotId, result.cycle, inputsRef.current);
+  }, [ready, sandbox, slotId, isSequential, recordSnapshot]);
 
   const scanPort = useCallback(async (addrNodeId: string, valuePortKey: string, count: number): Promise<number[] | null> => {
     if (!ready || count <= 0) return null;
@@ -379,7 +488,73 @@ export function useCircuitSimulator(
     setInputs(defaultInputs);
     if (result.peripheralState) setPeripheralState(result.peripheralState);
     else setPeripheralState({});
-  }, [sandbox, slotId, defaultInputs]);
+
+    // Sandbox reset already cleared its own snapshots. Clear ours too,
+    // then seed a fresh initial snapshot for the post-reset state so
+    // time-travel starts over from here.
+    historyRef.current = [];
+    if (isSequential) {
+      const snap = await sandbox.snapshot(slotId);
+      if (!('error' in snap) && snap.snapshotId !== undefined) {
+        historyRef.current = [{ snapshotId: snap.snapshotId, cycle: 0, inputs: { ...defaultInputs } }];
+      }
+    }
+    historyIndexRef.current = historyRef.current.length > 0 ? 0 : -1;
+    setHistoryIndex(historyRef.current.length > 0 ? 0 : -1);
+    setHistoryLen(historyRef.current.length);
+  }, [sandbox, slotId, defaultInputs, isSequential]);
+
+  // ── Time-travel actions ──
+
+  // Shared restore helper — applies a history entry to both the simulator
+  // and the host-side input state. We restore inputs because the UI "rewind"
+  // promise is a full restoration of user-visible state: switch positions,
+  // input values, circuit state. Omitting inputs would leave the UI showing
+  // a stale switch while the circuit actually runs with the restored value —
+  // see environmental-state.ts in packages/core for the same distinction.
+  const applyHistoryEntry = useCallback(async (entry: HistoryEntry, targetIndex: number) => {
+    const result = await sandbox.restore(entry.snapshotId, slotId);
+    if ('error' in result) return;
+    const pvMap = new Map<string, BitValue | BusValue>();
+    for (const [k, v] of Object.entries(result.portValues)) pvMap.set(k, v);
+    setPortValues(pvMap);
+    setCycle(result.cycle);
+    if (result.peripheralState) setPeripheralState(result.peripheralState);
+    else setPeripheralState({});
+    // Restore user inputs too. Keep inputsRef in lockstep so that any
+    // immediately-following setNode sees the restored values as its base.
+    const restoredInputs = { ...entry.inputs };
+    inputsRef.current = restoredInputs;
+    setInputs(restoredInputs);
+    historyIndexRef.current = targetIndex;
+    setHistoryIndex(targetIndex);
+  }, [sandbox, slotId]);
+
+  const stepBack = useCallback(async () => {
+    if (!ready) return;
+    const hist = historyRef.current;
+    const idx = historyIndexRef.current;
+    if (idx <= 0) return; // already at or before the start
+    await applyHistoryEntry(hist[idx - 1], idx - 1);
+  }, [ready, applyHistoryEntry]);
+
+  const stepForward = useCallback(async () => {
+    if (!ready) return;
+    const hist = historyRef.current;
+    const idx = historyIndexRef.current;
+    // Already at the live head — nothing to step into yet.
+    // (Clicking ▶ at the head is a no-op, not a tick. Users run the clock
+    //  explicitly via Tick/autorun to add new history.)
+    if (idx >= hist.length - 1) return;
+    await applyHistoryEntry(hist[idx + 1], idx + 1);
+  }, [ready, applyHistoryEntry]);
+
+  const seek = useCallback(async (index: number) => {
+    if (!ready) return;
+    const hist = historyRef.current;
+    if (index < 0 || index >= hist.length) return;
+    await applyHistoryEntry(hist[index], index);
+  }, [ready, applyHistoryEntry]);
 
   const startAutoRun = useCallback((ticksPerSecond: number, _opts?: { displayRate?: number; onBeforeTick?: () => void }) => {
     if (autoRunRef.current) clearInterval(autoRunRef.current);
@@ -430,6 +605,14 @@ export function useCircuitSimulator(
     };
   }, [peripheralState, cycle]);
 
+  // Shadow-typed history for the UI: the consumer only needs a length for
+  // showing the `N/M` counter and the ◀ ▶ enable logic. historyLen drives
+  // re-renders; the array identity is intentionally stable per-slot.
+  const historyForUi = useMemo(
+    () => historyRef.current.slice(0, historyLen).map(h => ({ engineSnapshot: h.snapshotId, metadata: h.cycle })),
+    [historyLen],
+  );
+
   return {
     // State
     outputs,
@@ -442,9 +625,9 @@ export function useCircuitSimulator(
     portValues: portValues.size > 0 ? portValues : null,
     sequentialState,
     componentLibrary,
-    history: historyRef.current,
-    historyIndex: -1,
-    isViewingPast: false,
+    history: historyForUi,
+    historyIndex,
+    isViewingPast: historyIndex >= 0 && historyIndex < historyLen - 1,
     isRunning,
     speed,
 
@@ -457,9 +640,9 @@ export function useCircuitSimulator(
     tickN,
     scanPort,
     reset,
-    stepBack: () => {},
-    stepForward: () => {},
-    seek: () => {},
+    stepBack,
+    stepForward,
+    seek,
     startAutoRun,
     stopAutoRun,
     setSpeed,

--- a/packages/ui/src/sandbox/useSandbox.ts
+++ b/packages/ui/src/sandbox/useSandbox.ts
@@ -62,6 +62,8 @@ export interface TickResult {
   portValues: Record<string, number | boolean>;
   cycle: number;
   peripheralState?: PeripheralState;
+  /** Snapshot id returned when the tick was requested with `{ snapshot: true }`. */
+  snapshotId?: number;
 }
 
 export interface SimulateResult {
@@ -80,6 +82,19 @@ export interface ResetResult {
 export interface SetNodeResult {
   portValues: Record<string, number | boolean>;
   peripheralState?: PeripheralState;
+  /** Snapshot id returned when `{ snapshot: true }` was passed. */
+  snapshotId?: number;
+}
+
+export interface SnapshotResult {
+  /** Undefined for combinational-only circuits (nothing to snapshot). */
+  snapshotId?: number;
+}
+
+export interface RestoreResult {
+  portValues: Record<string, number | boolean>;
+  cycle: number;
+  peripheralState?: PeripheralState;
 }
 
 export interface SandboxError {
@@ -89,13 +104,16 @@ export interface SandboxError {
 
 export type SandboxResult =
   | ({ type: 'compiled' } & CompileResult)
-  | ({ type: 'compiled-ir' } & { portValues: Record<string, number | boolean>; peripheralState?: PeripheralState })
+  | ({ type: 'compiled-ir' } & { portValues: Record<string, number | boolean>; peripheralState?: PeripheralState; snapshotId?: number })
   | ({ type: 'ticked' } & TickResult)
   | ({ type: 'ticked-n' } & TickResult)
   | ({ type: 'scanned-port' } & { values: number[] })
   | ({ type: 'simulated' } & SimulateResult)
   | ({ type: 'reset' } & ResetResult)
   | ({ type: 'set-node' } & SetNodeResult)
+  | ({ type: 'snapshot' } & SnapshotResult)
+  | ({ type: 'restored' } & RestoreResult)
+  | ({ type: 'pruned' } & { })
   | ({ type: 'disposed' } & { })
   | ({ type: 'error' } & SandboxError);
 
@@ -159,6 +177,8 @@ function nextId(state: SandboxState): string {
 export interface CompileIRResult {
   portValues: Record<string, number | boolean>;
   peripheralState?: PeripheralState;
+  /** Snapshot of the initial state, returned when `{ snapshot: true }` was requested. */
+  snapshotId?: number;
 }
 
 /** Serialized eval entry used to transfer eval functions to the sandbox */
@@ -179,15 +199,18 @@ export interface SandboxHandle {
    * Compile from Circuit IR (e.g. auto-harnessed circuit).
    * Optional evalSources map transfers eval functions from the caller's context.
    * If omitted, inherits eval functions from any previously-compiled slot.
+   * Pass `{ snapshot: true }` to capture the initial state for time-travel.
    */
-  compileIR(circuit: any, libraryCircuits: any[], slot: SimSlot, options?: { evalSources?: Record<string, EvalSource> }): Promise<CompileIRResult | SandboxError>;
-  tick(inputs?: Record<string, number | boolean>, slot?: SimSlot): Promise<TickResult | SandboxError>;
+  compileIR(circuit: any, libraryCircuits: any[], slot: SimSlot, options?: { evalSources?: Record<string, EvalSource>; snapshot?: boolean }): Promise<CompileIRResult | SandboxError>;
+  /** Pass `{ snapshot: true }` to also capture a post-tick snapshot for time-travel. */
+  tick(inputs?: Record<string, number | boolean>, slot?: SimSlot, options?: { snapshot?: boolean }): Promise<TickResult | SandboxError>;
   /**
    * Advance the simulator by N ticks in a single round-trip. Returns final
    * port values + one peripheral-state snapshot. Use for demos that need
    * many ticks per frame (raster displays, batched compute).
+   * Pass `{ snapshot: true }` to capture a post-tickN snapshot.
    */
-  tickN(n: number, inputs?: Record<string, number | boolean>, slot?: SimSlot): Promise<TickResult | SandboxError>;
+  tickN(n: number, inputs?: Record<string, number | boolean>, slot?: SimSlot, options?: { snapshot?: boolean }): Promise<TickResult | SandboxError>;
   /**
    * Combinationally scan a debug address input across 0..count-1, sampling
    * a value output port after each setting. Returns the array in one
@@ -202,7 +225,21 @@ export interface SandboxHandle {
     slot?: SimSlot;
   }): Promise<SimulateResult | SandboxError>;
   reset(slot?: SimSlot): Promise<ResetResult | SandboxError>;
-  setNode(nodeId: string, value: number | boolean | Map<number, number>, slot?: SimSlot): Promise<SetNodeResult | SandboxError>;
+  setNode(nodeId: string, value: number | boolean | Map<number, number>, slot?: SimSlot, options?: { snapshot?: boolean }): Promise<SetNodeResult | SandboxError>;
+  /**
+   * Take a snapshot of the current simulator state. Returns an opaque
+   * snapshotId the host can later pass to `restore()`. For combinational-only
+   * circuits returns `{ snapshotId: undefined }` — nothing to save.
+   */
+  snapshot(slot?: SimSlot): Promise<SnapshotResult | SandboxError>;
+  /** Restore the simulator to a previously-captured snapshot. */
+  restore(snapshotId: number, slot?: SimSlot): Promise<RestoreResult | SandboxError>;
+  /**
+   * Drop all snapshots with id <= keepAfterId. Called by the host when its
+   * local history cap is exceeded, so old snapshots get garbage-collected
+   * inside the sandbox. Silently succeeds if the slot has no snapshots.
+   */
+  pruneSnapshots(keepAfterId: number, slot?: SimSlot): Promise<{ type: 'pruned' } | SandboxError>;
   /** Free a slot's simulator + library when no longer needed (e.g. embed unmount). */
   dispose(slot: SimSlot): Promise<void>;
   isReady(): boolean;
@@ -325,37 +362,38 @@ export function useSandbox(): SandboxHandle {
   );
 
   const compileIR = useCallback(
-    async (circuit: any, libraryCircuits: any[], slot: SimSlot, options?: { evalSources?: Record<string, EvalSource> }): Promise<CompileIRResult | SandboxError> => {
+    async (circuit: any, libraryCircuits: any[], slot: SimSlot, options?: { evalSources?: Record<string, EvalSource>; snapshot?: boolean }): Promise<CompileIRResult | SandboxError> => {
       const result = await send<{ type: 'compiled-ir' } & CompileIRResult>({
         type: 'compile-ir',
         circuit,
         libraryCircuits,
         slot,
         evalSources: options?.evalSources,
+        snapshot: options?.snapshot,
       });
       if ('error' in result) return result as SandboxError;
       const r = result as { type: 'compiled-ir' } & CompileIRResult;
-      return { portValues: r.portValues, peripheralState: r.peripheralState };
+      return { portValues: r.portValues, peripheralState: r.peripheralState, snapshotId: r.snapshotId };
     },
     [send],
   );
 
   const tick = useCallback(
-    async (inputs?: Record<string, number | boolean>, slot: SimSlot = 'default'): Promise<TickResult | SandboxError> => {
-      const result = await send<{ type: 'ticked' } & TickResult>({ type: 'tick', inputs, slot });
+    async (inputs?: Record<string, number | boolean>, slot: SimSlot = 'default', options?: { snapshot?: boolean }): Promise<TickResult | SandboxError> => {
+      const result = await send<{ type: 'ticked' } & TickResult>({ type: 'tick', inputs, slot, snapshot: options?.snapshot });
       if ('error' in result) return result as SandboxError;
       const r = result as { type: 'ticked' } & TickResult;
-      return { portValues: r.portValues, cycle: r.cycle, peripheralState: r.peripheralState };
+      return { portValues: r.portValues, cycle: r.cycle, peripheralState: r.peripheralState, snapshotId: r.snapshotId };
     },
     [send],
   );
 
   const tickN = useCallback(
-    async (n: number, inputs?: Record<string, number | boolean>, slot: SimSlot = 'default'): Promise<TickResult | SandboxError> => {
-      const result = await send<{ type: 'ticked-n' } & TickResult>({ type: 'tick-n', n, inputs, slot });
+    async (n: number, inputs?: Record<string, number | boolean>, slot: SimSlot = 'default', options?: { snapshot?: boolean }): Promise<TickResult | SandboxError> => {
+      const result = await send<{ type: 'ticked-n' } & TickResult>({ type: 'tick-n', n, inputs, slot, snapshot: options?.snapshot });
       if ('error' in result) return result as SandboxError;
       const r = result as { type: 'ticked-n' } & TickResult;
-      return { portValues: r.portValues, cycle: r.cycle, peripheralState: r.peripheralState };
+      return { portValues: r.portValues, cycle: r.cycle, peripheralState: r.peripheralState, snapshotId: r.snapshotId };
     },
     [send],
   );
@@ -399,11 +437,40 @@ export function useSandbox(): SandboxHandle {
   }, [send]);
 
   const setNode = useCallback(
-    async (nodeId: string, value: number | boolean | Map<number, number>, slot: SimSlot = 'default'): Promise<SetNodeResult | SandboxError> => {
-      const result = await send<{ type: 'set-node' } & SetNodeResult>({ type: 'set-node', nodeId, value, slot });
+    async (nodeId: string, value: number | boolean | Map<number, number>, slot: SimSlot = 'default', options?: { snapshot?: boolean }): Promise<SetNodeResult | SandboxError> => {
+      const result = await send<{ type: 'set-node' } & SetNodeResult>({ type: 'set-node', nodeId, value, slot, snapshot: options?.snapshot });
       if ('error' in result) return result as SandboxError;
       const r = result as { type: 'set-node' } & SetNodeResult;
-      return { portValues: r.portValues, peripheralState: r.peripheralState };
+      return { portValues: r.portValues, peripheralState: r.peripheralState, snapshotId: r.snapshotId };
+    },
+    [send],
+  );
+
+  const snapshot = useCallback(
+    async (slot: SimSlot = 'default'): Promise<SnapshotResult | SandboxError> => {
+      const result = await send<{ type: 'snapshot' } & SnapshotResult>({ type: 'snapshot', slot });
+      if ('error' in result) return result as SandboxError;
+      const r = result as { type: 'snapshot' } & SnapshotResult;
+      return { snapshotId: r.snapshotId };
+    },
+    [send],
+  );
+
+  const restore = useCallback(
+    async (snapshotId: number, slot: SimSlot = 'default'): Promise<RestoreResult | SandboxError> => {
+      const result = await send<{ type: 'restored' } & RestoreResult>({ type: 'restore', snapshotId, slot });
+      if ('error' in result) return result as SandboxError;
+      const r = result as { type: 'restored' } & RestoreResult;
+      return { portValues: r.portValues, cycle: r.cycle, peripheralState: r.peripheralState };
+    },
+    [send],
+  );
+
+  const pruneSnapshots = useCallback(
+    async (keepAfterId: number, slot: SimSlot = 'default'): Promise<{ type: 'pruned' } | SandboxError> => {
+      const result = await send<{ type: 'pruned' }>({ type: 'prune-snapshots', keepAfterId, slot });
+      if ('error' in result) return result as SandboxError;
+      return result as { type: 'pruned' };
     },
     [send],
   );
@@ -417,5 +484,5 @@ export function useSandbox(): SandboxHandle {
 
   const isReady = useCallback(() => stateRef.current.ready, []);
 
-  return { compile, compileIR, tick, tickN, scanPort, simulate, reset, setNode, dispose, isReady };
+  return { compile, compileIR, tick, tickN, scanPort, simulate, reset, setNode, snapshot, restore, pruneSnapshots, dispose, isReady };
 }


### PR DESCRIPTION
…al state, propagate interactiveArg, walk FlatNode via primitiveType (closes #2)