### PR TITLE
chore: gitignore verilog-import spike scratch/demo artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ hardware/ulx3s/.cache/
 # cycle-diff cosim outputs (regenerated on every run)
 hardware/ulx3s/projects/cpu/cycle-diff.log
 hardware/ulx3s/projects/cpu/cycle-diff.vcd
+
+# Verilog-import spike scratch/demo artifacts (local only)
+packages/core/import-demo.mts
+packages/core/*.imported.circuit.ts


### PR DESCRIPTION
Ignores two local-only scratch/demo files left over from the Verilog-import spike (#234) so they stop showing up as untracked and tripping the Biome check locally:

- `packages/core/import-demo.mts` — throwaway demo runner
- `packages/core/*.imported.circuit.ts` — generated import output

No source or behavior change; `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)