### PR TITLE
feat(web): surface open-source/Apache-2.0 in footer + hero strip

### DIFF
--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -49,7 +49,15 @@ export function SiteFooter() {
         </nav>
       </div>
       <div className="px-4 pb-6 pt-1 text-[11px] text-muted-foreground/60">
-        © {year} Simten
+        © {year} Simten · Open source, licensed under{' '}
+        <a
+          href="https://github.com/simtenHQ/simten/blob/main/LICENSE"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline-offset-2 transition-colors hover:text-foreground hover:underline"
+        >
+          Apache-2.0
+        </a>
       </div>
     </footer>
   )

--- a/apps/web/src/features/splash/ClaudeDemoSection.tsx
+++ b/apps/web/src/features/splash/ClaudeDemoSection.tsx
@@ -1178,6 +1178,15 @@ export function ClaudeDemoSection({
             <CopyCommand command="claude mcp add simten npx @simten/mcp" />
           </div>
           <div className="mt-5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[12px] text-muted-foreground">
+            <a
+              href="https://github.com/simtenHQ/simten"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-foreground"
+            >
+              Open source · Apache-2.0
+            </a>
+            <span className="text-muted-foreground/40">·</span>
             <span>Synthesizable Verilog</span>
             <span className="text-muted-foreground/40">·</span>
             <span>Runs on real FPGAs (ULX3S)</span>


### PR DESCRIPTION
Pre-launch polish for the Show HN / developer audience: make the open-source posture and license legible. No stars badge — the project is unknown pre-launch, and an empty count reads worse than none; add one post-launch.

- **Footer** copyright line → `© <year> Simten · Open source, licensed under Apache-2.0`, with "Apache-2.0" linking the `LICENSE` on GitHub. (The legal `NOTICE` holder — Charles Harris — is unchanged; the footer shows the brand, which is standard and has no legal downside.)
- **Hero credibility strip** → a leading `Open source · Apache-2.0` chip linking the repo, ahead of the existing Verilog / FPGA / cycle-accurate items.

Claims are strictly accurate — open source + the license only, no invented positioning (dropped a "self-hostable" claim that wasn't substantiated). Two small JSX edits; no changeset (apps/web is private).