### PR TITLE
fix(mcp): exit on parent death instead of orphaning

### DIFF
--- a/.changeset/mcp-exit-on-parent-death.md
+++ b/.changeset/mcp-exit-on-parent-death.md
@@ -1,0 +1,5 @@
+---
+"@simten/mcp": patch
+---
+
+The MCP server now exits when its parent (Claude Code) goes away, instead of orphaning. Because the studio WS server is started eagerly, its listening socket kept the event loop alive, so the process never terminated on its own when stdin closed — leaking instances that outlived their session and held the studio port (causing dozens of stale servers to pile up). Shutdown is now wired to stdin EOF/close, the MCP transport closing, and SIGTERM/SIGINT, each closing the studio server and exiting. Plain `kill` (SIGTERM) now terminates the server without needing `-9`.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -139,3 +139,42 @@ getOrCreateServer()
   .catch((err: unknown) => {
     process.stderr.write(`[simten-mcp] WS server failed to start: ${err instanceof Error ? err.message : String(err)}\n`);
   });
+
+// --- Lifecycle: exit when the parent (Claude Code) goes away ----------------
+// The eagerly-started WS server keeps a listening socket (and per-connection
+// ping intervals) on the event loop, so this process will NOT terminate on its
+// own when stdin closes. Without an explicit exit it orphans — outliving its
+// Claude session and holding its studio port — which is how dozens of stale
+// instances pile up. Wire every parent-death signal to one shutdown that closes
+// the studio server and exits.
+let shuttingDown = false;
+function shutdown(reason: string): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  process.stderr.write(`[simten-mcp] shutting down (${reason})\n`);
+  try {
+    getPreviewServer()?.close();
+  } catch {
+    /* best effort — exit regardless */
+  }
+  process.exit(0);
+}
+
+// stdin EOF/close is the reliable lifeline: when the MCP client closes the pipe
+// (or the wrapper chain dies), our stdin ends even if no signal is delivered.
+process.stdin.on('end', () => shutdown('stdin end'));
+process.stdin.on('close', () => shutdown('stdin close'));
+
+// The MCP transport closing means the client disconnected; chain any handler the
+// SDK already installed, then shut down.
+const prevOnClose = transport.onclose;
+transport.onclose = () => {
+  prevOnClose?.();
+  shutdown('transport close');
+};
+
+// Make signals actually terminate. (preview-singleton also closes the studio on
+// these, but its handlers don't exit — which overrides Node's default and leaves
+// the process alive; this guarantees termination so `kill` works without -9.)
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));


### PR DESCRIPTION
## Why

We found ~12 stale `@simten/mcp` processes running at once. Root cause: the MCP stdio server **never exits when its Claude session ends**, so every session leaks one, and they pile up — each holding a studio WS server and fighting over port 19847, which is what produced the browser's connect/drop/reconnect loop.

Two things conspired:
1. `index.ts` starts the studio WS server **eagerly** on boot. Its listening socket (plus per-connection ping intervals) keeps the Node event loop alive, so the process can't exit on its own when stdin closes.
2. There was **no parent-death handling** after `server.connect()`. And the existing `SIGTERM`/`SIGINT` handlers in `preview-singleton` close the studio but don't `process.exit`, which overrides Node's default terminate-on-signal — so even a plain `kill` left them alive (you needed `kill -9`).

## What

Wire every parent-death signal to one idempotent `shutdown()` that closes the studio server and exits:
- `process.stdin` `end`/`close` — the reliable lifeline: when the client closes the pipe (or the `npx`/`tsx` wrapper chain dies), our stdin ends even if no signal arrives.
- `transport.onclose` — chained after any handler the SDK installed.
- `SIGTERM` / `SIGINT` — now actually terminate.

## Testing

Built (`tsc -b`), then a real lifecycle test spawning the server via `tsx` (the way the MCP actually runs), waiting for the WS server to start, then triggering each path:

- **stdin close → exited in ~0.9s** (code 0)
- **SIGTERM → exited in ~0.7s** (code 0, no `-9` needed)

No leftover process, port 19847 released.