### PR TITLE
fix(web): show_circuit editor is a sandbox view — file-watch no longer clobbers unsaved edits (#194)

### DIFF
--- a/apps/web/src/features/visual-editor/components/EditorWorkspace.tsx
+++ b/apps/web/src/features/visual-editor/components/EditorWorkspace.tsx
@@ -21,7 +21,7 @@ import type { Circuit } from "@simten/ui/editor/types";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { TSEditor, type TSEditorRef } from "@/features/code-editor/TSEditor";
-import { Download, Share2, Loader2 } from "lucide-react";
+import { Download, Share2, Loader2, RefreshCw } from "lucide-react";
 import { exportVerilog } from "@simten/core/verilog";
 import { SiteHeader } from "@/components/SiteHeader";
 import { encodeSourceForUrl, shouldUseShortLink } from "@simten/ui/share";
@@ -134,6 +134,16 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
 
   // Track whether we've loaded content so we can skip the first MCP cache replay
   const hasLoadedContentRef = useRef(false);
+
+  // The last source applied to the editor from the server (an explicit
+  // show_circuit push or a file-watcher update). Used to tell whether the user
+  // has unsaved sandbox edits, so a passive file-watch update doesn't clobber
+  // their experiments. See #194 — the editor is a sandbox VIEW of the file
+  // (which Claude edits from the terminal); the file is the source of truth.
+  const lastAppliedSourceRef = useRef<string | null>(null);
+  // A file-watch update deferred because the sandbox had unsaved edits — drives
+  // the non-destructive "Claude updated this — Reload?" prompt.
+  const [pendingFileUpdate, setPendingFileUpdate] = useState<string | null>(null);
 
   // Export to Verilog — uses library store
   const handleExportVerilog = useCallback(() => {
@@ -262,7 +272,23 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
       if (payload?.vcd) setWaveformData(payload);
     }, []),
     onSource: useCallback((source: string, requestId?: string) => {
+      // A `requestId` marks an explicit show_circuit push (intentional); no
+      // requestId means a passive file-watcher update. A passive update must
+      // not clobber unsaved sandbox experiments — defer it behind a Reload
+      // prompt. Explicit pushes always apply (the user/agent asked to re-show).
+      const isExplicit = !!requestId;
+      const current = editorRef.current?.getCode() ?? null;
+      const hasLocalEdits =
+        current != null &&
+        lastAppliedSourceRef.current != null &&
+        current !== lastAppliedSourceRef.current;
+      if (!isExplicit && hasLocalEdits) {
+        setPendingFileUpdate(source);
+        return;
+      }
       pendingRenderRef.current = requestId ?? null;
+      lastAppliedSourceRef.current = source;
+      setPendingFileUpdate(null);
       editorRef.current?.setCode(source);
       setTimeout(() => editorRef.current?.compile(), 100);
     }, []),
@@ -315,6 +341,16 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
       sendRenderResult(reqId, { ok: false, error: message });
     }
   }, [sendRenderResult]);
+
+  // Apply a deferred file-watch update — discards the sandbox experiments in
+  // favour of the file Claude changed (the user explicitly chose to reload).
+  const reloadFromFile = useCallback(() => {
+    if (pendingFileUpdate == null) return;
+    lastAppliedSourceRef.current = pendingFileUpdate;
+    editorRef.current?.setCode(pendingFileUpdate);
+    setTimeout(() => editorRef.current?.compile(), 100);
+    setPendingFileUpdate(null);
+  }, [pendingFileUpdate]);
 
   // Load an example into the editor
   const loadExample = useCallback((example: Example) => {
@@ -412,6 +448,30 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
                 <Download className="h-4 w-4" />
                 <span className="hidden sm:inline text-xs">Verilog</span>
               </Button>
+
+              {/* Deferred file-watch update — non-destructive reload prompt (#194) */}
+              {pendingFileUpdate != null && (
+                <Button
+                  onClick={reloadFromFile}
+                  variant="outline"
+                  size="sm"
+                  className="gap-2 border-amber-400 text-amber-600 dark:text-amber-400"
+                  title="Claude changed the circuit file on disk. Reload to discard your sandbox experiments and show the file's version."
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  <span className="hidden sm:inline text-xs">Claude updated — Reload</span>
+                </Button>
+              )}
+
+              {/* Sandbox indicator — when MCP-linked, the file is the source of truth */}
+              {mcpStatus === 'connected' && (
+                <span
+                  className="hidden md:inline text-[11px] leading-tight text-muted-foreground pl-2"
+                  title="This editor is a sandbox view. The file Claude edits (from the terminal) is the source of truth; edits here are local experiments — ask Claude to save them, or use Share."
+                >
+                  Sandbox · file is source of truth
+                </span>
+              )}
 
               {/* Studio Connection Status */}
               {mcpStatus === 'connected' && (


### PR DESCRIPTION
Fixes #194.

## Problem
With `show_circuit` open, the file watcher pushes on-disk changes straight into the Monaco editor (`onSource` → `setCode`), **unconditionally**. So when the file changed mid-session (Claude rewriting it, or a local IDE autosave) it **silently overwrote unsaved in-browser edits** and reverted the canvas.

## Fix (frontend-only, `@simten/web`)
Treat the editor as a **sandbox view of the file** — the file (which Claude edits) is the source of truth; in-browser edits are local experiments:
- **Distinguish push types** via the `requestId` the server already sends: explicit `show_circuit` pushes (have a `requestId`) apply as before; **passive file-watcher pushes (no `requestId`) no longer clobber** unsaved edits.
- When a passive update arrives **and the editor has unsaved edits** (current buffer ≠ last-applied source), it's **deferred** behind a non-destructive **"Claude updated — Reload"** prompt instead of overwriting. Clean editor → still live-syncs (the feature).
- Added a **"Sandbox · file is source of truth"** indicator when MCP-linked.

## Verified
- Typechecks clean (`tsc --noEmit`).
- Bundles (`build:viewer`) and the fix is present in the MCP-served editor.
- **Live-tested both paths:** clean editor → file change live-syncs; **dirty editor → edits preserved + Reload prompt appears**; non-compiling edits still hold last-good (compile gate, unchanged).

## Follow-ups (not in this PR)
- Move the prompt from the toolbar → an editor-top banner + add **Dismiss** (persistent).
- **Undo toast** for explicit pushes that overwrite local edits.
- Build-failed canvas overlay; gate-on-verified (`show_circuit` only paints verified circuits); block sharing unverified (#195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)