### PR TITLE
fix: build @simten/ui before apps/web viewer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "dev": "pnpm --filter @simten/core build && vite dev --port 3001",
     "dev:viewer": "pnpm --filter @simten/core build && vite dev -c vite.viewer.config.ts --port 3002",
-    "build": "pnpm --filter @simten/core build && node scripts/build.mjs",
-    "build:viewer": "pnpm --filter @simten/core build && vite build -c vite.viewer.config.ts",
+    "build": "pnpm --filter @simten/core --filter @simten/ui build && node scripts/build.mjs",
+    "build:viewer": "pnpm --filter @simten/core --filter @simten/ui build && vite build -c vite.viewer.config.ts",
     "analyze": "pnpm --filter @simten/core build && ANALYZE=true node scripts/build.mjs",
     "preview": "pnpm run build && vite preview",
     "test": "vitest run",


### PR DESCRIPTION
Follow-up to #227. The release workflow's "Build standalone viewer" step failed:

```
Could not resolve "./generated/core-types.gen" from "packages/ui/src/monaco/setup.ts"
```

`@simten/ui/monaco` imports `core-types.gen.ts`, which is gitignored and produced by `@simten/ui`'s build (`scripts/build-core-types.mjs`). `apps/web` resolves `@simten/ui` from source, so a fresh checkout has no generated file until `ui` is built.

`release.yml` builds the viewer *before* "Build packages", so the file was absent. (`ci.yml` builds packages first, which is why CI on the PR was green — the asymmetry hid it.)

Both `apps/web` build scripts already prebuild `@simten/core` for the same reason; this adds `@simten/ui` alongside it. Reproduced by deleting `packages/ui/src/monaco/generated/` and running `build:viewer` — fails before, passes after.