### PR TITLE
fix: per-instance studio token + bounded browser reconnect

### DIFF
--- a/.changeset/per-instance-token.md
+++ b/.changeset/per-instance-token.md
@@ -1,0 +1,5 @@
+---
+"@simten/mcp": patch
+---
+
+Use a per-process studio auth token instead of a persistent global one (`~/.simten/token`). Combined with the port, the token now uniquely identifies a single MCP instance, both delivered to the browser via show_circuit's URL fragment. A tab that reconnects to a different instance — a stale cached port now held by another project's MCP, or this instance after a restart — is cleanly rejected (close code 4001) instead of silently attaching to the wrong server. Trade-off: a browser tab no longer survives an MCP restart automatically; the next show_circuit re-establishes it.

--- a/apps/web/src/hooks/useMCPConnection.ts
+++ b/apps/web/src/hooks/useMCPConnection.ts
@@ -44,6 +44,10 @@ export interface MCPCallbacks {
 }
 
 const RETRY_INTERVAL = 5000;
+/** Reconnect a bounded number of times before giving up. The MCP's port can move
+ *  (dynamic port) and its token is per-process, so a dropped socket may mean the
+ *  server is gone or has a new identity — don't loop on a stale port forever. */
+const MAX_RECONNECT_ATTEMPTS = 5;
 const LS_KEY = 'simten:mcp-connection';
 
 function saveConnectionParams(params: { token: string; port: number }) {
@@ -96,6 +100,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
   // Store connection params (from fragment or auto-discovery)
   const connectionRef = useRef<{ token: string; port: number } | null>(null);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
 
   const connect = useCallback((port: number, token: string) => {
     // Close existing connection
@@ -111,6 +116,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
 
     ws.onopen = () => {
       setStatus('connected');
+      reconnectAttemptsRef.current = 0; // fresh budget for the next disconnect
       // Register this tab as a session
       ws.send(JSON.stringify({
         type: 'register',
@@ -182,14 +188,24 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
         setStatus('disconnected');
         return;
       }
-      if (connectionRef.current) {
-        // We had a valid connection — try to reconnect
+      if (connectionRef.current && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+        // We had a valid connection — retry a bounded number of times against the
+        // last-known port. Covers a transient drop or an MCP that restarted on the
+        // same (preferred) port. Don't loop forever: the port may have moved.
+        reconnectAttemptsRef.current += 1;
         setStatus('reconnecting');
         retryTimerRef.current = setTimeout(() => {
           const conn = connectionRef.current;
           if (conn) connect(conn.port, conn.token);
         }, RETRY_INTERVAL);
       } else {
+        // No prior connection, or retries exhausted: drop the stale params so a
+        // returning tab can't keep hammering — or silently mis-attach to — a port
+        // that has moved. The next show_circuit delivers a fresh fragment and
+        // reconnects cleanly.
+        try { localStorage.removeItem(LS_KEY); } catch { /* ignore */ }
+        connectionRef.current = null;
+        reconnectAttemptsRef.current = 0;
         setStatus('disconnected');
       }
     };

--- a/packages/mcp/src/lib/preview-singleton.ts
+++ b/packages/mcp/src/lib/preview-singleton.ts
@@ -5,9 +5,6 @@
  * (show, state, traces, test-results).
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import type { StudioServer, CircuitState, TracesPayload, TestResultsPayload } from '../server/ws-server.js';
 
@@ -18,20 +15,20 @@ let studioServer: StudioServer | null = null;
 let browserOpened = false;
 
 /**
- * Load the persistent token from ~/.simten/token, creating it if absent.
- * Survives MCP restarts — browser's localStorage stays valid.
+ * Per-process auth token: a fresh identity each time the MCP starts. Together
+ * with the port, it uniquely identifies THIS server instance; show_circuit hands
+ * both to the browser via the URL fragment. A tab that reconnects to a different
+ * instance — a stale cached port now held by another project's MCP, or this
+ * instance after a restart — presents a token that no longer matches and is
+ * cleanly rejected (WebSocket close code 4001) instead of silently attaching to
+ * the wrong server.
+ *
+ * Previously this was persisted to ~/.simten/token so a tab survived an MCP
+ * restart, but that persistence is precisely what let a stale tab authenticate
+ * against the wrong instance (cross-instance bleed). The fragment from the next
+ * show_circuit is the authoritative way to (re)establish a tab.
  */
-function getOrCreateToken(): string {
-  const tokenPath = join(homedir(), '.simten', 'token');
-  if (existsSync(tokenPath)) {
-    const stored = readFileSync(tokenPath, 'utf8').trim();
-    if (stored) return stored;
-  }
-  const token = randomUUID();
-  mkdirSync(join(homedir(), '.simten'), { recursive: true });
-  writeFileSync(tokenPath, token, { mode: 0o600 });
-  return token;
-}
+const PROCESS_TOKEN = randomUUID();
 
 // Callback for browser → Claude channel notifications
 let onSendToClaudeCallback: ((content: string, meta: Record<string, string>) => void) | null = null;
@@ -62,7 +59,7 @@ export async function getOrCreateServer(): Promise<StudioServer> {
 
   studioServer = await createStudioServer({
     port: DEFAULT_PORT,
-    token: getOrCreateToken(),
+    token: PROCESS_TOKEN,
     onSendToClaude: (content, meta) => {
       onSendToClaudeCallback?.(content, meta);
     },


### PR DESCRIPTION
## Why

Follow-up to the dynamic-port change (#164). That fix let the studio server move off port 19847, which exposed a latent app-side assumption: a browser tab assumed the port (and server) it first saw is the server forever. The root enabler was the **persistent global token** at `~/.simten/token` — shared by every MCP instance on the machine — whose entire job was to let a tab survive losing track of its server. That's definitionally the same machinery that lets a tab attach to the *wrong* server: a stale cached port now held by another project's MCP authenticates successfully (same token) and silently renders the wrong project's circuits.

## What

**MCP — per-instance token.** Replace the persistent global token with a fresh per-process token. Combined with the port, `(token, port)` now uniquely identifies one instance; both are already delivered to the browser via `show_circuit`'s URL fragment. A tab reconnecting to a different instance presents a token that no longer matches and is **cleanly rejected (close code 4001)** instead of silently mis-attaching. This is a deletion plus a one-line change to what gets minted — it makes the *existing* auth check meaningful rather than adding a new one.

**App — bounded reconnect.** Reconnect a bounded number of times against the last-known port (covers a transient drop or a restart that reclaimed the same preferred port), then clear stale `localStorage` params and go `disconnected`. A returning tab never loops on — or mis-attaches to — a moved port; the next `show_circuit` delivers a fresh fragment and reconnects.

**Trade-off (intentional):** a tab no longer survives an MCP *restart* automatically — the next `show_circuit` re-establishes it. In the agent-driven flow that's the normal path anyway. Pre-flight confirmed nothing outside the WS auth reads `~/.simten/token`, so dropping the persistence is clean.

## NOT addressed here (separate issue)

The live "new tab opens but never connects back" symptom in the default setup is most likely a **transport/mixed-content** problem, not tokens: the tab opens at `https://simten.dev` (default `SIMTEN_URL`) and the socket is always plain `ws://localhost` with no `wss`/secure-context handling. Chrome/Firefox allow `ws://localhost` via the localhost secure-context exception; Safari is inconsistent/blocks it. That sits on the deployed-frontend-vs-local-MCP boundary and needs its own fix — this change is correct regardless but is not presumed to close it.

## Testing

- `@simten/mcp` `tsc -b` — clean
- `apps/web` `tsc --noEmit` — 0 errors