### PR TITLE
fix(mcp): add get_grammar/list_components; shrink instructions under the 2KB cap

### DIFF
--- a/.changeset/mcp-reference-tools.md
+++ b/.changeset/mcp-reference-tools.md
@@ -1,0 +1,14 @@
+---
+"@simten/mcp": minor
+---
+
+Add `get_grammar` and `list_components` tools; shrink server instructions under the client truncation cap.
+
+Clients cap an MCP server's `instructions` field — [Claude Code truncates it at 2 KB](https://code.claude.com/docs/en/mcp.md). The server's instructions were ~15 KB, so everything after the first ~2 KB — the entire component catalog, the verify/oracle contract, and the canvas policy — was silently dropped before the model ever saw it. That left agents guessing component names (and falling back to looking in `node_modules`) and skipping the verify workflow.
+
+The instructions are now ~1.9 KB, front-loading the verify contract and a pointer to two new on-demand tools:
+
+- `get_grammar` — the `circuit()` builder API (inputs/outputs, nodes, connect) with worked examples.
+- `list_components` — the full stdlib component catalog, each with its ports and constructor options.
+
+Tool *results* aren't capped, so the full reference is reliably available on demand even though it can't fit in the instructions. This both fixes the discovery gap and lets the verify contract survive truncation.

--- a/apps/web/content/docs/claude-code.mdx
+++ b/apps/web/content/docs/claude-code.mdx
@@ -39,12 +39,16 @@ Once the MCP server is registered, Claude has access to these tools:
 
 | Tool | What it does |
 |------|-------------|
+| `get_grammar` | Return the `circuit()` builder API (inputs/outputs, nodes, connect) with worked examples. |
+| `list_components` | Return the full catalog of stdlib components — each with its ports and constructor options (e.g. `Register({ width })`). |
 | `show_circuit` | Push a circuit file to the browser viewer and open a live preview. Watches the file for changes. |
 | `check_circuit` | Validate circuit source (syntax, semantic, type, structural) without running it. |
 | `simulate_circuit` | Compile and simulate; return signal traces and the steady-state cycle. Observation only — shows what the circuit does, not whether it's correct. |
 | `verify_circuit` | Run a self-checking `.verify.ts` testbench at a declared oracle tier. This is the correctness gate (see [Verifying circuits](/docs/verifying-circuits)). |
 | `read_waveform` | Query a VCD waveform for specific signals over a cycle window. |
 | `run_on_fpga` | Build and run the circuit on a connected FPGA board. |
+
+`get_grammar` and `list_components` exist because clients cap an MCP server's instructions (Claude Code truncates them at 2 KB), which is too small to inline the full circuit API and component catalog. Claude calls these on demand to get the authoritative part names and signatures rather than guessing.
 
 ## How the connection works
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -22,54 +22,32 @@ import { registerVerifyTool } from './tools/verify.js';
 import { registerShowTools } from './tools/show.js';
 import { registerRunOnFpgaTool } from './tools/run_on_fpga.js';
 import { registerReadWaveformTool } from './tools/read_waveform.js';
+import { registerReferenceTools } from './tools/reference.js';
 import { getOrCreateServer, getPreviewServer } from './lib/preview-singleton.js';
-import { getGrammarHandler, getPrimitivesHandler, getLibrary } from '@simten/core/api';
-import { getFactoryOptionSignatures, annotatePrimitivesWithOptions } from './lib/primitive-params.js';
 
