### PR TITLE
feat(verify): emit per-test VCDs from iverilog cross-validation runs

### DIFF
--- a/apps/verifier/container_src/main.go
+++ b/apps/verifier/container_src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -41,7 +42,14 @@ type VerifyResponse struct {
 	Results       []OutputResult `json:"results,omitempty"`
 	SimulationLog string         `json:"simulationLog,omitempty"`
 	IverilogStderr string        `json:"iverilogStderr,omitempty"`
+	// VcdBase64 is the base64-encoded contents of verify.vcd, if the testbench
+	// emitted one via $dumpfile/$dumpvars. Capped at maxVcdSize.
+	VcdBase64 string `json:"vcdBase64,omitempty"`
 }
+
+// Cap returned VCDs at 8MB raw — larger than that is almost never useful for
+// debugging a single test and would blow the worker response budget.
+const maxVcdSize = 8 * 1024 * 1024
 
 func randomID() string {
 	b := make([]byte, 8)
@@ -177,6 +185,9 @@ func verifyHandler(w http.ResponseWriter, r *http.Request) {
 	defer simCancel()
 
 	simCmd := exec.CommandContext(simCtx, "vvp", simPath)
+	// Run vvp from the temp dir so any $dumpfile path the testbench emits
+	// (e.g. "verify.vcd") lands inside `dir` where we can read it back.
+	simCmd.Dir = dir
 	simOut, simErr := simCmd.CombinedOutput()
 	simOutput := string(simOut)
 
@@ -205,10 +216,20 @@ func verifyHandler(w http.ResponseWriter, r *http.Request) {
 	// Step 3: Parse results
 	results := parseResults(simOutput)
 
+	// Step 4: Read VCD if the testbench emitted one
+	var vcdB64 string
+	if data, err := os.ReadFile(filepath.Join(dir, "verify.vcd")); err == nil {
+		if len(data) > maxVcdSize {
+			data = data[:maxVcdSize]
+		}
+		vcdB64 = base64.StdEncoding.EncodeToString(data)
+	}
+
 	writeJSON(w, http.StatusOK, VerifyResponse{
 		Success:       true,
 		Results:       results,
 		SimulationLog: simOutput,
+		VcdBase64:     vcdB64,
 	})
 }
 

--- a/hardware/ulx3s/.gitignore
+++ b/hardware/ulx3s/.gitignore
@@ -2,3 +2,4 @@
 *.bit.gz
 firmware.hex
 combined.v
+.vcd/

--- a/hardware/ulx3s/projects/cpu/verify.ts
+++ b/hardware/ulx3s/projects/cpu/verify.ts
@@ -16,7 +16,7 @@
  *        bun hardware/ulx3s/cpu_verify.ts --filter ADD (ISA test by substring)
  */
 
-import { readFileSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { runFirmware } from './sim.js';
 import { tests, type Test } from './tests.js';
@@ -25,6 +25,21 @@ const VERIFIER_URL = process.env.VERIFIER_URL ?? 'https://verifier.charles-harri
 
 // Load the CPU's Verilog — already exported to combined.v
 const combinedV = readFileSync(resolve(import.meta.dir, 'combined.v'), 'utf8');
+
+// Where iverilog VCDs land. Created lazily on first write.
+const VCD_DIR = resolve(import.meta.dir, '.vcd');
+
+function slugify(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'unnamed';
+}
+
+function writeVcd(name: string, vcdBase64: string | undefined): string | null {
+  if (!vcdBase64) return null;
+  mkdirSync(VCD_DIR, { recursive: true });
+  const path = resolve(VCD_DIR, `${slugify(name)}.vcd`);
+  writeFileSync(path, Buffer.from(vcdBase64, 'base64'));
+  return path;
+}
 
 // ── Testbench generator ──────────────────────────────────────────────────────
 
@@ -113,6 +128,8 @@ module tb;
   integer cycle;
   integer i;
   initial begin
+    $dumpfile("verify.vcd");
+    $dumpvars(0, tb);
     for (i = 0; i < 512; i = i + 1) imem[i] = 32'h0;
     for (i = 0; i < 1024; i = i + 1) dmem[i] = 32'h0;
 ${imemInit}
@@ -139,7 +156,7 @@ function parseUartFromLog(log: string): number[] {
 
 // ── POST to verifier ─────────────────────────────────────────────────────────
 
-async function verify(firmware: number[], maxCycles: number): Promise<{ ok: boolean; bytes: number[]; log: string; error?: string }> {
+async function verify(firmware: number[], maxCycles: number): Promise<{ ok: boolean; bytes: number[]; log: string; vcdBase64?: string; error?: string }> {
   const testbench = generateTestbench(firmware, maxCycles);
   const resp = await fetch(VERIFIER_URL, {
     method: 'POST',
@@ -153,6 +170,7 @@ async function verify(firmware: number[], maxCycles: number): Promise<{ ok: bool
     simError?: string;
     simulationLog?: string;
     iverilogStderr?: string;
+    vcdBase64?: string;
   };
 
   if (!json.success) {
@@ -160,7 +178,7 @@ async function verify(firmware: number[], maxCycles: number): Promise<{ ok: bool
     return { ok: false, bytes: [], log: '', error: err || 'unknown' };
   }
 
-  return { ok: true, bytes: parseUartFromLog(json.simulationLog ?? ''), log: json.simulationLog ?? '' };
+  return { ok: true, bytes: parseUartFromLog(json.simulationLog ?? ''), log: json.simulationLog ?? '', vcdBase64: json.vcdBase64 };
 }
 
 // ── Test cases ───────────────────────────────────────────────────────────────
@@ -233,6 +251,8 @@ async function compareFirmware(name: string, firmware: number[], maxCycles: numb
     return false;
   }
   console.log(`  iverilog: ${vResult.bytes.length} UART bytes (${elapsed}ms)`);
+  const vcdPath = writeVcd(name, vResult.vcdBase64);
+  if (vcdPath) console.log(`  VCD: ${vcdPath}`);
 
   // Compare — trim iverilog to same length (it may run more cycles since no stall model)
   const compareLen = Math.min(tsBytes.length, vResult.bytes.length);
@@ -278,6 +298,8 @@ async function runOneTestViaVerilog(t: Test): Promise<Verdict> {
   if (!v.ok) {
     return { test: t, verdict: 'verilog-error', tsBytes, vBytes: [], error: v.error };
   }
+
+  writeVcd(`${t.category}_${t.name}`, v.vcdBase64);
 
   // Compare up to the expected length (suite tests define what matters)
   const expectedLen = t.expected.length;


### PR DESCRIPTION
## Summary
- Adds `\$dumpfile("verify.vcd"); \$dumpvars(0, tb);` to the iverilog testbench template in `verify.ts`, so every cross-validation run captures full signal state.
- Round-trips the resulting `verify.vcd` back from the Cloudflare Container verifier as base64 (capped at 8 MB raw), so the client can write per-test waveforms to `hardware/ulx3s/projects/cpu/.vcd/<slug>.vcd`.
- Ignores `.vcd/` in `hardware/ulx3s/.gitignore`.

Closes #42. Prereq for the upcoming `read_waveform` MCP tool.

## Implementation notes
- **Container** (`apps/verifier/container_src/main.go`): runs `vvp` with `cmd.Dir = dir` so the relative `verify.vcd` path lands inside the per-request temp dir; reads it back after sim completes and base64-encodes into a new `vcdBase64` response field. The Cloudflare Worker proxy is unchanged — it just streams the JSON through.
- **Client** (`hardware/ulx3s/projects/cpu/verify.ts`): decodes `vcdBase64` and writes to `.vcd/<slug>.vcd`. Slug is `<category>_<name>` for suite tests, plain name for one-offs. Missing `vcdBase64` is null-safe (just skips the write), so it stays compatible with older verifier deploys.

## Test plan
- [x] `pnpm fpga:regen-verilog` regenerates `combined.v`
- [x] `pnpm fpga:verify --filter=ADDI` produces 3 VCDs (~140 KB each) at `hardware/ulx3s/projects/cpu/.vcd/`
- [x] VCDs have valid Icarus headers (`\$date` / `\$version` / `\$timescale`) and `\$scope module tb` (confirms recursive dump captured the `cpu` instance hierarchy)
- [x] Opens in GTKWave — full ~3000 ns trace, clock toggling, instructions advancing, UART selects pulsing during boot
- [x] `git check-ignore` confirms `.vcd/` is ignored
- [x] `MATCH: 3/3` from the verifier — VCD capture didn't perturb correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)