### PR TITLE
chore(changesets): ignore private packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,13 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@simten/web",
+    "@simten/sandbox",
+    "@simten/compiler",
+    "@simten/verifier",
+    "@simten/synth",
+    "@simten/hardware-ulx3s",
+    "@simten/demos"
+  ]
 }

--- a/.changeset/hardware-integration-cleanup.md
+++ b/.changeset/hardware-integration-cleanup.md
@@ -1,5 +1,0 @@
----
-"@simten/hardware-ulx3s": patch
----
-
-Hardware integration cleanup: import `@simten/core` via its package aliases instead of deep `../../../../packages/core/src/...` paths; run the `fpga:*` scripts on a single runtime (tsx — replacing the bun-only `import.meta.dir`/`import.meta.main`); move the scripts into the package's own `package.json` with thin root delegators; and run the RV32I ISA suite plus the netlist byte-identity guard in CI so the FPGA path can't silently drift.


### PR DESCRIPTION
Adds all private (never-published) packages to the changesets `ignore` list, and removes the now-redundant `hardware-integration-cleanup` changeset.

**Why:** the Phase 2 changeset version-bumped `@simten/hardware-ulx3s` (private) and surfaced it in a "Version Packages" PR (#186) under generic "will be published to npm" text. Private packages never publish (`changeset publish` skips them), but they shouldn't be versioned or listed at all. Ignoring them keeps the only publishable set — `@simten/core`, `@simten/embed`, `@simten/mcp`, `@simten/ui` — and prevents the confusion recurring.

Ignored: `@simten/web`, `@simten/sandbox`, `@simten/compiler`, `@simten/verifier`, `@simten/synth`, `@simten/hardware-ulx3s`, `@simten/demos`.

`changeset status` → "NO packages to be bumped". Merging this closes the pending Version Packages PR (#186) automatically.

Internal changes to private packages simply won't carry changesets going forward — correct, since there's no npm consumer to notify.