-const builderAPI = getGrammarHandler();
-// Annotate parameterized components with their constructor options (e.g.
-// `Register ctor({ width?, value? })`) so the agent can parameterize them
-// without guessing — ports alone don't reveal factory options.
-const primitivesList = annotatePrimitivesWithOptions(
-  getPrimitivesHandler({ compact: true }, getLibrary()),
-  getFactoryOptionSignatures(),
-);
+// NOTE: clients truncate an MCP server's `instructions` at ~2KB (Claude Code
+// does — https://code.claude.com/docs/en/mcp.md), so this MUST stay small and
+// front-load what matters. The circuit-builder API and the ~10KB component
+// catalog deliberately do NOT live here — they'd be cut — and are exposed via
+// the `get_grammar` / `list_components` tools instead (tool results aren't
+// capped). Keep critical guidance (the verify contract, the reference pointer)
+// near the top so it survives truncation.
+const instructions = `You help developers design, simulate, and verify hardware from TypeScript. Circuits are files the host edits (write to \`circuits/<name>.circuit.ts\` unless told otherwise); the simten tools check, simulate, verify, and visualize them.
 
-const instructions = `You help developers design, simulate, and verify hardware systems from TypeScript. Circuits are files the host edits (write to \`circuits/<name>.circuit.ts\` in the project unless the user says otherwise); the simten tools then check, simulate, verify, and visualize them.
+## Reference (call these — don't guess)
+This server's instructions are truncated by clients at ~2KB, so the full reference lives in tools:
+- \`get_grammar\` — the \`circuit()\` API (inputs/outputs, nodes, connect) with examples. Read before writing a circuit.
+- \`list_components\` — every available component with its ports and constructor options (e.g. \`Register({ width })\`).
 
-Write each circuit file as a **standalone TS module**: \`import { circuit, bit, bus } from '@simten/core/circuit'\`, stdlib from \`@simten/core/std\`, and **\`export\` the top-level circuit** so a testbench can import it. Real imports keep the file valid in the editor and runnable with \`tsx\`/\`vitest\`. (Tests run on the host via \`tsx\`, so npm packages resolve from \`node_modules\` — you can import a reference implementation as an oracle. Don't write import-free circuit code.)
+## The contract
+- **Done = correct, at a declared tier.** A non-trivial design is complete only when \`verify_circuit\` passes at the highest feasible oracle tier (its description defines the tiers), sibling \`.verify.ts\` still pass (re-run them for any circuit you touched), and integrated changes have a system-level verify. \`simulate_circuit\` shows what a circuit *does*, not that it's correct — don't stop at a plausible waveform.
+- **Don't weaken the oracle to pass** — the \`independence_basis\` makes that visible. Lead with what you checked, against what, at what tier.
 
-## Circuit API
+## Writing circuits
+Write each circuit as a standalone TS module: \`import { circuit, bit, bus } from '@simten/core/circuit'\`, stdlib from \`@simten/core/std\`, and **\`export\`** the top-level circuit so a testbench can import it. Don't write import-free code.
 
-${builderAPI}
-
-## Available Components
-
-${primitivesList}
-
-## The contract (read this)
-
-- **Done = correct, at a declared tier.** A non-trivial design is complete only when \`verify_circuit\` passes at the highest feasible oracle tier (its description defines the tiers), **AND** existing sibling \`.verify.ts\` still pass (no regression — re-run them for any circuit you touched), **AND** for integrated/multi-module changes a system-level verify exists. \`simulate_circuit\` shows what a circuit *does*; it does NOT establish correctness — don't stop at a plausible-looking waveform.
-- **A named spec is the oracle.** If the prompt states the spec, verify against it; don't re-elicit. Surface acceptance criteria before building only on vague prompts for non-trivial designs.
-- **The gate enforces the oracle regardless of the order you wrote things in.** Testbench-first is recommended (harder to retrofit a softball), not required. Don't weaken the oracle to pass — the \`independence_basis\` makes that visible.
-- **Surface what you checked.** Lead with the oracle (what was checked, against what, at what tier), not just pass/fail.
-
-## Tools
-
-- \`check_circuit\` — fast well-formedness validation (syntax/semantic/type/structural).
-- \`simulate_circuit\` — run it, return traces. Observation only; does not paint the canvas unless \`show: true\`.
-- \`verify_circuit\` — run a self-checking testbench *file* (a \`circuits/<name>.verify.ts\` that imports its DUT) on the host; reports pass/fail + counterexample at a declared oracle tier. See its description for tiers and how to write the testbench.
-- \`show_circuit\` — paint/update the live canvas (call with no source to list connected tabs; \`close: true\` to close). The only tool that draws.
-- \`run_on_fpga\` — build, flash, and UART-capture a project on a connected ULX3S FPGA (projects: cpu, snake, uart_test).
-- \`read_waveform\` — query VCD files (iverilog cross-validation, ILA captures) for signals over a cycle window. Use \`test_name\` for the CPU verify-suite or \`vcd_path\` for arbitrary VCDs.
-
-## Canvas
-
-The canvas only paints via \`show_circuit\` (or \`simulate_circuit\` with \`show: true\`). Don't paint during tight iteration — paint at a verify tier-pass, or for a specific failure worth inspecting. Headless (no canvas connected): paint calls simply no-op. The canvas is a **viewer**: it displays and simulates what you push; it does not send anything back.
-
-## Trust
-
-\`verify_circuit\` runs the testbench on the host via \`tsx\` — full node/npm, under your own trust model (same as the agent running \`npm test\`). Appropriate for circuits you authored or trust. **Unfamiliar or shared circuits should be opened in the web \`/circuit\` editor** (a sandboxed worker), not run locally.
+## Canvas & trust
+\`show_circuit\` is the only tool that paints; the canvas is a one-way **viewer** (it displays/simulates what you push and sends nothing back). Don't paint during tight iteration — paint at a verify pass. \`verify_circuit\` runs the testbench on the host via \`tsx\` (full node/npm, your trust level — like \`npm test\`); open unfamiliar or shared circuits in the sandboxed web \`/circuit\` editor, not locally.
 `;
 
 const server = new McpServer(
@@ -89,6 +67,7 @@ registerVerifyTool(server);
 registerShowTools(server);
 registerRunOnFpgaTool(server);
 registerReadWaveformTool(server);
+registerReferenceTools(server);
 
 // The local studio is VIEWER-ONLY: the MCP pushes circuits to the browser for
 // display/simulation and accepts nothing actionable back. The browser→Claude

--- a/packages/mcp/src/tools/reference.test.ts
+++ b/packages/mcp/src/tools/reference.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { registerReferenceTools } from './reference.js';
+
+type Handler = () => Promise<{ content: { type: string; text: string }[] }>;
+
+function captureTools(): Map<string, Handler> {
+  const tools = new Map<string, Handler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: Handler) => tools.set(name, handler),
+  };
+  registerReferenceTools(server as never);
+  return tools;
+}
+
+describe('reference tools', () => {
+  it('registers get_grammar and list_components', () => {
+    expect([...captureTools().keys()].sort()).toEqual(['get_grammar', 'list_components']);
+  });
+
+  it('list_components returns the catalog with real part names + ctor options', async () => {
+    const res = await captureTools().get('list_components')!();
+    const text = res.content[0].text;
+    // This is exactly the ~10KB that can't fit in the 2KB instructions cap —
+    // so it must be reachable on demand instead.
+    expect(text.length).toBeGreaterThan(1000);
+    for (const part of ['Register', 'Adder', 'Mux']) expect(text).toContain(part);
+  });
+
+  it('get_grammar returns the circuit-builder API', async () => {
+    const res = await captureTools().get('get_grammar')!();
+    expect(res.content[0].text).toContain('circuit(');
+  });
+});

