### PR TITLE
feat(mcp): show_circuit is the sole canvas trigger — remove file-watcher auto-push (#198)

### DIFF
--- a/.changeset/show-circuit-sole-canvas-trigger.md
+++ b/.changeset/show-circuit-sole-canvas-trigger.md
@@ -1,0 +1,5 @@
+---
+"@simten/mcp": minor
+---
+
+`show_circuit` no longer watches the file or auto-updates the canvas on edits. It is now the **sole** trigger for painting the browser canvas — re-call `show_circuit` to repaint after editing a circuit. This removes the file-watcher that caused unverified/intermediate states to appear on the canvas and clobbered unsaved in-browser edits.

--- a/apps/web/src/features/visual-editor/components/EditorWorkspace.tsx
+++ b/apps/web/src/features/visual-editor/components/EditorWorkspace.tsx
@@ -21,7 +21,7 @@ import type { Circuit } from "@simten/ui/editor/types";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { TSEditor, type TSEditorRef } from "@/features/code-editor/TSEditor";
-import { Download, Share2, Loader2, RefreshCw } from "lucide-react";
+import { Download, Share2, Loader2 } from "lucide-react";
 import { exportVerilog } from "@simten/core/verilog";
 import { SiteHeader } from "@/components/SiteHeader";
 import { encodeSourceForUrl, shouldUseShortLink } from "@simten/ui/share";
@@ -134,16 +134,6 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
 
   // Track whether we've loaded content so we can skip the first MCP cache replay
   const hasLoadedContentRef = useRef(false);
-
-  // The last source applied to the editor from the server (an explicit
-  // show_circuit push or a file-watcher update). Used to tell whether the user
-  // has unsaved sandbox edits, so a passive file-watch update doesn't clobber
-  // their experiments. See #194 — the editor is a sandbox VIEW of the file
-  // (which Claude edits from the terminal); the file is the source of truth.
-  const lastAppliedSourceRef = useRef<string | null>(null);
-  // A file-watch update deferred because the sandbox had unsaved edits — drives
-  // the non-destructive "Claude updated this — Reload?" prompt.
-  const [pendingFileUpdate, setPendingFileUpdate] = useState<string | null>(null);
 
   // Export to Verilog — uses library store
   const handleExportVerilog = useCallback(() => {
@@ -272,23 +262,7 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
       if (payload?.vcd) setWaveformData(payload);
     }, []),
     onSource: useCallback((source: string, requestId?: string) => {
-      // A `requestId` marks an explicit show_circuit push (intentional); no
-      // requestId means a passive file-watcher update. A passive update must
-      // not clobber unsaved sandbox experiments — defer it behind a Reload
-      // prompt. Explicit pushes always apply (the user/agent asked to re-show).
-      const isExplicit = !!requestId;
-      const current = editorRef.current?.getCode() ?? null;
-      const hasLocalEdits =
-        current != null &&
-        lastAppliedSourceRef.current != null &&
-        current !== lastAppliedSourceRef.current;
-      if (!isExplicit && hasLocalEdits) {
-        setPendingFileUpdate(source);
-        return;
-      }
       pendingRenderRef.current = requestId ?? null;
-      lastAppliedSourceRef.current = source;
-      setPendingFileUpdate(null);
       editorRef.current?.setCode(source);
       setTimeout(() => editorRef.current?.compile(), 100);
     }, []),
@@ -341,16 +315,6 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
       sendRenderResult(reqId, { ok: false, error: message });
     }
   }, [sendRenderResult]);
