### PR TITLE
Public /api/verilog-import route (Verilog → simten source), rate-limited

### DIFF
--- a/apps/web/src/api/routes.ts
+++ b/apps/web/src/api/routes.ts
@@ -6,6 +6,7 @@
  */
 
 import { handleCompile } from './compile';
+import { handleVerilogImport } from './synth';
 import { handleVerify } from './verify';
 
 export async function handleApiRoute(
@@ -20,6 +21,10 @@ export async function handleApiRoute(
 
   if (url.pathname === '/api/verify' && request.method === 'POST') {
     return handleVerify(request, env);
+  }
+
+  if (url.pathname === '/api/verilog-import' && request.method === 'POST') {
+    return handleVerilogImport(request, env);
   }
 
   return null;

--- a/apps/web/src/api/synth.ts
+++ b/apps/web/src/api/synth.ts
@@ -1,0 +1,120 @@
+/**
+ * Verilog Import API Handler — Verilog source → clean, editable simten TypeScript.
+ *
+ * Runs yosys on the synth container (the `import` target: generic RTL netlist,
+ * no techmapping) then lifts that netlist into simten source with
+ * @simten/core's importer. The lift is pure TS and runs here in the worker.
+ *
+ * Production: uses the SYNTH Cloudflare service binding.
+ * Local dev:  falls back to the synth container on localhost:8792.
+ */
+
+import { buildFromIR, circuitToSource } from '@simten/core/circuit';
+import { importNetlist, type YosysNetlist } from '@simten/core/import';
+
+interface SynthContainerResponse {
+  success: boolean;
+  netlist?: string;
+  stats?: { cells: number; wires: number; cellBreakdown: Record<string, number> };
+  log?: string;
+  error?: string;
+}
+
+export async function handleVerilogImport(
+  request: Request,
+  env: Record<string, unknown>,
+): Promise<Response> {
+  let body: { verilog?: string; top?: string; files?: Record<string, string> };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ success: false, error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (typeof body.verilog !== 'string' || body.verilog.length === 0) {
+    return Response.json({ success: false, error: 'verilog source is required' }, { status: 400 });
+  }
+  if (typeof body.top !== 'string' || body.top.length === 0) {
+    return Response.json({ success: false, error: 'top module name is required' }, { status: 400 });
+  }
+
+  // Rate limit — yosys is CPU-heavy and the container has few instances, so keep
+  // this modest per IP (5/min). Mirrors the compile/verify handlers.
+  const rl = (
+    env as { SYNTH_RL?: { limit: (k: { key: string }) => Promise<{ success: boolean }> } }
+  ).SYNTH_RL;
+  if (rl) {
+    const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+    const { success } = await rl.limit({ key: ip });
+    if (!success) {
+      return Response.json(
+        { success: false, error: 'Rate limit exceeded — try again in a minute' },
+        { status: 429 },
+      );
+    }
+  }
+
+  const reqInit: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      verilog: body.verilog,
+      top: body.top,
+      target: 'import',
+      files: body.files,
+    }),
+  };
+
+  // Service binding (production) → local synth container fallback (dev)
+  const synth = env.SYNTH as { fetch: typeof fetch } | undefined;
+
+  let synthResult: SynthContainerResponse;
+  try {
+    const resp = synth
+      ? await synth.fetch('https://synth/synth', reqInit)
+      : await fetch('http://localhost:8792/synth', reqInit);
+    synthResult = await resp.json();
+  } catch (e) {
+    return Response.json(
+      {
+        success: false,
+        error: `Synth service error: ${e instanceof Error ? e.message : String(e)}`,
+      },
+      { status: 502 },
+    );
+  }
+
+  if (!synthResult.success || !synthResult.netlist) {
+    // yosys couldn't elaborate the Verilog (syntax error, wrong top, …).
+    return Response.json(
+      {
+        success: false,
+        error: synthResult.error ?? 'yosys elaboration failed',
+        log: synthResult.log,
+      },
+      { status: 422 },
+    );
+  }
+
+  // Lift the generic RTL netlist into clean, editable simten source. The
+  // importer throws on cell types outside its scope (e.g. $adff/$sdff/$dffe —
+  // see issue #237) rather than mis-translate; surface that as a clean 422 with
+  // an `unsupported` flag the UI can special-case.
+  try {
+    const netlist = JSON.parse(synthResult.netlist) as YosysNetlist;
+    const { top, library } = importNetlist(netlist, body.top);
+    const deps = [...library.values()].filter((c) => c.name !== top.name);
+    const source = circuitToSource(buildFromIR(top, deps));
+    return Response.json({ success: true, source, stats: synthResult.stats });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return Response.json(
+      {
+        success: false,
+        error: `Import failed: ${msg}`,
+        unsupported: /unsupported cell/i.test(msg),
+      },
+      { status: 422 },
+    );
+  }
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -20,7 +20,8 @@
   "ratelimits": [
     { "name": "COMPILE_RL", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },
     { "name": "VERIFY_RL", "namespace_id": "1002", "simple": { "limit": 3, "period": 60 } },
-    { "name": "SHARE_RL", "namespace_id": "1003", "simple": { "limit": 30, "period": 60 } }
+    { "name": "SHARE_RL", "namespace_id": "1003", "simple": { "limit": 30, "period": 60 } },
+    { "name": "SYNTH_RL", "namespace_id": "1004", "simple": { "limit": 5, "period": 60 } }
   ],
   "kv_namespaces": [
     {


### PR DESCRIPTION
Adds the public API endpoint that turns pasted Verilog into clean simten source, backed by the deployed synth container's `import` target (merged in #238).

**`POST /api/verilog-import`** — `{ verilog, top }` → `{ success, source }`
- Rate-limited: new `SYNTH_RL` (5 req/min per IP, keyed on `CF-Connecting-IP`), matching the compile/verify handlers.
- Calls the `SYNTH` service binding with `target: "import"` to get a generic RTL netlist, then runs `importNetlist` → `circuitToSource` in the worker (both pure TS, no node builtins — verified worker-safe).
- Error handling: `400` bad input · `429` rate limited · `422` (+ `unsupported: true`) for the importer's unsupported-cell throw (e.g. `$adff`, #237) · `502` synth unreachable.
- Dispatched in `api/routes.ts` alongside `/api/compile` and `/api/verify`; localhost:8792 fallback for dev.

Verified: biome + web typecheck clean, `pnpm --filter @simten/web build` passes (worker bundles `@simten/core/import` fine). The lift chain was proven end-to-end separately.

Not included yet: the circuit-page UI. This is the backend route so the flow can be tested first. The route goes live on the next `pnpm deploy:web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)