--- a/packages/mcp/src/tools/reference.ts
+++ b/packages/mcp/src/tools/reference.ts
@@ -1,0 +1,40 @@
+/**
+ * Reference tools — get_grammar + list_components.
+ *
+ * Clients cap an MCP server's `instructions` field (Claude Code truncates at
+ * 2KB; see https://code.claude.com/docs/en/mcp.md). The circuit-builder API
+ * (~2KB) and the component catalog (~10KB) can't fit there — they'd be cut,
+ * leaving the agent to guess part names and ports. So instead of baking that
+ * reference into the always-injected instructions, we expose it on demand via
+ * these tools: tool *results* aren't capped, so the agent gets the full text.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getGrammarHandler, getPrimitivesHandler, getLibrary } from '@simten/core/api';
+import { getFactoryOptionSignatures, annotatePrimitivesWithOptions } from '../lib/primitive-params.js';
+
+// Static reference, built once. The grammar is the circuit() builder API +
+// worked examples; the component list is every primitive with its ports and
+// constructor options (e.g. `Register ctor({ width?, value? })`) — ports alone
+// don't reveal factory options.
+const grammar = getGrammarHandler();
+const components = annotatePrimitivesWithOptions(
+  getPrimitivesHandler({ compact: true }, getLibrary()),
+  getFactoryOptionSignatures(),
+);
+
+export function registerReferenceTools(server: McpServer): void {
+  server.tool(
+    'get_grammar',
+    'Return the circuit-builder API: how to write a `circuit()` module — inputs/outputs, nodes, connect — with worked examples. Call this before writing a circuit.',
+    {},
+    async () => ({ content: [{ type: 'text' as const, text: grammar }] }),
+  );
+
+  server.tool(
+    'list_components',
+    'Return the full catalog of available components from `@simten/core/std`, each with its ports and constructor options (e.g. `Register({ width })`). Call this to discover exact part names and parameters instead of guessing.',
+    {},
+    async () => ({ content: [{ type: 'text' as const, text: components }] }),
+  );
+}


### PR DESCRIPTION
## Problem

Clients cap an MCP server's `instructions` field — [Claude Code truncates it at 2 KB](https://code.claude.com/docs/en/mcp.md) (and shares a ~4 KB budget across servers, [#43474](https://github.com/anthropics/claude-code/issues/43474)). The simten server's instructions were **~15 KB**, so only the first ~2 KB reached the model. Everything after the Circuit API examples was silently dropped:

- the **~10 KB component catalog** (`## Available Components`),
- the **verify/oracle contract** ("done = verified at a tier"),
- the **canvas policy** and trust notes.

Observed in real use: an agent had no component list (it went looking in `node_modules`, then guessed names and leaned on `check_circuit` trial-and-error), and skipped the verify workflow — because the guidance telling it otherwise never arrived.

## Fix

Move the big reference **out of the always-injected instructions** (which are capped) and into **on-demand tools** (tool *results* aren't capped):

- **`get_grammar`** — the `circuit()` builder API (inputs/outputs, nodes, connect) with worked examples.
- **`list_components`** — the full stdlib catalog, each with ports and constructor options (e.g. `Register({ width })`).

Instructions rewritten to **~1.9 KB** (measured), front-loading the **verify contract** and a **pointer to the two tools** so the essentials survive truncation. The per-tool descriptions (each independently ≤2 KB) are unaffected.

## Testing

- `@simten/mcp`: **63 tests pass** (+3 `reference.test.ts`: both tools register; `list_components` returns the catalog with real part names + ctor options; `get_grammar` returns the API).
- `tsc -b` clean.
- Instructions size asserted < 2 KB.

## Changeset

`@simten/mcp` minor — see `.changeset/mcp-reference-tools.md`.