-
-  // Apply a deferred file-watch update — discards the sandbox experiments in
-  // favour of the file Claude changed (the user explicitly chose to reload).
-  const reloadFromFile = useCallback(() => {
-    if (pendingFileUpdate == null) return;
-    lastAppliedSourceRef.current = pendingFileUpdate;
-    editorRef.current?.setCode(pendingFileUpdate);
-    setTimeout(() => editorRef.current?.compile(), 100);
-    setPendingFileUpdate(null);
-  }, [pendingFileUpdate]);
 
   // Load an example into the editor
   const loadExample = useCallback((example: Example) => {
@@ -448,20 +412,6 @@ export function EditorWorkspace({ theme = "light", initialSource, standalone = f
                 <Download className="h-4 w-4" />
                 <span className="hidden sm:inline text-xs">Verilog</span>
               </Button>
-
-              {/* Deferred file-watch update — non-destructive reload prompt (#194) */}
-              {pendingFileUpdate != null && (
-                <Button
-                  onClick={reloadFromFile}
-                  variant="outline"
-                  size="sm"
-                  className="gap-2 border-amber-400 text-amber-600 dark:text-amber-400"
-                  title="Claude changed the circuit file on disk. Reload to discard your sandbox experiments and show the file's version."
-                >
-                  <RefreshCw className="h-4 w-4" />
-                  <span className="hidden sm:inline text-xs">Claude updated — Reload</span>
-                </Button>
-              )}
 
               {/* Sandbox indicator — when MCP-linked, the file is the source of truth */}
               {mcpStatus === 'connected' && (

--- a/packages/mcp/src/server/ws-server.ts
+++ b/packages/mcp/src/server/ws-server.ts
@@ -13,7 +13,6 @@
  */
 
 import { WebSocketServer, WebSocket } from 'ws';
-import { watchFile as fsWatchFile, unwatchFile, existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:http';
@@ -45,7 +44,6 @@ export interface StudioServer {
   updateSourceAndAwait(source: string, sessionId?: string, timeoutMs?: number): Promise<RenderResult>;
   /** Push source and await the render ack from a not-yet-connected tab (fresh open). */
   updateSourceAndAwaitConnect(source: string, timeoutMs?: number): Promise<RenderResult>;
-  watchFile(filePath: string): void;
   pushTraces(data: TracesPayload, sessionId?: string): void;
   pushTestResults(data: TestResultsPayload, sessionId?: string): void;
   pushMemoryData(data: MemoryDataPayload, sessionId?: string): void;
@@ -59,9 +57,6 @@ const STATE_REQUEST_TIMEOUT = 3000;
 /** Timeout for awaiting the first render after opening a fresh browser tab (ms).
  *  Generous: covers browser launch + page load + esm.sh fetch + compile. */
 const CONNECT_RENDER_TIMEOUT = 20000;
-
-/** Dedup window: ignore file watcher events within this many ms of an explicit push */
-const DEDUP_WINDOW_MS = 500;
 
 export async function createStudioServer(
   options?: {
@@ -83,8 +78,6 @@ export async function createStudioServer(
   let cachedTraces: TracesPayload | null = null;
   let cachedTestResults: TestResultsPayload | null = null;
   let cachedMemoryData: MemoryDataPayload | null = null;
-  let watchedPath: string | null = null;
-  let lastExplicitPushAt = 0;
 
   // Track the most recently active session for default targeting
   let lastActiveSessionId: string | null = null;
@@ -320,7 +313,6 @@ export async function createStudioServer(
 
   function updateSource(source: string, sessionId?: string) {
     currentSource = source;
-    lastExplicitPushAt = Date.now();
     broadcast({ type: 'source', source }, sessionId);
   }
 
@@ -337,7 +329,6 @@ export async function createStudioServer(
     timeoutMs: number = STATE_REQUEST_TIMEOUT,
   ): Promise<RenderResult> {
     currentSource = source;
-    lastExplicitPushAt = Date.now();
     const target = getTargetSession(sessionId);
     if (!target) return Promise.resolve({ ok: false, error: 'no browser tab connected' });
 
@@ -364,7 +355,6 @@ export async function createStudioServer(
     timeoutMs: number = CONNECT_RENDER_TIMEOUT,
   ): Promise<RenderResult> {
     currentSource = source;
-    lastExplicitPushAt = Date.now();
     const requestId = randomUUID();
     return new Promise((resolveReq) => {
       const timer = setTimeout(() => {
@@ -374,37 +364,6 @@ export async function createStudioServer(
       }, timeoutMs);
       pendingRequests.set(requestId, { resolve: resolveReq as (v: unknown) => void, timer });
       pendingConnectRender = requestId;
-    });
-  }
-
-  function watchFile(filePath: string) {
-    const absPath = resolve(filePath);
-
-    if (watchedPath === absPath) return;
-
-    if (watchedPath) {
-      unwatchFile(watchedPath);
-    }
-
-    watchedPath = absPath;
-
-    fsWatchFile(absPath, { interval: 200 }, (curr, prev) => {
-      if (curr.mtimeMs === prev.mtimeMs) return;
-
-      // Dedup: skip if we just did an explicit push
-      if (Date.now() - lastExplicitPushAt < DEDUP_WINDOW_MS) return;
-
-      if (curr.size === 0 && !existsSync(absPath)) {
-        broadcast({ type: 'file-deleted' });
-        return;
-      }
-
-      try {
-        const content = readFileSync(absPath, 'utf-8');
-        updateSource(content);
-      } catch {
-        broadcast({ type: 'error', message: `Failed to read ${absPath}` });
-      }
     });
   }
 
@@ -428,10 +387,6 @@ export async function createStudioServer(
   }
 
   function close() {
-    if (watchedPath) {
-      unwatchFile(watchedPath);
-      watchedPath = null;
-    }
     for (const pending of pendingRequests.values()) {
       clearTimeout(pending.timer);
     }
@@ -452,7 +407,6 @@ export async function createStudioServer(
     updateSource,
     updateSourceAndAwait,
     updateSourceAndAwaitConnect,
-    watchFile,
     pushTraces,
     pushTestResults,
     pushMemoryData,

--- a/packages/mcp/src/tools/show.ts
+++ b/packages/mcp/src/tools/show.ts
@@ -8,7 +8,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { exec } from 'node:child_process';
-import { resolve } from 'node:path';
 import { readCircuitSource } from '../lib/file-reader.js';
 import { SIMTEN_URL, LOCAL_SERVE } from '../lib/config.js';
 import {
@@ -51,13 +50,13 @@ export function registerShowTools(server: McpServer): void {
   // the preview (close:true) and discovering connected tabs (no source/filePath).
   server.tool(
     'show_circuit',
-    'Paint or update the live circuit canvas in the browser — the only tool that draws. Watches the file for changes when filePath is given. Call with NO source/filePath to list connected browser tabs (discovery). Pass close:true to close the preview and stop the server. Canvas policy: don\'t paint during tight iteration — paint at a verify tier-pass or for a specific result worth showing.',
+    'Paint or update the live circuit canvas in the browser — the only tool that draws. This is the ONLY thing that updates the canvas: editing the .circuit.ts file does NOT auto-update the browser, so re-call show_circuit (typically after a verify tier-pass) to repaint. Call with NO source/filePath to list connected browser tabs (discovery). Pass close:true to close the preview and stop the server. Canvas policy: don\'t paint during tight iteration — paint at a verify tier-pass or for a specific result worth showing.',
     {
       source: z.string().optional().describe('TypeScript circuit code as a string'),
       filePath: z
         .string()
         .optional()
-        .describe('Path to a .circuit.ts file (will be watched for changes)'),
+        .describe('Path to a .circuit.ts file (read once; not watched — re-call show_circuit to repaint)'),
       close: z
         .boolean()
         .optional()
@@ -139,10 +138,10 @@ export function registerShowTools(server: McpServer): void {
         };
       }
 
-      // 3. Pre-load memory + arm file watching before the push, so a freshly
-      // connecting tab receives them alongside its first render.
+      // 3. Pre-load memory before the push, so a freshly connecting tab
+      // receives it alongside its first render. (The file is read once for its
+      // source above — NOT watched; show_circuit is the sole canvas trigger.)
       if (memoryData) studio.pushMemoryData(memoryData, session);
-      if (filePath) studio.watchFile(resolve(filePath));
 
       // 4. Push the source and AWAIT the render acknowledgment.
       //   - Connected tab: await its render directly.
@@ -175,7 +174,6 @@ export function registerShowTools(server: McpServer): void {
       }
 
       // 5. Report, leading with the render acknowledgment.
-      const watchingNote = filePath ? ` Watching ${resolve(filePath)} for changes.` : '';
       const sessionNote = session ? ` (session: ${session})` : '';
       if (!render.ok && !render.timedOut) {
         // The browser reported a render failure (boolean ack). VIEWER-ONLY: do
@@ -189,13 +187,13 @@ export function registerShowTools(server: McpServer): void {
       if (!render.ok && render.timedOut) {
         // Never heard back (slow or no browser) — not necessarily an error.
         return {
-          content: [{ type: 'text' as const, text: `Circuit pushed; render not yet confirmed (${render.error ?? 'timed out'}). The tab may still be loading — check the browser.${watchingNote}${sessionNote}` }],
+          content: [{ type: 'text' as const, text: `Circuit pushed; render not yet confirmed (${render.error ?? 'timed out'}). The tab may still be loading — check the browser.${sessionNote}` }],
         };
       }
       return {
         // Name derived from the source the MCP pushed — NOT from the browser
         // (viewer-only: browser-reported names are untrusted).
-        content: [{ type: 'text' as const, text: `Circuit preview running. Rendered as "${circuitNameFromSource(read.source)}".${watchingNote}${sessionNote}` }],
+        content: [{ type: 'text' as const, text: `Circuit preview running. Rendered as "${circuitNameFromSource(read.source)}".${sessionNote}` }],
       };
     }
   );


### PR DESCRIPTION
Fixes #198.

## What
Remove the `show_circuit` file watcher. **`show_circuit` is now the sole trigger that updates the browser canvas/editor** — editing the `.circuit.ts` no longer auto-pushes to the browser.

## Why
Root-cause fix for two problems: the watcher auto-pushed **unverified/intermediate** file states onto the canvas, and it **clobbered unsaved in-browser edits**. Making `show_circuit` the only painter means the canvas only changes on a deliberate call (which the agent makes *after* verifying — per the tool's "paint at a verify tier-pass" guidance), so the canvas reflects verified circuits **by construction** — without the brittle "which circuit was verified" inference that the abandoned gate-on-verified approach required.

## Changes
- `packages/mcp/src/server/ws-server.ts` — remove the `fsWatchFile` watcher (and its dedup/`watchedPath` machinery). The reconnect-replay of the last *shown* source is kept (a reloaded tab still gets the last `show_circuit`).
- `packages/mcp/src/tools/show.ts` — stop arming the watcher; `filePath` is now read once (not watched); tool description updated to say `show_circuit` is the sole canvas trigger.
- `apps/web/.../EditorWorkspace.tsx` — remove the now-unreachable #194 file-watch clobber-guard (kept the "Sandbox · file is source of truth" indicator).

## Trade-off
Loses live-reload-on-file-save: editing the `.circuit.ts` directly won't update the canvas until `show_circuit` is re-called. Intended in the agent-driven model (the model drives updates).

## Verified
- MCP builds clean; **64/64 MCP tests pass** (incl. `viewer-only.test.ts`).
- Web typechecks clean; viewer + MCP editor bundle rebuilt.
- **Tested live in a fresh chat** — file edits no longer auto-update; `show_circuit` repaints as expected.

## Notes
- Changeset: `@simten/mcp` **minor** (behavior change). `@simten/web` is ignored → no changeset.
- `packages/mcp/src/server/preview-server.ts` is dead code (its `createPreviewServer` is never imported) and still has a parallel watcher — left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)