### PR TITLE
fix(mcp): default front-end URL to https://simten.dev; rename TI_URL → SIMTEN_URL

### DIFF
--- a/.changeset/default-simten-url.md
+++ b/.changeset/default-simten-url.md
@@ -1,0 +1,7 @@
+---
+"@simten/mcp": patch
+---
+
+fix(mcp): default the front-end URL to https://simten.dev and rename TI_URL → SIMTEN_URL
+
+`show_circuit` opened the editor at the front-end base URL, which defaulted to `http://localhost:3001` — a dev-only port. Installed users of `@simten/mcp` therefore got a dead preview unless they happened to be running the web app locally. The default is now the deployed site (`https://simten.dev`); the dev build overrides it via the `SIMTEN_URL` env var. The env var itself is renamed from the leftover `TI_URL` (the project's former "Turing Incomplete" name) to `SIMTEN_URL`.

--- a/packages/mcp/src/lib/config.ts
+++ b/packages/mcp/src/lib/config.ts
@@ -1,5 +1,5 @@
-const DEFAULT_TI_URL = 'http://localhost:3001';
+const DEFAULT_SIMTEN_URL = 'https://simten.dev';
 
-export const TI_URL = process.env.TI_URL || DEFAULT_TI_URL;
+export const SIMTEN_URL = process.env.SIMTEN_URL || DEFAULT_SIMTEN_URL;
 
 export const DEFAULT_PORT = 19847;

--- a/packages/mcp/src/server/preview-server.ts
+++ b/packages/mcp/src/server/preview-server.ts
@@ -2,7 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { watchFile as fsWatchFile, unwatchFile, existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { CircuitState, TracesPayload, TestResultsPayload } from './types.js';
-import { TI_URL } from '../lib/config.js';
+import { SIMTEN_URL } from '../lib/config.js';
 
 export type { CircuitState, TracesPayload, TestResultsPayload };
 
@@ -24,7 +24,7 @@ export async function createPreviewServer(
   options?: { port?: number }
 ): Promise<PreviewServer> {
   const port = options?.port ?? 0;
-  const allowedOrigin = TI_URL;
+  const allowedOrigin = SIMTEN_URL;
 
   let currentSource: string | null = null;
   let cachedState: CircuitState | null = null;

--- a/packages/mcp/src/tools/show.ts
+++ b/packages/mcp/src/tools/show.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { exec } from 'node:child_process';
 import { resolve } from 'node:path';
 import { readCircuitSource } from '../lib/file-reader.js';
-import { TI_URL } from '../lib/config.js';
+import { SIMTEN_URL } from '../lib/config.js';
 import {
   getOrCreateServer,
   getPreviewServer,
@@ -146,7 +146,7 @@ export function registerShowTools(server: McpServer): void {
         render = await studio.updateSourceAndAwait(read.source, session);
       } else {
         const pending = studio.updateSourceAndAwaitConnect(read.source);
-        openBrowser(`${TI_URL}/circuit#token=${studio.token}&port=${studio.port}`);
+        openBrowser(`${SIMTEN_URL}/circuit#token=${studio.token}&port=${studio.port}`);
         render = await pending;
       }
 


### PR DESCRIPTION
## What

- `show_circuit` opens the editor at the front-end base URL, which defaulted to `http://localhost:3001` — a dev-only port. Installed users of `@simten/mcp` got a dead preview unless they happened to be running the web app locally.
- Default the base URL to the deployed site (`https://simten.dev`). The dev build overrides it via the env var.
- Rename the env var `TI_URL` → `SIMTEN_URL` (leftover from the project's former "Turing Incomplete" name). Updated in `config.ts`, `preview-server.ts`, and `show.ts`.

## Precedence

`SIMTEN_URL` env > `https://simten.dev` default. The local dev MCP registration sets `SIMTEN_URL=http://localhost:3001` so dev still previews locally without deploying.

## Changeset

`patch` for `@simten/mcp`. The env-var rename is technically breaking, but it's undocumented and the package is pre-1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)