### PR TITLE
docs(mcp): clarify show_circuit is the sole canvas trigger + sandbox-view model

### DIFF
--- a/.changeset/mcp-docs-sole-canvas-trigger.md
+++ b/.changeset/mcp-docs-sole-canvas-trigger.md
@@ -1,0 +1,5 @@
+---
+"@simten/mcp": patch
+---
+
+Docs: clarify that `show_circuit` is the sole canvas trigger (editing the circuit file no longer auto-updates the browser — re-call `show_circuit` to repaint) and that the web editor is a sandbox view of the file (the file is the source of truth; in-browser edits are local experiments). Updates the server instructions + README and removes a stale file-watching note. No functional change.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -62,6 +62,8 @@ The server listens on `127.0.0.1:19847` for the browser WebSocket bridge. The po
 
 Multiple browser tabs can connect simultaneously. State is cached for late-joining clients.
 
+**`show_circuit` is the sole canvas trigger.** Editing the `.circuit.ts` does *not* auto-update the browser — re-call `show_circuit` to repaint. The web editor mirrors the file as a **sandbox view**: the file you (or Claude) edit is the source of truth; edits made directly in the browser editor are local experiments, not written back to the file.
+
 ## Example session
 
 ```

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -47,7 +47,7 @@ This server's instructions are truncated by clients at ~2KB, so the full referen
 Write each circuit as a standalone TS module: \`import { circuit, bit, bus } from '@simten/core/circuit'\`, stdlib from \`@simten/core/std\`, and **\`export\`** the top-level circuit so a testbench can import it. Don't write import-free code.
 
 ## Canvas & trust
-\`show_circuit\` is the only tool that paints; the canvas is a one-way **viewer** (it displays/simulates what you push and sends nothing back). Don't paint during tight iteration — paint at a verify pass. \`verify_circuit\` runs the testbench on the host via \`tsx\` (full node/npm, your trust level — like \`npm test\`); open unfamiliar or shared circuits in the sandboxed web \`/circuit\` editor, not locally.
+\`show_circuit\` is the only tool that paints; the canvas is a one-way **viewer** (it displays/simulates what you push and sends nothing back). \`show_circuit\` is also the ONLY thing that updates the canvas — editing the \`.circuit.ts\` does NOT auto-update the browser; re-call \`show_circuit\` to repaint (at a verify pass, not during tight iteration). The web editor is a sandbox **view** of the file: the file you edit is the source of truth; in-browser edits are local experiments. \`verify_circuit\` runs the testbench on the host via \`tsx\` (full node/npm, your trust level — like \`npm test\`); open unfamiliar or shared circuits in the sandboxed web \`/circuit\` editor, not locally.
 `;
 
 const server = new McpServer(

--- a/packages/mcp/src/server/ws-server.ts
+++ b/packages/mcp/src/server/ws-server.ts
@@ -5,7 +5,6 @@
  * - Manages sessions (one per browser tab, identified by UUID)
  * - Pushes circuit source, traces, test results, memory data to connected tabs
  * - Requests circuit state on demand (pull model)
- * - File watching with dedup (skips watcher events within 500ms of explicit push)
  * - Token auth: connections must provide the server's token to be accepted
  * - Origin allowlist: browser connections must originate from localhost (a
  *   cross-site page you visit is refused); non-browser clients (no Origin) pass


### PR DESCRIPTION
Documents the intricacies introduced by #198 so users/agents don't trip on them (expecting live-reload, or thinking in-browser edits are authoritative).

- **Server `instructions`** (`src/index.ts`, "Canvas & trust"): `show_circuit` is the only thing that updates the canvas — editing the `.circuit.ts` does NOT auto-update; re-call `show_circuit` to repaint. The web editor is a **sandbox view** of the file (file = source of truth; in-browser edits are local experiments).
- **README "How it works"**: same, in plain terms for humans.
- **`ws-server.ts` header comment**: removed the now-stale "File watching with dedup" bullet (the watcher was removed in #198).

`@simten/mcp` **patch** changeset (the shipped `instructions` string changed). No functional change. MCP builds clean; instructions render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)