### PR TITLE
feat(mcp): setup_project — zero-friction first run for verify_circuit

### DIFF
--- a/.changeset/mcp-setup-project.md
+++ b/.changeset/mcp-setup-project.md
@@ -1,0 +1,5 @@
+---
+"@simten/mcp": minor
+---
+
+Add `setup_project` so a new/empty folder is one call away from running `verify_circuit`. Designing and simulating already need no setup; verify runs the testbench on the host via `tsx` and resolves `@simten/core` + `fast-check` from the project, so an empty folder previously failed with a cryptic module-not-found that led to a manual `npm init` / `type: module` dance. `setup_project` does it proactively: writes an ESM `package.json` (never clobbering an explicit CommonJS one — falls back to `.mts` there), a NodeNext `tsconfig` for editor IntelliSense, a `circuits/` dir, and installs the deps with the detected package manager. `verify_circuit` now preflights and returns a `setup_required` signal pointing at it instead of failing obscurely.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -25,7 +25,7 @@ claude mcp add --scope user simten npx @simten/mcp
 
 That's it. `--scope user` makes simten available across every project; drop the flag for a project-local install. Verify with `claude mcp list`.
 
-`verify_circuit`'s testbench runs in your project's `node_modules` context, so the project needs `@simten/core` and `fast-check` installed (the tool tells you the exact command if you forget).
+Designing and simulating need nothing else. `verify_circuit` runs the testbench on the host via `tsx`, so it needs `@simten/core` + `fast-check` + `tsx` installed in the project — Claude runs `setup_project` automatically on first use to write a `package.json` and install them (or run it yourself; it's idempotent). Existing projects with those deps already work as-is.
 
 (If you prefer global installs over `npx`: `npm install -g @simten/mcp`, then `claude mcp add --scope user simten simten-mcp`.)
 
@@ -37,6 +37,7 @@ The server listens on `127.0.0.1:19847` for the browser WebSocket bridge. The po
 
 | Tool | Description |
 |------|-------------|
+| `setup_project` | Make an empty/new folder ready for `verify_circuit`: write an ESM `package.json` + tsconfig, install `@simten/core`/`fast-check`/`tsx`. Idempotent |
 | `check_circuit` | Validate circuit well-formedness (syntax, semantic, type, structural) |
 | `simulate_circuit` | Compile and simulate, return signal traces (observation only; does not establish correctness) |
 | `verify_circuit` | Run a self-checking testbench *file* (`.verify.ts`) on the host via `tsx`; reports pass/fail + counterexample at a declared oracle tier |

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -19,6 +19,7 @@ import pkg from '../package.json' with { type: 'json' };
 import { registerCheckTool } from './tools/check.js';
 import { registerSimulateTool } from './tools/simulate.js';
 import { registerVerifyTool } from './tools/verify.js';
+import { registerSetupTool } from './tools/setup.js';
 import { registerShowTools } from './tools/show.js';
 import { registerRunOnFpgaTool } from './tools/run_on_fpga.js';
 import { registerReadWaveformTool } from './tools/read_waveform.js';
@@ -33,6 +34,9 @@ import { getOrCreateServer, getPreviewServer } from './lib/preview-singleton.js'
 // capped). Keep critical guidance (the verify contract, the reference pointer)
 // near the top so it survives truncation.
 const instructions = `You help developers design, simulate, and verify hardware from TypeScript. Circuits are files the host edits (write to \`circuits/<name>.circuit.ts\` unless told otherwise); the simten tools check, simulate, verify, and visualize them.
+
+## New or empty folder? Set it up first
+\`check_circuit\` and \`simulate_circuit\` need no setup. \`verify_circuit\` does — it runs on the host via \`tsx\` and resolves \`@simten/core\` + \`fast-check\` from the project. In a new/empty folder, call \`setup_project\` once (writes \`package.json\`, installs the deps); it reports the file extension to use (\`.ts\`, or \`.mts\` for an existing CommonJS project). \`verify_circuit\` will tell you to run it if you forget.
 
 ## Reference (call these — don't guess)
 This server's instructions are truncated by clients at ~2KB, so the full reference lives in tools:
@@ -64,6 +68,7 @@ const server = new McpServer(
 registerCheckTool(server);
 registerSimulateTool(server);
 registerVerifyTool(server);
+registerSetupTool(server);
 registerShowTools(server);
 registerRunOnFpgaTool(server);
 registerReadWaveformTool(server);

--- a/packages/mcp/src/lib/project-setup.test.ts
+++ b/packages/mcp/src/lib/project-setup.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import {
+  detectPackageManager,
+  ensurePackageJson,
+  ensureTsconfig,
+  isProjectReady,
+  installCommand,
+} from './project-setup.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'simten-setup-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const readPkg = () => JSON.parse(readFileSync(resolve(dir, 'package.json'), 'utf-8'));
+
+describe('ensurePackageJson — extension policy', () => {
+  it('empty folder → creates type:module package.json, uses .ts', () => {
+    const plan = ensurePackageJson(dir);
+    expect(plan).toMatchObject({ action: 'created', ext: '.ts' });
+    expect(readPkg().type).toBe('module');
+    expect(readPkg().private).toBe(true);
+  });
+
+  it('existing package.json with NO type → adds type:module, uses .ts', () => {
+    writeFileSync(resolve(dir, 'package.json'), JSON.stringify({ name: 'x' }));
+    const plan = ensurePackageJson(dir);
+    expect(plan).toMatchObject({ action: 'patched', ext: '.ts' });
+    expect(readPkg().type).toBe('module');
+  });
+
+  it('existing type:module → unchanged, uses .ts', () => {
+    writeFileSync(resolve(dir, 'package.json'), JSON.stringify({ name: 'x', type: 'module' }));
+    const plan = ensurePackageJson(dir);
+    expect(plan).toMatchObject({ action: 'unchanged', ext: '.ts' });
+  });
+
+  it('explicit type:commonjs → NEVER clobbered, falls back to .mts', () => {
+    writeFileSync(resolve(dir, 'package.json'), JSON.stringify({ name: 'x', type: 'commonjs' }));
+    const plan = ensurePackageJson(dir);
+    expect(plan).toMatchObject({ action: 'unchanged', ext: '.mts' });
+    expect(readPkg().type).toBe('commonjs'); // untouched
+    expect(plan.note).toMatch(/commonjs/i);
+  });
+
+  it('unparseable package.json → untouched, .mts', () => {
+    writeFileSync(resolve(dir, 'package.json'), '{ not json');
+    const plan = ensurePackageJson(dir);
+    expect(plan).toMatchObject({ action: 'unchanged', ext: '.mts' });
+  });
+});
+
+describe('detectPackageManager', () => {
+  it('defaults to npm with no lockfile', () => {
+    expect(detectPackageManager(dir)).toBe('npm');
+  });
+  it.each([
+    ['pnpm-lock.yaml', 'pnpm'],
+    ['yarn.lock', 'yarn'],
+    ['bun.lockb', 'bun'],
+    ['package-lock.json', 'npm'],
+  ])('detects %s → %s', (lockfile, pm) => {
+    writeFileSync(resolve(dir, lockfile), '');
+    expect(detectPackageManager(dir)).toBe(pm);
+  });
+});
+
+describe('isProjectReady', () => {
+  it('false when framework deps are absent', () => {
+    expect(isProjectReady(dir)).toBe(false);
+  });
+  it('true when both @simten/core and fast-check resolve', () => {
+    mkdirSync(resolve(dir, 'node_modules', '@simten', 'core'), { recursive: true });
+    mkdirSync(resolve(dir, 'node_modules', 'fast-check'), { recursive: true });
+    expect(isProjectReady(dir)).toBe(true);
+  });
+  it('false when only one is present', () => {
+    mkdirSync(resolve(dir, 'node_modules', '@simten', 'core'), { recursive: true });
+    expect(isProjectReady(dir)).toBe(false);
+  });
+});
+
+describe('ensureTsconfig', () => {
+  it('writes a NodeNext tsconfig when absent, no-ops when present', () => {
+    expect(ensureTsconfig(dir)).toBe(true);
+    expect(JSON.parse(readFileSync(resolve(dir, 'tsconfig.json'), 'utf-8')).compilerOptions.moduleResolution).toBe('NodeNext');
+    expect(ensureTsconfig(dir)).toBe(false);
+  });
+});
+
+describe('installCommand', () => {
+  it('npm uses install, others use add; bun uses -d', () => {
+    expect(installCommand('npm')).toContain('npm install @simten/core fast-check');
+    expect(installCommand('npm')).toContain('npm install -D tsx typescript');
+    expect(installCommand('pnpm')).toContain('pnpm add @simten/core fast-check');
+    expect(installCommand('pnpm')).toContain('pnpm add -D tsx typescript');
+    expect(installCommand('bun')).toContain('bun add -d tsx typescript');
+  });
+});

--- a/packages/mcp/src/lib/project-setup.ts
+++ b/packages/mcp/src/lib/project-setup.ts
@@ -1,0 +1,185 @@
+/**
+ * Project setup helpers for `setup_project`.
+ *
+ * The MCP's design/simulate tools run in-process against the bundled
+ * `@simten/core` and need nothing on disk. `verify_circuit`, by contrast,
+ * shells out to `tsx` and resolves the testbench's imports from the USER's
+ * folder — so a brand-new/empty folder needs `@simten/core` + `fast-check` +
+ * `tsx` installed and an ESM `package.json` before verify can run.
+ *
+ * Rather than make the user discover that through a chain of cryptic errors
+ * (the original first-run friction: failed verify → `npm init` → missing
+ * `type: module` → retry), `setup_project` does it once, proactively: write a
+ * correct `package.json`, install the deps, and report back. Standard Node
+ * resolution from there on — no loader hooks, no format trickery.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/** Which testbench/circuit extension a project must use to load as ESM. */
+export type CircuitExt = '.ts' | '.mts';
+
+/** Detect the package manager from a lockfile; default npm (ships with Node). */
+export function detectPackageManager(root: string): PackageManager {
+  if (existsSync(resolve(root, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(resolve(root, 'yarn.lock'))) return 'yarn';
+  if (existsSync(resolve(root, 'bun.lockb'))) return 'bun';
+  // package-lock.json or nothing → npm
+  return 'npm';
+}
+
+/** The framework deps verify needs resolvable from the user's project. */
+export const RUNTIME_DEPS = ['@simten/core', 'fast-check'] as const;
+export const DEV_DEPS = ['tsx', 'typescript'] as const;
+
+/** `verify` is runnable here iff the framework deps resolve from the project. */
+export function isProjectReady(root: string): boolean {
+  return existsSync(resolve(root, 'node_modules', '@simten', 'core')) &&
+    existsSync(resolve(root, 'node_modules', 'fast-check'));
+}
+
+/** The exact manual install command, for docs / offline fallback. */
+export function installCommand(pm: PackageManager): string {
+  const add = pm === 'npm' ? 'install' : 'add';
+  const dev = pm === 'bun' ? '-d' : '-D';
+  return `${pm} ${add} ${RUNTIME_DEPS.join(' ')} && ${pm} ${add} ${dev} ${DEV_DEPS.join(' ')}`;
+}
+
+export interface PackageJsonPlan {
+  /** 'created' (none existed), 'patched' (added type:module), 'unchanged'. */
+  action: 'created' | 'patched' | 'unchanged';
+  /** Extension circuit/verify files must use so they load as ESM. */
+  ext: CircuitExt;
+  /** Human note for the result, e.g. the commonjs escape-hatch explanation. */
+  note?: string;
+}
+
+/**
+ * Ensure `package.json` declares ESM, without ever clobbering an explicit
+ * CommonJS project. Returns the plan + the extension circuits must use:
+ *  - absent / no `type`  → make it `type: module`, use `.ts`
+ *  - `type: module`      → leave it, use `.ts`
+ *  - `type: commonjs`    → leave it, use `.mts` (ESM by extension, since every
+ *                          file importing the ESM-only @simten/core must be ESM)
+ */
+export function ensurePackageJson(root: string): PackageJsonPlan {
+  const pkgPath = resolve(root, 'package.json');
+
+  if (!existsSync(pkgPath)) {
+    const pkg = {
+      name: sanitizeName(basename(root)),
+      private: true,
+      type: 'module',
+    };
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    return { action: 'created', ext: '.ts' };
+  }
+
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    // Unparseable package.json — don't touch it; fall back to .mts so files are
+    // ESM regardless of whatever's in there.
+    return {
+      action: 'unchanged',
+      ext: '.mts',
+      note: 'package.json could not be parsed; using .mts so testbenches load as ESM regardless.',
+    };
+  }
+
+  if (pkg.type === 'commonjs') {
+    return {
+      action: 'unchanged',
+      ext: '.mts',
+      note: 'package.json is type:commonjs — leaving it untouched. Every file importing @simten/core (circuits and testbenches) must use the .mts extension so it loads as ESM.',
+    };
+  }
+
+  if (pkg.type === 'module') {
+    return { action: 'unchanged', ext: '.ts' };
+  }
+
+  // No type field → add it (safe for a fresh circuit project).
+  pkg.type = 'module';
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  return {
+    action: 'patched',
+    ext: '.ts',
+    note: 'Added "type": "module" to your existing package.json so .ts files load as ESM.',
+  };
+}
+
+const TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2022',
+    module: 'NodeNext',
+    moduleResolution: 'NodeNext',
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  },
+} as const;
+
+/** Write a minimal NodeNext tsconfig for editor IntelliSense, if absent. */
+export function ensureTsconfig(root: string): boolean {
+  const p = resolve(root, 'tsconfig.json');
+  if (existsSync(p)) return false;
+  writeFileSync(p, JSON.stringify(TSCONFIG, null, 2) + '\n');
+  return true;
+}
+
+export interface InstallResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+/** Run a package-manager install of the given deps. */
+export function runInstall(
+  root: string,
+  pm: PackageManager,
+  deps: readonly string[],
+  opts: { dev?: boolean; timeoutMs?: number } = {},
+): Promise<InstallResult> {
+  const add = pm === 'npm' ? 'install' : 'add';
+  const flag = opts.dev ? [pm === 'bun' ? '-d' : '-D'] : [];
+  const args = [add, ...flag, ...deps];
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+
+  return new Promise((res) => {
+    // shell:true so the pm resolves cross-platform (npm → npm.cmd on Windows).
+    // Args are fixed package names, not user input.
+    const proc = spawn(pm, args, { cwd: root, shell: true });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill('SIGKILL');
+    }, timeoutMs);
+
+    proc.stdout?.on('data', (c: Buffer) => (stdout += c.toString('utf8')));
+    proc.stderr?.on('data', (c: Buffer) => (stderr += c.toString('utf8')));
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      res({ ok: code === 0 && !timedOut, stdout, stderr, exitCode: code ?? -1, timedOut });
+    });
+    proc.on('error', (e) => {
+      clearTimeout(timer);
+      res({ ok: false, stdout, stderr: stderr + String(e), exitCode: -1, timedOut });
+    });
+  });
+}
+
+/** npm package names must be lowercase and url-safe; fall back to a default. */
+function sanitizeName(raw: string): string {
+  const name = raw.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^[-_.]+|[-_.]+$/g, '');
+  return name || 'simten-circuits';
+}

--- a/packages/mcp/src/tools/setup.test.ts
+++ b/packages/mcp/src/tools/setup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerSetupTool } from './setup.js';
+import { registerVerifyTool } from './verify.js';
+
+type Handler = (args: Record<string, unknown>) => Promise<{ content: { text: string }[]; isError?: boolean }>;
+
+function capture(register: (s: never) => void): Map<string, Handler> {
+  const tools = new Map<string, Handler>();
+  const server = { tool: (name: string, _d: string, _s: unknown, h: Handler) => tools.set(name, h) };
+  register(server as never);
+  return tools;
+}
+
+describe('setup_project registration', () => {
+  it('registers the setup_project tool', () => {
+    expect([...capture(registerSetupTool).keys()]).toEqual(['setup_project']);
+  });
+});
+
+describe('verify_circuit preflight', () => {
+  let dir: string;
+  let prevCwd: string;
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), 'simten-verify-'));
+    process.chdir(dir);
+  });
+  afterEach(() => {
+    process.chdir(prevCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns setup_required (without running tsx) when the folder has no framework deps', async () => {
+    const verify = capture(registerVerifyTool).get('verify_circuit')!;
+    const res = await verify({
+      testbench: 'whatever.verify.ts',
+      oracle: { tier: 'C', type: 't', independence_basis: 'b' },
+    });
+    expect(res.isError).toBe(true);
+    const json = JSON.parse(res.content[0].text);
+    expect(json.status).toBe('setup_required');
+    expect(json.manual).toContain('@simten/core');
+  });
+});

--- a/packages/mcp/src/tools/setup.ts
+++ b/packages/mcp/src/tools/setup.ts
@@ -1,0 +1,110 @@
+/**
+ * setup_project — make a folder ready for `verify_circuit`.
+ *
+ * `check_circuit` and `simulate_circuit` run in-process against the bundled
+ * `@simten/core` and need no setup. `verify_circuit` shells out to `tsx` and
+ * resolves the testbench's imports from the project, so an empty folder needs:
+ * an ESM `package.json`, plus `@simten/core` + `fast-check` + `tsx` installed.
+ *
+ * This tool does that once, proactively — the alternative is the user
+ * discovering each requirement through a failed-verify error chain.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { existsSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  detectPackageManager,
+  ensurePackageJson,
+  ensureTsconfig,
+  runInstall,
+  isProjectReady,
+  installCommand,
+  RUNTIME_DEPS,
+  DEV_DEPS,
+  type PackageManager,
+} from '../lib/project-setup.js';
+
+const DESCRIPTION = `Make the current folder ready to RUN verify_circuit. check_circuit and simulate_circuit need no setup; verify_circuit does, because it runs the testbench on the host via tsx and resolves @simten/core + fast-check from this project.
+
+Call this once when starting in a new/empty folder (or whenever verify_circuit reports "setup_required"). It is idempotent — safe to re-run. It writes an ESM package.json (never clobbering an explicit CommonJS one), a minimal tsconfig for editor IntelliSense, a circuits/ dir, and installs @simten/core, fast-check, and tsx with your package manager.
+
+The result reports the extension to use for circuit/testbench files: ".ts" normally, ".mts" only if you already have a type:commonjs package.json.`;
+
+export function registerSetupTool(server: McpServer): void {
+  server.tool(
+    'setup_project',
+    DESCRIPTION,
+    {
+      dir: z.string().optional().describe('Project root to set up (default: the MCP working directory)'),
+      packageManager: z.enum(['npm', 'pnpm', 'yarn', 'bun']).optional()
+        .describe('Override the package manager (default: detect from lockfile, else npm)'),
+    },
+    async ({ dir, packageManager }) => {
+      const root = dir ? resolve(dir) : process.cwd();
+      const pm: PackageManager = packageManager ?? detectPackageManager(root);
+
+      const steps: string[] = [];
+
+      // 1. package.json (decides the file extension; never clobbers commonjs).
+      const pkgPlan = ensurePackageJson(root);
+      steps.push(`package.json: ${pkgPlan.action}${pkgPlan.note ? ` — ${pkgPlan.note}` : ''}`);
+
+      // 2. tsconfig for editor IntelliSense.
+      steps.push(`tsconfig.json: ${ensureTsconfig(root) ? 'created' : 'unchanged'}`);
+
+      // 3. circuits/ dir.
+      const circuitsDir = resolve(root, 'circuits');
+      if (!existsSync(circuitsDir)) {
+        mkdirSync(circuitsDir, { recursive: true });
+        steps.push('circuits/: created');
+      } else {
+        steps.push('circuits/: unchanged');
+      }
+
+      // 4. Install — skip if already resolvable.
+      let installNote: string;
+      if (isProjectReady(root)) {
+        installNote = 'dependencies already installed; skipped';
+      } else {
+        const prod = await runInstall(root, pm, RUNTIME_DEPS, { dev: false });
+        const dev = prod.ok ? await runInstall(root, pm, DEV_DEPS, { dev: true }) : null;
+        if (prod.ok && dev?.ok && isProjectReady(root)) {
+          installNote = `installed ${[...RUNTIME_DEPS, ...DEV_DEPS].join(', ')} with ${pm}`;
+        } else {
+          // Offline / install failure: report the manual command as fallback.
+          const failed = !prod.ok ? prod : dev;
+          return errorResult(
+            `Project files are set up, but the install failed (${pm}). Run this manually in ${root}, then retry verify_circuit:\n  ${installCommand(pm)}`,
+            { steps, stderr_tail: (failed?.stderr ?? '').slice(-1500) },
+          );
+        }
+      }
+      steps.push(`install: ${installNote}`);
+
+      const ready = isProjectReady(root);
+      const summary = {
+        ready,
+        root,
+        packageManager: pm,
+        circuitExtension: pkgPlan.ext,
+        steps,
+        next: ready
+          ? `Ready. Write circuits as circuits/<name>.circuit${pkgPlan.ext} and testbenches as circuits/<name>.verify${pkgPlan.ext}, then verify_circuit.`
+          : 'Not ready — see steps; install may have partially failed.',
+      };
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }],
+        isError: !ready,
+      };
+    },
+  );
+}
+
+function errorResult(error: string, extra?: Record<string, unknown>) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error, ...extra }, null, 2) }],
+    isError: true,
+  };
+}

--- a/packages/mcp/src/tools/verify.ts
+++ b/packages/mcp/src/tools/verify.ts
@@ -14,7 +14,8 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { runTsx, extractDelimitedJson } from '../lib/host-run.js';
+import { runTsx, findRepoRoot, extractDelimitedJson } from '../lib/host-run.js';
+import { isProjectReady, detectPackageManager, installCommand } from '../lib/project-setup.js';
 import { VERIFY_JSON_BEGIN, VERIFY_JSON_END, type VerifyResult, type VerifyContractError } from '@simten/core/verify';
 
 const DESCRIPTION = `Run a self-checking testbench FILE against a circuit and report the result AT A DECLARED ORACLE TIER. simulate_circuit shows what a circuit does; verify_circuit tells you whether it's correct — a design isn't "done" until it passes at the highest feasible tier.
@@ -49,6 +50,19 @@ export function registerVerifyTool(server: McpServer): void {
       timeoutMs: z.number().int().min(1).optional().describe('Wall-clock budget in ms (default 30000); the subprocess is killed past it'),
     },
     async ({ testbench, oracle, timeoutMs }) => {
+      // Preflight: verify runs the testbench via tsx and resolves @simten/core +
+      // fast-check from the PROJECT. In an unconfigured folder that fails with a
+      // cryptic module-not-found; instead, detect it up front and point the agent
+      // at setup_project (which writes package.json and installs the deps).
+      const root = findRepoRoot();
+      if (!isProjectReady(root)) {
+        const pm = detectPackageManager(root);
+        return errorResult(
+          "This folder isn't set up for verify yet. Call setup_project (writes package.json, installs @simten/core + fast-check + tsx), then retry.",
+          { status: 'setup_required', root, manual: installCommand(pm) },
+        );
+      }
+
       const run = await runTsx(testbench, {
         env: { SIMTEN_VERIFY_ORACLE: JSON.stringify(oracle) },
         timeoutMs: timeoutMs ?? 30_000,
@@ -64,14 +78,12 @@ export function registerVerifyTool(server: McpServer): void {
       const parsed = extractDelimitedJson<VerifyResult | VerifyContractError>(run.stdout, VERIFY_JSON_BEGIN, VERIFY_JSON_END);
       if (!parsed) {
         // Nonzero exit with no JSON block = crash/compile error in the testbench.
-        // The single most common cause for first-time users is missing deps in
-        // the project — the MCP bundles @simten/core + fast-check for its own
-        // use but Node only walks up from the testbench file. If stderr shows
-        // a module-resolution error, suggest the install. Cheap hint, no
-        // detection plumbing.
+        // The framework deps are guaranteed present (preflight), so a module-not-
+        // found here means an EXTERNAL package the testbench imports — typically a
+        // Tier-A oracle (e.g. @noble/hashes). Point at installing that, not core.
         const looksLikeMissingDeps = /Cannot find (module|package)|ERR_MODULE_NOT_FOUND/.test(run.stderr);
         const hint = looksLikeMissingDeps
-          ? ' Looks like a missing dep — try `pnpm add -D @simten/core fast-check` (or npm/yarn/bun equivalent) in this project.'
+          ? ' Looks like a missing dep — if the testbench imports an external oracle package (e.g. @noble/hashes), install it in this project (npm install <pkg>).'
           : '';
         return errorResult(
           `Testbench produced no verify result (exit ${run.exitCode}). Likely a crash or compile error.${hint}`,


### PR DESCRIPTION
## Problem

Loading `@simten/mcp` into a new/empty folder, `verify_circuit` failed cryptically. Designing and simulating work zero-config (they run in-process against the bundled `@simten/core`), but verify shells out to `tsx` and resolves `@simten/core` + `fast-check` from the **project** — so an empty folder hit a module-not-found that led to a manual `npm init` / `type: module` dance. Bad first impression.

## Fix

A `setup_project` tool that does it proactively, once:
- Writes an ESM `package.json` — never clobbering an explicit `type: commonjs` project (falls back to `.mts` there so files still load as ESM).
- Writes a NodeNext `tsconfig` for editor IntelliSense, and a `circuits/` dir.
- Installs `@simten/core` + `fast-check` + `tsx` with the detected package manager (lockfile → else npm).
- Idempotent; offline/failure falls back to printing the exact manual command.

`verify_circuit` now **preflights** (`isProjectReady`) and returns a structured `setup_required` signal pointing at `setup_project`, instead of failing obscurely. The server instructions tell the agent to call it on a new folder, so the signal is rarely hit.

### Why not the zero-install loader-hook approach
Spiked it (bundle tsx+fast-check, redirect `@simten/core`/`fast-check` resolution to the bundle). It ran green from a depless folder, but only fixes *running* — the editor's TS server still can't resolve `@simten/core` without `node_modules`, so authoring shows red squiggles. It also needed fragile `format:'module'` forcing + fighting Node 22.18+/23 native type-stripping. Since a real install is needed for IntelliSense anyway, auto-install wins on robustness, editor, and simplicity.

## Tests
- 17 new (`project-setup.test.ts`, `setup.test.ts`); 81/81 pass; `tsc -b` clean.
- Real end-to-end against the **published** `@simten/core`: `setup_required` → `setup_project` (real `npm install`) → `testbench_passed: true`.