### PR TITLE
feat: MDX blog collection + first post

### DIFF
--- a/apps/web/.source/browser.ts
+++ b/apps/web/.source/browser.ts
@@ -8,6 +8,13 @@ const create = browser<typeof Config, import("fumadocs-mdx/runtime/types").Inter
   }
 }>();
 const browserCollections = {
+  blog: create.doc("blog", import.meta.glob(["./**/*.{mdx,md}"], {
+    "base": "./../content/blog",
+    "query": {
+      "collection": "blog"
+    },
+    "eager": false
+  })),
   docs: create.doc("docs", import.meta.glob(["./**/*.{mdx,md}"], {
     "base": "./../content/docs",
     "query": {

--- a/apps/web/.source/server.ts
+++ b/apps/web/.source/server.ts
@@ -8,6 +8,21 @@ const create = server<typeof Config, import("fumadocs-mdx/runtime/types").Intern
   }
 }>({"doc":{"passthroughs":["extractedReferences"]}});
 
+export const blog = await create.docs("blog", "content/blog", import.meta.glob(["./**/*.{json,yaml}"], {
+  "base": "./../content/blog",
+  "query": {
+    "collection": "blog"
+  },
+  "import": "default",
+  "eager": true
+}), import.meta.glob(["./**/*.{mdx,md}"], {
+  "base": "./../content/blog",
+  "query": {
+    "collection": "blog"
+  },
+  "eager": true
+}));
+
 export const docs = await create.docs("docs", "content/docs", import.meta.glob(["./**/*.{json,yaml}"], {
   "base": "./../content/docs",
   "query": {

--- a/apps/web/.source/source.config.mjs
+++ b/apps/web/.source/source.config.mjs
@@ -1,0 +1,12 @@
+// source.config.ts
+import { defineDocs } from "fumadocs-mdx/config";
+var docs = defineDocs({
+  dir: "content/docs"
+});
+var blog = defineDocs({
+  dir: "content/blog"
+});
+export {
+  blog,
+  docs
+};

--- a/apps/web/content/blog/infer-from-one-literal.mdx
+++ b/apps/web/content/blog/infer-from-one-literal.mdx
@@ -1,0 +1,119 @@
+---
+title: Infer everything from one object literal
+description: How one generic call lets a callback know the types of the keys next to it. It's what Zod and tRPC do, and two parts of it are genuinely fiddly to get right.
+---
+
+You've used this even if you've never built it. Call `z.object({ id: z.string() }).refine((v) => v.id.length > 0)` and the `v` inside already knows it has a string `id`. A tRPC resolver gets handed the exact input shape you declared right above it. React Hook Form's `handleSubmit` gives you back an object with your own field names on it. Every time, one part of an object literal got typed against another part of the same literal, and some callback ended up knowing names you only typed once. That's the thing I want to take apart.
+
+I ran into it building [Simten](/), which lets you design hardware in TypeScript. A circuit is a single object. Inside it is a `connect` callback, and that callback has to know about the ports you declared in the keys next to it:
+
+```ts
+const HalfAdder = circuit('HalfAdder', {
+  inputs:  { a: bit, b: bit },
+  outputs: { sum: bit, carry: bit },
+  nodes:   { xor1: Xor, and1: And },
+  connect: ({ inputs, outputs, nodes: { xor1, and1 } }) => [
+    inputs.a.to(xor1.a, and1.a),
+    inputs.b.to(xor1.b, and1.b),
+    xor1.out.to(outputs.sum),
+    and1.out.to(outputs.carry),
+  ],
+})
+```
+
+Inside `connect`, `inputs.a` autocompletes. `inputs.c` doesn't, because there's no `c`. Less obvious: `xor1.a.to(...)` is an error too, because `xor1.a` is an input you feed into, not something you draw a wire from. Nothing there got declared twice. The names and the directions both fell out of that one literal.
+
+## The one-pass part
+
+The signature is generic over the three port maps:
+
+```ts
+function circuit<
+  Ins   extends Record<string, PortType>,
+  Outs  extends Record<string, PortType>,
+  Nodes extends Record<string, BuiltCircuit>,
+>(name: string, config: {
+  inputs?:  Ins
+  outputs?: Outs
+  nodes?:   Nodes
+  connect?: (arg: ConnectArg<Ins, Outs, Nodes>) => Connection[]
+}): BuiltCircuit<Ins, Outs>
+```
+
+Pass an object literal and TypeScript pins `Ins`, `Outs`, and `Nodes` from the `inputs`, `outputs`, and `nodes` keys. Then look at the `connect` line: its argument is typed in terms of those same generics. So the moment TypeScript knows what's in `inputs`, it knows what `connect` gets. It all resolves in one pass, which is why it doesn't get slow on a big circuit. And nothing has to stay in sync, because you only wrote the ports down once.
+
+That part comes basically for free. The rest of it didn't.
+
+## Trap 1: structural typing will wire your signals backwards
+
+A port reference has a direction. A source is something values come out of, and you connect it by calling `.to(...)`. A sink is where values go in; it just sits there and receives. The obvious first attempt is two interfaces:
+
+```ts
+interface Source { to(...targets: Sink[]): Connection }
+interface Sink {}
+
+declare const out: Source  // an adder's output
+declare const in_: Sink    // a register's input
+
+out.to(in_)   // correct: source into sink
+out.to(out)   // ??
+```
+
+That last line compiles, and it shouldn't. `Sink` has no members, so it's `{}`, and in a structural type system everything non-null is assignable to `{}`. Which makes a `Source` a perfectly valid `Sink`. You've wired an output into a slot that wanted an input, backwards, and nothing said a word. In real hardware that's a short.
+
+To fix it you have to make the two types genuinely distinct, even though they carry the same fields. A `unique symbol` brand does that:
+
+```ts
+declare const dir: unique symbol
+
+interface Source { readonly [dir]: 'source'; to(...targets: Sink[]): Connection }
+interface Sink   { readonly [dir]: 'sink' }
+
+out.to(in_)   // still fine
+out.to(out)   // Error: 'source' is not assignable to 'sink'
+in_.to(out)   // Error: Property 'to' does not exist on type 'Sink'
+```
+
+The brand is a phantom. `declare const dir: unique symbol` never exists at runtime, and there's no way for user code to name it or fake it. But it's enough to make `Source` and `Sink` disjoint, so handing one to something that wanted the other finally fails. I ran both versions through TypeScript 5.9 to check: without the brand the backwards wire compiles, with it you get an error on the backwards wire and on calling `.to` on a sink.
+
+The two objects are identical at runtime, for what it's worth. Both have a `.to` method. Direction only lives in the types, so the check only happens in your editor. For something people write by hand that's exactly where you want it.
+
+## Trap 2: the brand can disappear when you publish
+
+This is the one that could ship a broken build with every local test still passing. When you build with `stripInternal`, members marked `@internal` get cut out of the generated `.d.ts`. Usually that's what you want. Here it breaks the whole thing.
+
+Strip the brand key out of the published types and anyone who installs the package sees `Sink` as `{}` again. You're back to Trap 1, except only downstream, only in the built package, and never in your own repo where the source still has the brand. It passes every test you run, then breaks for everyone who installs it.
+
+So the brand has to be marked as an exception to the stripping. It's the one internal detail that has to survive into the published types, and it needs a comment next to it saying so, because otherwise it reads like something dead that somebody will tidy away.
+
+## Trap 3: a warning I couldn't reproduce
+
+There was a comment in the codebase, sitting next to the mapped type that builds the `connect` argument. The type is roughly this:
+
+```ts
+type ConnectArg<Ins, Outs, Nodes> = {
+  inputs:  { readonly [K in keyof Ins]:  Source<Ins[K]> }
+  outputs: { readonly [K in keyof Outs]: Sink<Outs[K]> }
+  nodes: {
+    readonly [K in keyof Nodes]: Nodes[K] extends BuiltCircuit<infer NIns, infer NOuts>
+      ? SinkRefs<NIns> & SourceRefs<NOuts>
+      : never
+  }
+}
+```
+
+The direction flips between the two levels. The outer circuit's inputs are sources you drive from; a child node's inputs are sinks you drive into. So a node's reference is an intersection: sinks for its inputs, sources for its outputs. That flip does most of the work of making the API feel obvious to write.
+
+The comment warned that if you pulled the conditional out into its own named alias, the kind of cleanup a linter nudges you toward, port-name checking would quietly break and `nodes.xor1.bogusPort` would start compiling when it shouldn't. I didn't want to write that down without checking it, so I built the smallest version of both shapes and compiled them. On 5.9 both of them reject `bogusPort` the way they should. I couldn't get it to fail.
+
+That doesn't mean the comment was wrong. These type-level bugs shift around between compiler versions and with the exact generics in play, and my stripped-down case might just miss whatever the original hit. Or a later release fixed it. The inlined version stays either way, since it costs nothing and whoever left the note clearly ran into something. Mostly it reminded me that a comment like that is a claim, and this one took about ten minutes to check.
+
+## What it doesn't catch
+
+There's one thing this doesn't do yet, on purpose. A bus has a width, but on the port type that width is just a `number`, not a literal. So the compiler can tell a single bit from a bus, but it can't tell an 8-bit bus from a 16-bit one, and `.to()` will connect any width to any other. Catching that would mean threading a literal `Width` type through every one of these mapped types, and the port type doesn't carry one, so the check isn't there. The same setup that gets names and directions right just stops at widths.
+
+## Why it's shaped this way
+
+All the hard parts trace back to one decision: everything gets inferred from a single object literal, so that `connect` callback lights up with the right names and directions. That's what drags in the generics, the mapped types, the phantom brand, all the care about what makes it into the published `.d.ts`. How I wanted it to feel to write is what decided how the types had to be built.
+
+If you've ever wondered how Zod or tRPC make a callback know about the keys around it, that's roughly how it works, brand and all.

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -3,3 +3,11 @@ import { defineDocs } from 'fumadocs-mdx/config';
 export const docs = defineDocs({
   dir: 'content/docs',
 });
+
+// Blog posts authored in MDX (prose + embedded interactive React). Rendered at
+// /blog/<slug> via the src/routes/blog/$.tsx splat route; the existing bespoke
+// TSX posts under src/routes/blog/<slug>.tsx take routing precedence, so MDX
+// slugs only resolve for files that live here.
+export const blog = defineDocs({
+  dir: 'content/blog',
+});

--- a/apps/web/src/features/blog/posts.ts
+++ b/apps/web/src/features/blog/posts.ts
@@ -4,7 +4,8 @@ export type PostCategory =
   | 'accelerator'
   | 'networking'
   | 'architecture'
-  | 'interactive';
+  | 'interactive'
+  | 'engineering';
 
 export interface BlogPost {
   slug: string;
@@ -15,6 +16,14 @@ export interface BlogPost {
 }
 
 export const posts: BlogPost[] = [
+  {
+    slug: 'infer-from-one-literal',
+    title: 'Infer everything from one object literal',
+    description:
+      "How one generic call lets a callback know the types of the keys next to it. It's what Zod and tRPC do, and two parts of it are genuinely fiddly to get right.",
+    category: 'engineering',
+    nodes: 'TypeScript',
+  },
   {
     slug: 'pong-in-hardware',
     title: 'Pong in Hardware',

--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -1,7 +1,12 @@
-import { docs } from 'collections/server';
+import { blog, docs } from 'collections/server';
 import { loader } from 'fumadocs-core/source';
 
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
+});
+
+export const blogSource = loader({
+  baseUrl: '/blog',
+  source: blog.toFumadocsSource(),
 });

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as BlogChacha20InHardwareRouteImport } from './routes/blog/chacha
 import { Route as BlogBuildingACpuRouteImport } from './routes/blog/building-a-cpu'
 import { Route as BlogBreakoutInHardwareRouteImport } from './routes/blog/breakout-in-hardware'
 import { Route as BlogAesInHardwareRouteImport } from './routes/blog/aes-in-hardware'
+import { Route as BlogSplatRouteImport } from './routes/blog/$'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as CircuitSHashRouteImport } from './routes/circuit_.s.$hash'
 
@@ -170,6 +171,11 @@ const BlogAesInHardwareRoute = BlogAesInHardwareRouteImport.update({
   path: '/aes-in-hardware',
   getParentRoute: () => BlogRoute,
 } as any)
+const BlogSplatRoute = BlogSplatRouteImport.update({
+  id: '/$',
+  path: '/$',
+  getParentRoute: () => BlogRoute,
+} as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
   id: '/api/search',
   path: '/api/search',
@@ -188,6 +194,7 @@ export interface FileRoutesByFullPath {
   '/privacy': typeof PrivacyRoute
   '/terms': typeof TermsRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$': typeof BlogSplatRoute
   '/blog/aes-in-hardware': typeof BlogAesInHardwareRoute
   '/blog/breakout-in-hardware': typeof BlogBreakoutInHardwareRoute
   '/blog/building-a-cpu': typeof BlogBuildingACpuRoute
@@ -217,6 +224,7 @@ export interface FileRoutesByTo {
   '/privacy': typeof PrivacyRoute
   '/terms': typeof TermsRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$': typeof BlogSplatRoute
   '/blog/aes-in-hardware': typeof BlogAesInHardwareRoute
   '/blog/breakout-in-hardware': typeof BlogBreakoutInHardwareRoute
   '/blog/building-a-cpu': typeof BlogBuildingACpuRoute
@@ -248,6 +256,7 @@ export interface FileRoutesById {
   '/privacy': typeof PrivacyRoute
   '/terms': typeof TermsRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$': typeof BlogSplatRoute
   '/blog/aes-in-hardware': typeof BlogAesInHardwareRoute
   '/blog/breakout-in-hardware': typeof BlogBreakoutInHardwareRoute
   '/blog/building-a-cpu': typeof BlogBuildingACpuRoute
@@ -280,6 +289,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/terms'
     | '/api/search'
+    | '/blog/$'
     | '/blog/aes-in-hardware'
     | '/blog/breakout-in-hardware'
     | '/blog/building-a-cpu'
@@ -309,6 +319,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/terms'
     | '/api/search'
+    | '/blog/$'
     | '/blog/aes-in-hardware'
     | '/blog/breakout-in-hardware'
     | '/blog/building-a-cpu'
@@ -339,6 +350,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/terms'
     | '/api/search'
+    | '/blog/$'
     | '/blog/aes-in-hardware'
     | '/blog/breakout-in-hardware'
     | '/blog/building-a-cpu'
@@ -565,6 +577,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogAesInHardwareRouteImport
       parentRoute: typeof BlogRoute
     }
+    '/blog/$': {
+      id: '/blog/$'
+      path: '/$'
+      fullPath: '/blog/$'
+      preLoaderRoute: typeof BlogSplatRouteImport
+      parentRoute: typeof BlogRoute
+    }
     '/api/search': {
       id: '/api/search'
       path: '/api/search'
@@ -583,6 +602,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface BlogRouteChildren {
+  BlogSplatRoute: typeof BlogSplatRoute
   BlogAesInHardwareRoute: typeof BlogAesInHardwareRoute
   BlogBreakoutInHardwareRoute: typeof BlogBreakoutInHardwareRoute
   BlogBuildingACpuRoute: typeof BlogBuildingACpuRoute
@@ -599,6 +619,7 @@ interface BlogRouteChildren {
 }
 
 const BlogRouteChildren: BlogRouteChildren = {
+  BlogSplatRoute: BlogSplatRoute,
   BlogAesInHardwareRoute: BlogAesInHardwareRoute,
   BlogBreakoutInHardwareRoute: BlogBreakoutInHardwareRoute,
   BlogBuildingACpuRoute: BlogBuildingACpuRoute,

--- a/apps/web/src/routes/api/search.ts
+++ b/apps/web/src/routes/api/search.ts
@@ -1,9 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { createFromSource } from 'fumadocs-core/search/server';
-import { source } from '@/lib/source';
+import { createSearchAPI } from 'fumadocs-core/search/server';
+import { blogSource, source } from '@/lib/source';
 
-const server = createFromSource(source, {
+// Unified index across both collections. Each page is tagged 'docs' or 'blog'
+// so the client can scope results (?tag=…) while a single search still spans
+// everything — a reader on a blog post can find the relevant doc and vice versa.
+const server = createSearchAPI('advanced', {
   language: 'english',
+  indexes: [...source.getPages(), ...blogSource.getPages()].map((page) => ({
+    id: page.url,
+    title: page.data.title,
+    description: page.data.description,
+    url: page.url,
+    tag: page.url.startsWith('/blog') ? 'blog' : 'docs',
+    structuredData: page.data.structuredData,
+  })),
 });
 
 export const Route = createFileRoute('/api/search')({

--- a/apps/web/src/routes/blog/$.tsx
+++ b/apps/web/src/routes/blog/$.tsx
@@ -1,0 +1,71 @@
+import { createFileRoute, notFound } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import browserCollections from 'collections/browser';
+import { useFumadocsLoader } from 'fumadocs-core/source/client';
+import { DocsBody } from 'fumadocs-ui/layouts/docs/page';
+import { Suspense } from 'react';
+import { useMDXComponents } from '@/components/mdx';
+import { posts } from '@/features/blog/posts';
+import { pageHead } from '@/lib/seo';
+import { blogSource } from '@/lib/source';
+
+// MDX blog posts live in content/blog/*.mdx and render here. The bespoke TSX
+// posts under src/routes/blog/<slug>.tsx are static routes and take precedence
+// over this splat, so only slugs backed by an MDX file resolve to this route.
+export const Route = createFileRoute('/blog/$')({
+  component: Page,
+  // SEO comes from the posts manifest (the same source the blog index uses),
+  // keyed by slug — not from loaderData, which TanStack can't type through the
+  // async server fn here. Unregistered slugs (e.g. placeholders) get a generic
+  // head rather than throwing.
+  head: ({ params }) => {
+    const slug = params._splat ?? '';
+    const post = posts.find((p) => p.slug === slug);
+    return pageHead({
+      title: post?.title ?? 'Blog',
+      description: post?.description ?? '',
+      path: `/blog/${slug}`,
+      type: 'article',
+    });
+  },
+  loader: async ({ params }) => {
+    const slugs = params._splat?.split('/') ?? [];
+    const data = await serverLoader({ data: slugs });
+    await clientLoader.preload(data.path);
+    return data;
+  },
+});
+
+const serverLoader = createServerFn({ method: 'GET' })
+  .inputValidator((slugs: string[]) => slugs)
+  .handler(async ({ data: slugs }) => {
+    const page = blogSource.getPage(slugs);
+    if (!page) throw notFound();
+
+    return { path: page.path };
+  });
+
+const clientLoader = browserCollections.blog.createClientLoader({
+  component({ frontmatter, default: MDX }, _props: undefined) {
+    return (
+      <article className="mx-auto max-w-3xl pt-12">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{frontmatter.title}</h1>
+        {frontmatter.description ? (
+          <p className="text-muted-foreground text-lg mb-10">{frontmatter.description}</p>
+        ) : null}
+        <DocsBody>
+          <MDX components={useMDXComponents()} />
+        </DocsBody>
+      </article>
+    );
+  },
+});
+
+function Page() {
+  // Route.useLoaderData() mistypes as `undefined` here: the head() callback
+  // collapses this splat route's loader generics in this TanStack version. The
+  // loader always returns { path } at runtime, so pin the type.
+  const data = useFumadocsLoader(Route.useLoaderData() as { path: string });
+
+  return <Suspense>{clientLoader.useContent(data.path)}</Suspense>;
+}

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -24,6 +24,8 @@ const CATEGORY_COLORS: Record<PostCategory, string> = {
     'bg-cyan-100 text-cyan-700 border-cyan-200 dark:bg-cyan-900/50 dark:text-cyan-400 dark:border-cyan-800/50',
   interactive:
     'bg-pink-100 text-pink-700 border-pink-200 dark:bg-pink-900/50 dark:text-pink-400 dark:border-pink-800/50',
+  engineering:
+    'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800/50 dark:text-slate-300 dark:border-slate-700/50',
 };
 
 const CATEGORY_LABELS: Record<PostCategory, string> = {
@@ -33,6 +35,7 @@ const CATEGORY_LABELS: Record<PostCategory, string> = {
   networking: 'Networking',
   architecture: 'Architecture',
   interactive: 'Interactive',
+  engineering: 'Engineering',
 };
 
 function BlogIndex() {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,8 +27,15 @@ const docsPages = readdirSync(resolve(__dirname, 'content/docs'))
 // Auto-discover blog post routes from src/routes/blog/<slug>.tsx so adding
 // a new post just means dropping in a route file — no vite.config edit.
 const blogPages = readdirSync(resolve(__dirname, 'src/routes/blog'))
-  .filter((f) => f.endsWith('.tsx') && f !== 'index.tsx')
+  .filter((f) => f.endsWith('.tsx') && f !== 'index.tsx' && f !== '$.tsx')
   .map((f) => ({ path: `/blog/${f.replace(/\.tsx$/, '')}` }));
+
+// Auto-discover MDX blog posts from content/blog/*.mdx. These render through
+// the /blog/$ splat route; index.mdx is excluded (it would map to /blog, which
+// the TSX blog index already owns).
+const blogMdxPages = readdirSync(resolve(__dirname, 'content/blog'))
+  .filter((f) => (f.endsWith('.mdx') || f.endsWith('.md')) && f !== 'index.mdx')
+  .map((f) => ({ path: `/blog/${f.replace(/\.(mdx|md)$/, '')}` }));
 
 const config = defineConfig(({ command }) => ({
   plugins: [
@@ -82,8 +89,10 @@ const config = defineConfig(({ command }) => ({
         { path: '/learn/registers' },
         { path: '/cpu' },
         { path: '/cpu/rv32i' },
-        // Blog posts — auto-discovered from src/routes/blog/<slug>.tsx.
+        // Blog posts — auto-discovered from src/routes/blog/<slug>.tsx (TSX)
+        // and content/blog/*.mdx (MDX, via the /blog/$ splat route).
         ...blogPages,
+        ...blogMdxPages,
         // Docs — auto-discovered from content/docs/*.mdx. Prerender bakes
         // each MDX body into static HTML at build time — TanStack's SSR
         // pass waits for the clientLoader Suspense boundary to resolve,


### PR DESCRIPTION
Adds a fumadocs MDX blog collection alongside the existing docs, rendered at `/blog/<slug>` via a splat route. Existing TSX blog posts keep routing precedence and are untouched.

- `content/blog/*.mdx` collection + loader, `/blog/$` route
- Unified, tagged search across docs + blog (`createSearchAPI('advanced')`)
- Prerender discovery for MDX posts
- First post: "Infer everything from one object literal" (a TypeScript piece), listed under a new "Engineering" category

No dependency changes.

Known follow-ups (not blocking):
- Search indexes MDX only; the existing TSX posts become searchable once converted to MDX.