### PR TITLE
fix: caret ranges for internal @simten/* deps

### DIFF
--- a/.changeset/wide-melons-cheer.md
+++ b/.changeset/wide-melons-cheer.md
@@ -1,0 +1,11 @@
+---
+"@simten/embed": patch
+"@simten/ui": patch
+"@simten/mcp": patch
+---
+
+Depend on sibling `@simten/*` packages with a caret range rather than an exact version.
+
+The workspace deps were declared `workspace:*`, which pnpm rewrites to the **exact** version at publish time — so e.g. published `@simten/embed@0.1.15` pinned `@simten/ui` to exactly `0.1.14`. When a consumer bumped `@simten/ui` ahead (to get a new feature) but kept an older `@simten/embed`, the exact pin forced pnpm to install **two** copies of `@simten/ui`. Two copies don't share module identity, so objects minted by one (a sim from `useCircuitSimulator`) weren't recognized by the other (`CircuitCanvas`), silently breaking rendering.
+
+Switching to `workspace:^` publishes a caret range, letting a single compatible copy satisfy both packages. No behavior change for anyone already on matching versions.

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -67,8 +67,8 @@
   },
   "dependencies": {
     "@r2wc/react-to-web-component": "^2.1.1",
-    "@simten/core": "workspace:*",
-    "@simten/ui": "workspace:*",
+    "@simten/core": "workspace:^",
+    "@simten/ui": "workspace:^",
     "@xyflow/react": "^12.10.0",
     "clsx": "^2.1.1",
     "elkjs": "^0.9.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "@simten/core": "workspace:*",
+    "@simten/core": "workspace:^",
     "ws": "^8.21.0",
     "zod": "^3.24.0",
     "zod-to-json-schema": "^3.24.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
     "@radix-ui/react-dialog": "^1.1.15",
-    "@simten/core": "workspace:*",
+    "@simten/core": "workspace:^",
     "@xyflow/react": "^12.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,10 +328,10 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(react-dom@19.2.0)(react@19.2.0)
       '@simten/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@simten/ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../ui
       '@xyflow/react':
         specifier: ^12.10.0
@@ -392,7 +392,7 @@ importers:
         specifier: ^1.12.0
         version: 1.26.0(zod@3.25.76)
       '@simten/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       ws:
         specifier: ^8.21.0
@@ -426,7 +426,7 @@ importers:
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
       '@simten/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@typescript/ata':
         specifier: ^0.9.8


### PR DESCRIPTION
Internal deps were declared `workspace:*`, which pnpm rewrites to an **exact** version on publish — so published `@simten/embed@0.1.15` pinned `@simten/ui` to exactly `0.1.14`. A consumer bumping `@simten/ui` ahead while keeping older `@simten/embed` then gets **two** copies of `@simten/ui` installed; they don't share module identity, so a `sim` from `useCircuitSimulator` (one copy) isn't recognized by `CircuitCanvas` (the other), silently breaking rendering. This bit the multiplayer app's clock in exactly this way.

Switches all four internal deps (`ui→core`, `embed→core`, `embed→ui`, `mcp→core`) to `workspace:^`, which publishes a caret range so one compatible copy satisfies everyone. Install still resolves cleanly; no change for anyone already on matching versions.