### PR TITLE
Wire Verilog import into synth + reliable container deploy

### DIFF
--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -1,0 +1,59 @@
+name: Deploy container app
+
+# Manual deploy for the Cloudflare Container apps (synth / verifier / compiler).
+#
+# Why this exists: these images are large (the synth image bundles the ECP5
+# toolchain), and pushing them from a laptop through Docker Desktop's VM
+# networking is unreliable — large blob uploads get their connection severed
+# mid-push. A GitHub Actions runner builds the image natively on amd64 (no qemu,
+# fast) and pushes straight to Cloudflare's registry over a datacenter uplink,
+# which is what makes the push reliable. Reuses the same CLOUDFLARE_* repo
+# secrets CI already uses (Settings → Secrets and variables → Actions).
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: Which Cloudflare container app to deploy
+        type: choice
+        default: synth
+        options:
+          - synth
+          - verifier
+          - compiler
+
+concurrency:
+  # Never cancel a deploy mid-push; queue instead.
+  group: deploy-${{ github.event.inputs.app }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: wrangler deploy (${{ github.event.inputs.app }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        # Version inferred from `packageManager` in package.json
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy ${{ github.event.inputs.app }}
+        # `wrangler deploy` builds the app's Dockerfile with the runner's native
+        # Docker (preinstalled on ubuntu-latest) and pushes to the Cloudflare
+        # registry. Creds come from repo secrets, not .env/dotenv-cli.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm --filter @simten/${{ github.event.inputs.app }} run deploy

--- a/apps/synth/Dockerfile
+++ b/apps/synth/Dockerfile
@@ -32,9 +32,37 @@ ARG OSS_CAD_SUITE_DATE=2026-07-07
 RUN COMPACT=$(echo "$OSS_CAD_SUITE_DATE" | tr -d '-') \
     && curl -fsSL "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${OSS_CAD_SUITE_DATE}/oss-cad-suite-linux-x64-${COMPACT}.tgz" -o /tmp/oss-cad-suite.tgz \
     && tar -xzf /tmp/oss-cad-suite.tgz -C /opt \
-    && rm /tmp/oss-cad-suite.tgz
+    && rm /tmp/oss-cad-suite.tgz \
+    # --- Slim to the ECP5 flow (yosys + nextpnr-ecp5 + ecppack) --------------
+    # The suite ships the whole OSS EDA ecosystem (~2.5 GB extracted), but this
+    # container only ever runs those three tools (see container_src/main.go).
+    # Pruning the unused ~1.6 GB keeps registry pushes resumable and cold starts
+    # fast. MUST stay in this RUN so the bytes never land in a persisted layer.
+    # Kept on purpose: nextpnr-ecp5 is built with an embedded Python interpreter
+    # and Qt, so lib/python3.11 (+ libpython3.11.so) and libQt5*/libicu* are load
+    # -time requirements even headless; trellis/yosys/ecp5 DBs are required. The
+    # smoke test below fails the build if a future suite layout breaks the flow.
+    && cd /opt/oss-cad-suite \
+    && rm -rf lib/python2.7 lib/ghdl lib/ivl lib/dri lib/python3.11/test \
+    && rm -f  lib/libpython2.7.so* lib/libLLVM* lib/libghdl* lib/libvvp* \
+    && rm -rf share/icebox share/icons share/openFPGALoader share/openocd \
+              share/nextpnr/himbaechel examples include super_prove py3bin \
+    && rm -f  libexec/nextpnr-ice40 libexec/nextpnr-machxo2 libexec/nextpnr-nexus \
+              libexec/surfer libexec/ivl libexec/z3 libexec/cvc4 libexec/cvc5 \
+              libexec/pono libexec/prjoxide libexec/verilator_bin_dbg libexec/aigcexmin
 
 ENV PATH="/opt/oss-cad-suite/bin:$PATH"
+
+# Smoke test: run the real ECP5 flow so an over-aggressive prune (or a future
+# suite version that relocates a database) fails the BUILD instead of shipping a
+# broken image. Cheap; produces a bitstream from a trivial design.
+RUN set -eux \
+    && printf 'module smoke(input a,b,output y); assign y=a&b; endmodule\n' > /tmp/smoke.v \
+    && yosys -q -p 'synth_ecp5 -top smoke -json /tmp/smoke.json' /tmp/smoke.v \
+    && nextpnr-ecp5 --85k --json /tmp/smoke.json --textcfg /tmp/smoke.cfg --timing-allow-fail \
+    && ecppack --input /tmp/smoke.cfg --bit /tmp/smoke.bit \
+    && test -s /tmp/smoke.bit \
+    && rm -f /tmp/smoke.*
 
 # Copy the Go server
 COPY --from=build-server /server /server

--- a/apps/synth/container_src/main.go
+++ b/apps/synth/container_src/main.go
@@ -74,7 +74,22 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 }
 
 // buildYosysScript returns the Yosys synthesis script for the given target.
+//
+// The "import" target stops at the coarse-grain RTL netlist: it runs the
+// generic front-end passes but NOT techmapping, so word-level cells ($add,
+// $mux, $dff, $mem_v2, …) survive for @simten/core's Verilog importer to lift
+// into stdlib components. Every synth* target (including plain "synth") lowers
+// those to gate/tech primitives ($_AND_, LUT4, TRELLIS_FF …), which the
+// importer can't recover into clean source. `hierarchy` (no `flatten`) keeps
+// submodules as separate modules so the importer emits one Circuit per module.
 func buildYosysScript(top, target, netlistPath string) string {
+	if target == "import" {
+		return fmt.Sprintf(
+			"hierarchy -top %s; proc; opt_clean; memory_collect; stat; write_json %s",
+			top, netlistPath,
+		)
+	}
+
 	var synthCmd string
 	switch target {
 	case "ice40":

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -14,7 +14,8 @@
   },
   "services": [
     { "binding": "COMPILER", "service": "compiler", "remote": true },
-    { "binding": "VERIFIER", "service": "verifier", "remote": true }
+    { "binding": "VERIFIER", "service": "verifier", "remote": true },
+    { "binding": "SYNTH", "service": "synth", "remote": true }
   ],
   "ratelimits": [
     { "name": "COMPILE_RL", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },


### PR DESCRIPTION
Backend + infra to support pasting Verilog on the circuit page. Two commits:

**1. synth `import` target + web SYNTH binding**
- New yosys `target: "import"` on the synth container's `/synth` route. It runs the generic RTL passes (`hierarchy; proc; opt_clean; memory_collect; write_json`) and stops before techmapping, so word-level cells (`$add`/`$mux`/`$dff`/`$mem_v2`) survive for `@simten/core`'s importer to lift. Every existing `synth_*` target is unchanged.
- Adds the `SYNTH` service binding to `apps/web` so the web worker can reach the deployed synth container.
- Verified end to end locally: the target's yosys output runs through `importNetlist` → `circuitToSource` and produces clean, `Rtl*`-free source.

**2. Slim the synth image + CI container deploy**
- Prune the ECP5 image from ~766 MB to ~325 MB by dropping tooling this container never runs (other FPGA families, formal solvers, Icarus/Verilator/GHDL, ice40/Gowin DBs, LLVM, GUI stack). Every cut was verified by re-running the real `yosys → nextpnr-ecp5 → ecppack` flow to a byte-identical bitstream. A build-time smoke test now runs that flow so an over-prune fails the build.
- Add `.github/workflows/deploy-container.yml`: a **manual-only** (`workflow_dispatch`) deploy for the container apps. Building/pushing from a native amd64 runner avoids the Docker Desktop VM networking that was severing large registry pushes from the laptop.

Note: merging is what makes the deploy workflow dispatchable (workflow_dispatch requires the file on the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)