### PR TITLE
Fix: 32-bit editor inputs stuck at 0 (signed shift overflow)

### DIFF
--- a/.changeset/wide-input-clamp.md
+++ b/.changeset/wide-input-clamp.md
@@ -1,0 +1,5 @@
+---
+"@simten/ui": patch
+---
+
+Fix wide (≥31-bit) editor inputs being stuck at 0. The input nodes clamped values to `(1 << Math.min(width, 31)) - 1`, but JavaScript's `<<` is signed 32-bit: `1 << 31` is negative, so `maxValue` went negative and `Math.min(maxValue, value)` forced every entered value to 0. A 32-bit input (e.g. an imported ALU's operands) could never be set to anything but 0, while narrow inputs worked. Now uses `2 ** Math.min(width, 32) - 1`, allowing the full unsigned range up to 2^32-1.

--- a/packages/ui/src/nodes/InputNode.tsx
+++ b/packages/ui/src/nodes/InputNode.tsx
@@ -12,7 +12,10 @@ interface InputNodeProps {
 
 function NumericInputControl({ data }: { data: NodeData }) {
   const width = data.width ?? 8;
-  const maxValue = (1 << Math.min(width, 31)) - 1;
+  // Use 2**width, not (1 << width): JS `<<` is signed 32-bit, so `1 << 31` is
+  // negative and `1 << 32` wraps to 1 — either way maxValue went bad and clamped
+  // every wide input to 0. Cap at 32 (simten's max bus width) → up to 2^32-1.
+  const maxValue = 2 ** Math.min(width, 32) - 1;
   const currentValue = data.numericValue ?? 0;
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState('');

--- a/packages/ui/src/nodes/NumericInputNode.tsx
+++ b/packages/ui/src/nodes/NumericInputNode.tsx
@@ -11,7 +11,9 @@ interface NumericInputNodeProps {
 export function NumericInputNode({ data, selected }: NumericInputNodeProps) {
   const value = data.numericValue ?? 0;
   const width = data.width ?? 8;
-  const maxValue = (1 << Math.min(width, 31)) - 1;
+  // 2**width, not (1 << width): JS `<<` is signed 32-bit, so `1 << 31` is negative
+  // and `1 << 32` wraps to 1 — clamping every wide input to 0. Cap at 32-bit.
+  const maxValue = 2 ** Math.min(width, 32) - 1;
 
   const [isEditingValue, setIsEditingValue] = useState(false);
   const [editValue, setEditValue] = useState(value.toString());


### PR DESCRIPTION
## Symptom
In the editor, a 32-bit input (e.g. an imported ALU's `in1`/`in2`) can't be set to anything but 0 — you type a value and it stays 0 — while a narrow input (`sl`, 3-bit) works.

## Cause
Both input nodes clamped to `(1 << Math.min(width, 31)) - 1`. JavaScript's `<<` operates on **signed 32-bit** integers, so `1 << 31` is `-2147483648` (not `2^31`). `maxValue` therefore went negative, and `Math.max(0, Math.min(maxValue, value))` collapsed every entered value to 0. Narrow widths (`1 << 3 = 8`) were unaffected, which is why only wide inputs broke.

## Fix
Use `2 ** Math.min(width, 32) - 1` (floating-point, no 32-bit wrap) in `InputNode.tsx` and `NumericInputNode.tsx` — allows the full unsigned range up to `2^32-1`. Verified: width 3→7, 8→255, 31→2147483647, 32→4294967295.

Pre-existing bug, surfaced by importing a design with 32-bit operands. Changeset: `@simten/ui` patch.