### PR TITLE
fix: pin npm to 11.x in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,14 @@ jobs:
         # `npm publish` only supports OIDC-based Trusted Publishing from
         # npm CLI 11.5.1 onward. actions/setup-node@v4 with node-version: 20
         # ships with npm 10.x; upgrading here is the smallest valid fix.
-        run: npm install -g npm@latest
+        #
+        # Pinned to the 11.x line, not @latest. npm 12 requires node
+        # >=22.22.2 and refuses to install on node 20, which silently broke
+        # every release the moment it shipped — the job died here, before
+        # changesets/action could open a Version Packages PR or publish.
+        # Pinning the major keeps a future npm from doing that again; bump
+        # this deliberately alongside node-version above.
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Releases have been silently failing since ~8 Jul. `npm install -g npm@latest` now resolves to npm 12, which requires `node >=22.22.2` and refuses to install on the workflow's node 20:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The job dies at that step — before `changesets/action` runs — so no Version Packages PR gets opened and nothing publishes. Last green run was 7 Jul; [13 Jul](https://github.com/simtenHQ/simten/actions/runs/29284504469) and [15 Jul](https://github.com/simtenHQ/simten/actions/runs/29455009467) both failed here.

Pins to `npm@^11.5.1` → 11.18.0, which requires `node ^20.17.0 || >=22.9.0` (installs fine on node 20) and is well past the 11.5.1 that Trusted Publishing OIDC needs.

Follow-ups, deliberately not in this PR: node 20 hit EOL in April, so `node-version` should go to 22 in both workflows — that changes the build runtime for every package and wants its own green run. And a failure notification on `release.yml` would help; this broke for a week and looked like "no Version Packages PR appeared" rather than anything red.