### PR TITLE
chore: add changeset for mcp dynamic port fallback

### DIFF
--- a/.changeset/mcp-dynamic-port.md
+++ b/.changeset/mcp-dynamic-port.md
@@ -1,0 +1,5 @@
+---
+"@simten/mcp": patch
+---
+
+Studio server now falls back to an OS-assigned free port when the preferred port (19847) is already in use, instead of failing with "port already in use". This lets a second project's MCP instance start its preview. The real port is advertised to the browser via the existing URL fragment, so any port works end-to-end.


### PR DESCRIPTION
Follow-up to #164, which merged the dynamic-port fix but missed its changeset (it landed on the branch after the squash-merge). Without it, the version bot won't bump `@simten/mcp` or publish.

This PR adds only the changeset (`@simten/mcp`: patch) so the fix from #164 actually ships to npm.