### PR TITLE
fix(web): widen hero demo code panel so full-width comments stay legible

### DIFF
--- a/apps/web/src/features/splash/ClaudeDemoSection.tsx
+++ b/apps/web/src/features/splash/ClaudeDemoSection.tsx
@@ -924,7 +924,10 @@ const HeroBrowserWindow = forwardRef<
     return (
       <BrowserWindow className="flex-1" showMcp={codeTyping || showCircuit}>
         <div className="flex h-full">
-          <div className="w-[340px] shrink-0 border-r border-border overflow-auto">
+          {/* Widen on larger screens so full-width comments (~63 chars) stay
+              legible without horizontal clipping; the canvas (flex-1) absorbs
+              the difference where there's room. */}
+          <div className="w-[360px] lg:w-[440px] xl:w-[500px] shrink-0 border-r border-border overflow-auto">
             {codeTyping ? (
               <HighlightedCode
                 code={codeTw.displayed}


### PR DESCRIPTION
The hero "Claude typing a circuit" demo, once it expands to full width, showed its code in a fixed `w-[340px]` pane with `whitespace-pre` (no wrap). The figlet demo's ~60–63 char comment lines (`// Render ASCII-art at compile time with a real npm package,`) clipped off the right edge.

Made the pane responsive — `w-[360px] lg:w-[440px] xl:w-[500px]` — so comments stay legible on larger screens (xl ≈ 500px fits the 63-char comment) while the `flex-1` canvas absorbs the difference and smaller desktops aren't starved.

One-line change to `ClaudeDemoSection.tsx`. No changeset (apps/web is private/not published).