### PR TITLE
fix(mcp): fall back to a free port when the studio port is taken

### DIFF
--- a/apps/web/src/hooks/useMCPConnection.ts
+++ b/apps/web/src/hooks/useMCPConnection.ts
@@ -2,7 +2,8 @@
  * useMCPConnection — WebSocket connection to the MCP server.
  *
  * Handles:
- * - Auto-discovery: tries ws://localhost:19847 on mount, retries every 5s
+ * - Connects using the token + port from the URL fragment (show_circuit sets
+ *   these; the port is OS-assigned and may not be the default 19847)
  * - Token auth from URL fragment (cleaned immediately)
  * - Session registration with a stable UUID
  * - Incoming messages: circuit source, traces, test results, memory data

--- a/packages/mcp/src/server/ws-server.ts
+++ b/packages/mcp/src/server/ws-server.ts
@@ -60,7 +60,7 @@ const DEDUP_WINDOW_MS = 500;
 export async function createStudioServer(
   options?: { port?: number; token?: string; onSendToClaude?: (content: string, meta: Record<string, string>) => void }
 ): Promise<StudioServer> {
-  const port = options?.port ?? 0;
+  const preferredPort = options?.port ?? 0;
   const token = options?.token ?? randomUUID();
 
   const sessions = new Map<string, Session>();
@@ -80,25 +80,44 @@ export async function createStudioServer(
   // the next tab to register receives the source WITH that id and acks it.
   let pendingConnectRender: string | null = null;
 
-  const wss = new WebSocketServer({ port, host: '127.0.0.1' });
-
-  const assignedPort = await new Promise<number>((resolvePort, reject) => {
-    wss.on('listening', () => {
-      const addr = wss.address();
-      if (typeof addr === 'object' && addr) {
-        resolvePort(addr.port);
-      } else {
-        reject(new Error('Failed to get server address'));
-      }
-    });
-    wss.on('error', (err) => {
-      if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
-        reject(new Error(`Port ${port} is already in use. Another MCP server or process may be running on this port.`));
-      } else {
+  // Bind to a single port, resolving the actual port the OS assigned.
+  // Rejects on EADDRINUSE (so the caller can fall back) and any other error.
+  function tryListen(p: number): Promise<{ wss: WebSocketServer; port: number }> {
+    return new Promise((resolveBind, reject) => {
+      const server = new WebSocketServer({ port: p, host: '127.0.0.1' });
+      server.on('listening', () => {
+        const addr = server.address();
+        if (typeof addr === 'object' && addr) {
+          resolveBind({ wss: server, port: addr.port });
+        } else {
+          server.close();
+          reject(new Error('Failed to get server address'));
+        }
+      });
+      server.on('error', (err) => {
+        // Close the half-open server before surfacing the error so it can't leak.
+        server.close();
         reject(err);
-      }
+      });
     });
-  });
+  }
+
+  // Prefer the well-known port (so a browser tab's persisted localStorage
+  // reconnects across MCP restarts), but when it's already taken — e.g. another
+  // project's MCP instance is running — fall back to an OS-assigned free port
+  // instead of failing. show_circuit advertises the real port to the browser via
+  // the URL fragment, so any port works end-to-end.
+  let wss: WebSocketServer;
+  let assignedPort: number;
+  try {
+    ({ wss, port: assignedPort } = await tryListen(preferredPort));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE' && preferredPort !== 0) {
+      ({ wss, port: assignedPort } = await tryListen(0));
+    } else {
+      throw err;
+    }
+  }
 
   wss.on('connection', (ws, req) => {
     // Validate token from query string: ws://localhost:19847?token=xxx


### PR DESCRIPTION
## Problem

The studio server bound the well-known port (19847) and **rejected with "already in use"** on `EADDRINUSE`. So when a second project's MCP instance was running (or a stale `node` process held the port), `show_circuit` could never start its preview — it just errored.

## Fix

Bind logic now **prefers** the well-known port but **falls back to an OS-assigned free port** when it's taken:

- Single instance → still gets 19847, so a browser tab's persisted `localStorage` reconnects across MCP restarts (unchanged design intent).
- Port busy → `tryListen(0)` lets the OS pick a free port instead of failing.

This works end-to-end with no other changes because the chain was already dynamic-port aware:
- `createStudioServer` reads back the real assigned port
- `show.ts` already advertises it via the URL fragment (`#token=…&port=…`)
- the web client already connects to whatever port it receives

Also corrected a stale comment in `useMCPConnection.ts` that claimed it hardcoded `ws://localhost:19847`.

## Testing

- `pnpm build` (tsc) — clean
- Runtime: two servers on the same preferred port → second falls back to a free port; explicit `port:0` → ephemeral. Verified the original port is kept when free and a different one is chosen when taken.