### PR TITLE
fix(mcp): add get_verify_api; keep verify_circuit's description under the 2KB cap

### DIFF
--- a/.changeset/mcp-get-verify-api.md
+++ b/.changeset/mcp-get-verify-api.md
@@ -1,0 +1,10 @@
+---
+"@simten/mcp": minor
+---
+
+Add a `get_verify_api` tool and move the testbench-writing reference out of `verify_circuit`'s description.
+
+Clients cap each MCP tool description at 2 KB ([Claude Code does](https://code.claude.com/docs/en/mcp.md)) — the same per-field cap that truncated the server instructions. `verify_circuit`'s description was ~2.5 KB, so the `simulate()` testbench API at the end (`s.set` / `s.tick` / `s.get` / `s.dispose`) was cut off mid-example. Agents couldn't see how to write a `.verify.ts` and fell back to digging through library source.
+
+- New `get_verify_api` tool returns the full testbench reference: the `simulate()` stepper API, `verify.exhaustive` vs `verify.check`, `declareOracle`, and the Tier-A npm-oracle pattern.
+- `verify_circuit`'s description is slimmed to ~1.6 KB (the oracle tiers + a pointer to `get_verify_api`), back under the cap. All tool descriptions are now under 2 KB.

--- a/apps/web/content/docs/claude-code.mdx
+++ b/apps/web/content/docs/claude-code.mdx
@@ -41,6 +41,7 @@ Once the MCP server is registered, Claude has access to these tools:
 |------|-------------|
 | `get_grammar` | Return the `circuit()` builder API (inputs/outputs, nodes, connect) with worked examples. |
 | `list_components` | Return the full catalog of stdlib components — each with its ports and constructor options (e.g. `Register({ width })`). |
+| `get_verify_api` | Return how to write a `.verify.ts` testbench — the `simulate()` stepper API, `verify.exhaustive`/`verify.check`, `declareOracle`, and worked examples. |
 | `show_circuit` | Push a circuit file to the browser viewer and open a live preview. Watches the file for changes. |
 | `check_circuit` | Validate circuit source (syntax, semantic, type, structural) without running it. |
 | `simulate_circuit` | Compile and simulate; return signal traces and the steady-state cycle. Observation only — shows what the circuit does, not whether it's correct. |
@@ -48,7 +49,7 @@ Once the MCP server is registered, Claude has access to these tools:
 | `read_waveform` | Query a VCD waveform for specific signals over a cycle window. |
 | `run_on_fpga` | Build and run the circuit on a connected FPGA board. |
 
-`get_grammar` and `list_components` exist because clients cap an MCP server's instructions (Claude Code truncates them at 2 KB), which is too small to inline the full circuit API and component catalog. Claude calls these on demand to get the authoritative part names and signatures rather than guessing.
+`get_grammar`, `list_components`, and `get_verify_api` exist because clients cap an MCP server's instructions *and each tool description* at 2 KB — too small to inline the circuit API, the component catalog, or the testbench-writing guide. Claude calls these on demand to get the authoritative part names, signatures, and `simulate()` API rather than guessing.
 
 ## How the connection works
 

--- a/packages/mcp/src/tools/reference.test.ts
+++ b/packages/mcp/src/tools/reference.test.ts
@@ -13,8 +13,8 @@ function captureTools(): Map<string, Handler> {
 }
 
 describe('reference tools', () => {
-  it('registers get_grammar and list_components', () => {
-    expect([...captureTools().keys()].sort()).toEqual(['get_grammar', 'list_components']);
+  it('registers get_grammar, list_components, and get_verify_api', () => {
+    expect([...captureTools().keys()].sort()).toEqual(['get_grammar', 'get_verify_api', 'list_components']);
   });
 
   it('list_components returns the catalog with real part names + ctor options', async () => {
@@ -29,5 +29,12 @@ describe('reference tools', () => {
   it('get_grammar returns the circuit-builder API', async () => {
     const res = await captureTools().get('get_grammar')!();
     expect(res.content[0].text).toContain('circuit(');
+  });
+
+  it('get_verify_api returns the testbench/simulate() reference that was truncating off verify_circuit', async () => {
+    const text = (await captureTools().get('get_verify_api')!()).content[0].text;
+    for (const token of ['simulate(', 's.set(', 's.tick(', 's.get(', 'verify.run()', 'declareOracle']) {
+      expect(text).toContain(token);
+    }
   });
 });

--- a/packages/mcp/src/tools/reference.ts
+++ b/packages/mcp/src/tools/reference.ts
@@ -23,6 +23,57 @@ const components = annotatePrimitivesWithOptions(
   getFactoryOptionSignatures(),
 );
 
+// How to write a .verify.ts testbench. This lives here (not in verify_circuit's
+// description) because that description is capped at 2KB by clients — the
+// simulate() stepper API was getting truncated off the end. Kept faithful to
+// docs/verifying-circuits.mdx (the simulate() handle is lifted from a fixture).
+const VERIFY_API = `Writing a .verify.ts testbench — a sibling file to your circuit, run on the host via tsx (full npm resolution, no sandbox).
+
+SHAPE
+  import { simulate } from '@simten/core/sim';
+  import { verify, declareOracle } from '@simten/core/verify';
+  import * as fc from 'fast-check';                       // only if you use verify.check
+  import { MyCircuit } from './my_circuit.circuit.js';     // your DUT — must be exported
+
+  declareOracle({ tier: 'B', type: '...', independence_basis: '...' });  // module top level, one per file
+
+  verify.exhaustive('truth table', [2, 2], (a, b) => {
+    const s = simulate(MyCircuit);
+    try {
+      s.set({ a, b });                                     // drive inputs by port name
+      return s.get('sum') === (a ^ b) && s.get('carry') === (a & b);
+    } finally {
+      s.dispose();
+    }
+  });
+
+  verify.run();   // REQUIRED — flushes the structured result (this is the gate)
+
+THE simulate() HANDLE
+  const s = simulate(Circuit);
+  s.set({ portName: value, ... });   // set input port values (number/boolean)
+  s.tick();                          // advance one rising clock edge (sequential circuits)
+  s.get('portName');                 // read an output port's current value
+  s.dispose();                       // ALWAYS in finally — frees the sim
+  // Combinational: set() then get(). Sequential: set(), tick() per cycle, get().
+  // Pulse a reset: s.set({ reset: 1 }); s.tick(); s.set({ reset: 0 }); then drive normally.
+
+CHECK STRATEGIES
+  verify.exhaustive(name, spaces, predicate) — sweep every combination. spaces: [256] = 0..255; [2,2] = all 4 (a,b) pairs. Harness caps at 2^20. Use when the space is enumerable.
+  verify.check(name, fc.property(fc.nat(255), (x) => { ... })) — fast-check sampling for large spaces; shrinks to a minimal repro on failure.
+
+TIER-A npm-oracle pattern (the flagship) — import a real package and compare the circuit against it:
+  import { sha256 } from '@noble/hashes/sha2.js';
+  const expected = sha256(new Uint8Array(0));            // independent reference, computed outside the circuit
+  declareOracle({ tier: 'A', type: '@noble/hashes sha256("") vector', independence_basis: 'expected bytes come from an external crypto library, not this circuit' });
+  verify.exhaustive('rom holds sha256("")[0..3]', [4], (addr) => {
+    const s = simulate(HashRom);
+    try { s.set({ addr }); s.tick(); return s.get('data') === expected[addr]; } finally { s.dispose(); }
+  });
+  verify.run();
+
+The same file runs unchanged three ways: via verify_circuit (agent), 'tsx file.verify.ts' (CLI), or under vitest (wrap as test('verify', () => verify.run())). Lead with the tier when you report — Tier-A exhaustive is a far stronger claim than Tier-D sampled.`;
+
 export function registerReferenceTools(server: McpServer): void {
   server.tool(
     'get_grammar',
@@ -36,5 +87,12 @@ export function registerReferenceTools(server: McpServer): void {
     'Return the full catalog of available components from `@simten/core/std`, each with its ports and constructor options (e.g. `Register({ width })`). Call this to discover exact part names and parameters instead of guessing.',
     {},
     async () => ({ content: [{ type: 'text' as const, text: components }] }),
+  );
+
+  server.tool(
+    'get_verify_api',
+    'Return how to write a `.verify.ts` testbench for `verify_circuit`: the `simulate()` stepper API (set/tick/get/dispose), `verify.exhaustive` vs `verify.check`, `declareOracle`, and worked examples (incl. the Tier-A npm-oracle pattern). Call this before writing a testbench.',
+    {},
+    async () => ({ content: [{ type: 'text' as const, text: VERIFY_API }] }),
   );
 }

--- a/packages/mcp/src/tools/verify.ts
+++ b/packages/mcp/src/tools/verify.ts
@@ -19,28 +19,16 @@ import { VERIFY_JSON_BEGIN, VERIFY_JSON_END, type VerifyResult, type VerifyContr
 
 const DESCRIPTION = `Run a self-checking testbench FILE against a circuit and report the result AT A DECLARED ORACLE TIER. simulate_circuit shows what a circuit does; verify_circuit tells you whether it's correct — a design isn't "done" until it passes at the highest feasible tier.
 
-There is no global pass/fail verdict, on purpose: you usually write both the circuit and the testbench, so a self-authored test inherits the implementation's blind spots. What matters is how INDEPENDENT the expected values are from the implementation. Declare that with the required \`oracle\` block — the gate refuses a passed result without it.
+You usually write both the circuit and its testbench, so what matters is how INDEPENDENT the expected values are from the implementation. The required \`oracle\` block declares that; the gate refuses a passed result without it. Don't weaken the oracle to pass — \`independence_basis\` makes that visible.
 
-ORACLE TIERS (highest → lowest independence):
-- A — External ground truth: expected outputs come from a source OTHER than this circuit (compiled programs with known results, captured real-world data, spec/RFC reference vectors, or an npm reference implementation — e.g. \`import { sha256 } from '@noble/hashes/sha2'\`). What makes it Tier A is the externality of the expected values, NOT the execution path.
-- B — Paradigm-diverse reference: a behavioral model written in a different style than the implementation (structural adder vs (a+b)&0xff; pipelined CPU vs a single-cycle reference). Standard golden-model differential testing.
-- C — Domain invariants: properties the spec implies regardless of implementation (commutativity, identity, monotonicity, bit-width bounds).
-- D — Property tests against your own understanding of the spec. Low independence.
-- E — Round-trip / smoke tests, no independent oracle. Lowest.
+ORACLE TIERS (highest → lowest independence) for the \`oracle.tier\` field:
+- A — external ground truth: expected values from a source OTHER than this circuit (npm reference impl, RFC/spec vectors, captured data, known program output).
+- B — paradigm-diverse reference model, written in a different style than the implementation (golden-model differential testing).
+- C — domain invariants the spec implies regardless of implementation (commutativity, identity, bounds).
+- D — property tests against your own understanding of the spec. Low independence.
+- E — round-trip / smoke; no independent oracle.
 
-WRITING THE TESTBENCH (a \`circuits/<name>.verify.ts\` file, run on the host via tsx):
-  import { simulate } from '@simten/core/sim';
-  import * as fc from 'fast-check';
-  import { verify, declareOracle } from '@simten/core/verify';
-  import { MyCircuit } from './my_circuit.circuit.js';   // import your DUT (it must be exported)
-  declareOracle({ tier: 'B', type: '...', independence_basis: '...' });
-  verify.check('name', fc.property(fc.nat(255), (x) => { const s = simulate(MyCircuit); try { ... } finally { s.dispose(); } }));
-  // or verify.exhaustive('name', [256], (x) => ...);   // full sweep, input space <= 2^20
-  verify.run();   // required — flushes the structured result
-
-- Real npm packages work as oracles (the host resolves them from node_modules).
-- The testbench imports its DUT; only what the circuit file EXPORTS is reachable.
-- It also runs under \`vitest\` (wrap as test('verify', () => verify.run())) — so verification drops into CI.
+To WRITE the testbench (the \`simulate()\` stepper API, \`verify.exhaustive\`/\`verify.check\`, \`declareOracle\`, worked examples), call the \`get_verify_api\` tool — it's kept there because this description is capped at 2KB by clients. The testbench is a \`circuits/<name>.verify.ts\` that imports its exported DUT and ends with \`verify.run()\`.
 
 Result carries a fixed caveat: TS simulation only; FPGA synthesis/timing not guaranteed.`;
 


### PR DESCRIPTION
## Problem

Follow-up to the instructions-truncation fix (#175). That PR fixed the **server `instructions`** field, but the 2 KB client cap ([Claude Code](https://code.claude.com/docs/en/mcp.md)) applies **per field — including each tool description**, and one was still over:

`verify_circuit`'s description was **2.54 KB**. The `simulate()` testbench API at the end (`s.set` / `s.tick` / `s.get` / `s.dispose`) sat at ~2065 bytes — just past the cut — so it was truncated mid-example. An agent writing a `.verify.ts` couldn't see the stepper API and fell back to digging through library source (confirmed live: an agent ran `find / -name @simten` to reconstruct it).

## Fix

Same pattern as #175 — move the reference out of the capped field into an on-demand tool (tool *results* aren't capped):

- **`get_verify_api`** — returns the full testbench reference: the `simulate()` handle (`set`/`tick`/`get`/`dispose`), `verify.exhaustive` vs `verify.check`, `declareOracle`, and the Tier-A npm-oracle pattern. Content is faithful to `docs/verifying-circuits.mdx` (the `simulate()` calls are lifted from a fixture, not guessed).
- **`verify_circuit`'s description** slimmed to **~1.6 KB** (oracle tiers + a pointer to `get_verify_api`).

Audited **all** tool descriptions: every one is now under 2 KB (largest non-`get_verify_api` is `run_on_fpga` at 0.57 KB).

## Testing

- `@simten/mcp`: **64 tests pass** (+1 `reference.test.ts` asserting `get_verify_api` registers and returns the `simulate()`/`verify.run()`/`declareOracle` API).
- `tsc -b` clean; description-size audit shows all tools < 2 KB.

## Not covered (separate gap)

The agent also hit a *behavioral*-semantics gap: `list_components` gives a component's **ports** but not its **temporal protocol** (e.g. `Eth_FrameParser`'s beat/`tkeep`/`tlast` handshake). That's a content gap a `describe_component` tool could address — out of scope here.

## Changeset

`@simten/mcp` minor — `.changeset/mcp-get-verify-api.md`.