### PR TITLE
Tolerate undriven nets + surface import/yosys warnings

### DIFF
--- a/.changeset/import-undriven-and-warnings.md
+++ b/.changeset/import-undriven-and-warnings.md
@@ -1,0 +1,7 @@
+---
+"@simten/core": minor
+---
+
+The Verilog importer now tolerates undriven nets instead of aborting. An unassigned or misspelled signal (yosys keeps it as a floating wire) previously threw `net N has no driver` and failed the whole import. It's now tied to 0 — simten's 2-state analog of how yosys/iverilog tolerate a floating wire — so the design still imports and the user sees the (broken) result.
+
+`ImportResult` gains a `warnings: string[]` field carrying these non-fatal notes (e.g. "an undriven net was tied to 0"), deduped per module. Callers (like the web import route) can surface them alongside yosys's own warnings.

--- a/apps/web/src/api/synth.ts
+++ b/apps/web/src/api/synth.ts
@@ -102,10 +102,23 @@ export async function handleVerilogImport(
   // an `unsupported` flag the UI can special-case.
   try {
     const netlist = JSON.parse(synthResult.netlist) as YosysNetlist;
-    const { top, library } = importNetlist(netlist, body.top);
+    const { top, library, warnings } = importNetlist(netlist, body.top);
     const deps = [...library.values()].filter((c) => c.name !== top.name);
     const source = circuitToSource(buildFromIR(top, deps));
-    return Response.json({ success: true, source, stats: synthResult.stats });
+    // Non-fatal notes: the importer's warnings (e.g. undriven nets) plus yosys's
+    // own warnings from the synth log (e.g. implicit/undeclared wires). Strip the
+    // per-line source location so repeats collapse, dedupe, and cap the list.
+    const yosysWarnings = (synthResult.log ?? '')
+      .split('\n')
+      .filter((l) => /Warning:/i.test(l))
+      .map((l) => l.trim().replace(/\s+at\s+\S+:\d[\d.-]*\s*$/, ''));
+    const allWarnings = [...new Set([...warnings, ...yosysWarnings])].slice(0, 12);
+    return Response.json({
+      success: true,
+      source,
+      stats: synthResult.stats,
+      warnings: allWarnings,
+    });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return Response.json(

--- a/apps/web/src/features/visual-editor/components/VerilogImportSheet.tsx
+++ b/apps/web/src/features/visual-editor/components/VerilogImportSheet.tsx
@@ -36,6 +36,7 @@ function detectModules(src: string): string[] {
 type Status =
   | { kind: 'idle' }
   | { kind: 'loading' }
+  | { kind: 'warned'; warnings: string[] }
   | { kind: 'error'; message: string; unsupported?: boolean };
 
 const PLACEHOLDER = `module adder8(input [7:0] a, input [7:0] b, output [7:0] y);
@@ -76,6 +77,7 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
         source?: string;
         error?: string;
         unsupported?: boolean;
+        warnings?: string[];
       };
       if (!resp.ok || !data.success || !data.source) {
         setStatus({
@@ -88,8 +90,14 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
       onImport(data.source);
       setVerilog('');
       topEdited.current = false;
-      setStatus({ kind: 'idle' });
-      setOpen(false);
+      // Import succeeded. If there were non-fatal notes, keep the sheet open so
+      // the user can read them; otherwise close.
+      if (data.warnings && data.warnings.length > 0) {
+        setStatus({ kind: 'warned', warnings: data.warnings });
+      } else {
+        setStatus({ kind: 'idle' });
+        setOpen(false);
+      }
     } catch (e) {
       setStatus({ kind: 'error', message: e instanceof Error ? e.message : 'Network error' });
     }
@@ -148,6 +156,21 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
                 or clock-enable). Try a simpler module for now.
               </p>
             )}
+          </div>
+        )}
+
+        {status.kind === 'warned' && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+            <p className="font-medium">Imported with warnings:</p>
+            <ul className="mt-1 list-disc space-y-0.5 pl-4">
+              {status.warnings.map((w) => (
+                <li key={w}>{w}</li>
+              ))}
+            </ul>
+            <p className="mt-1.5 text-muted-foreground">
+              The source is in the editor — these are usually undeclared or misspelled signals in
+              the Verilog.
+            </p>
           </div>
         )}
 

--- a/packages/core/src/import/__tests__/import-undriven.test.ts
+++ b/packages/core/src/import/__tests__/import-undriven.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Undriven nets are tolerated, not fatal.
+ *
+ * An undriven net (usually an unassigned or misspelled signal in the source —
+ * yosys keeps it as a floating wire) used to throw `net N has no driver`, which
+ * aborted the whole import. The importer now ties undriven nets to 0 — simten's
+ * 2-state analog of how yosys/iverilog tolerate a floating wire (x/z) — and
+ * records a warning, so the (broken) design still imports and the user can see
+ * it. This mirrors real-tool behavior and turns a hard stop into a note.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildFromIR, circuitToSource } from '../../circuit/index.js';
+import { importNetlist, type YosysNetlist } from '../index.js';
+
+describe('undriven nets tie to 0 with a warning (not a hard error)', () => {
+  // `module top(output y);` where y reads net 2, which nothing drives.
+  const undriven: YosysNetlist = {
+    modules: { top: { ports: { y: { direction: 'output', bits: [2] } }, cells: {} } },
+  };
+
+  it('imports without throwing and reports a warning', () => {
+    const result = importNetlist(undriven, 'top');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/undriven/i);
+  });
+
+  it('ties the undriven output to a Constant(0) in the generated source', () => {
+    const { top, library } = importNetlist(undriven, 'top');
+    const deps = [...library.values()].filter((c) => c.name !== top.name);
+    const source = circuitToSource(buildFromIR(top, deps));
+    expect(source).toContain('Constant({ width: 1, value: 0 })');
+    expect(source).not.toMatch(/inWidth: null/); // tied constant carries its width
+  });
+
+  it('dedupes repeated warnings across a module', () => {
+    // y and z both read undriven nets → one deduped warning, not two.
+    const twoUndriven: YosysNetlist = {
+      modules: {
+        top: {
+          ports: {
+            y: { direction: 'output', bits: [2] },
+            z: { direction: 'output', bits: [3] },
+          },
+          cells: {},
+        },
+      },
+    };
+    expect(importNetlist(twoUndriven, 'top').warnings).toHaveLength(1);
+  });
+});

--- a/packages/core/src/import/import-netlist.ts
+++ b/packages/core/src/import/import-netlist.ts
@@ -541,6 +541,7 @@ function translateModule(
   netlist: YosysNetlist,
   libDeps: Map<string, Circuit>,
   moduleNameOf: (raw: string) => string,
+  warnings: string[],
 ): Circuit {
   const nodes: Node[] = [];
   const connections: Connection[] = [];
@@ -629,8 +630,18 @@ function translateModule(
   }
   const driverOf = (net: number): BitDriver => {
     const d = drivers.get(net);
-    if (!d) throw new Error(`${name}: net ${net} has no driver`);
-    return d;
+    if (d) return d;
+    // Undriven net: tie to 0 and continue rather than hard-failing. This is
+    // simten's 2-state analog of how yosys/iverilog tolerate an undriven wire
+    // (x/z) — usually an unassigned or misspelled signal in the source. Register
+    // the tie so repeat reads reuse it (and the warning fires once per net).
+    const id = `_u${helperId++}`;
+    pushBuilt(id, Constant({ width: 1, value: 0 }), { width: 1, value: 0 });
+    const tie: BitDriver = { nodeId: id, portName: 'out', index: 0 };
+    drivers.set(net, tie);
+    sourceWidth.set(key(id, 'out'), 1);
+    warnings.push(`${name}: an undriven net was tied to 0 (an unassigned or misspelled signal)`);
+    return tie;
   };
 
   // --- resolve a bit vector to a single {nodeId, portName} source -------
@@ -926,6 +937,8 @@ export interface ImportResult {
   top: Circuit;
   /** Every module circuit + every stdlib/rtl dependency circuit, by name. */
   library: Map<string, Circuit>;
+  /** Non-fatal notes about the import (e.g. undriven nets tied to 0). */
+  warnings: string[];
 }
 
 /**
@@ -969,11 +982,12 @@ export function importNetlist(netlist: YosysNetlist, topName?: string): ImportRe
   const shapes = moduleShapes(netlist);
   const moduleNameOf = makeModuleNameSanitizer(netlist);
   const library = new Map<string, Circuit>();
+  const warnings: string[] = [];
 
   for (const [name, mod] of Object.entries(netlist.modules)) {
     library.set(
       moduleNameOf(name),
-      translateModule(name, mod, shapes, netlist, library, moduleNameOf),
+      translateModule(name, mod, shapes, netlist, library, moduleNameOf, warnings),
     );
   }
 
@@ -990,5 +1004,5 @@ export function importNetlist(netlist: YosysNetlist, topName?: string): ImportRe
     top = roots[0];
   }
 
-  return { top: library.get(moduleNameOf(top))!, library };
+  return { top: library.get(moduleNameOf(top))!, library, warnings: [...new Set(warnings)] };
 }


### PR DESCRIPTION
Two small, paired improvements to the Verilog import UX. Prompted by a corpus FSM (Moore Nonoverlap) that failed to import — turned out its source has a real bug (declares `next_state`/`out` but writes `ns`/`new_out`, so those regs are never assigned).

## (a) Tolerate undriven nets — `@simten/core`
An undriven net (unassigned/misspelled signal; yosys keeps it as a floating wire) used to throw `net N has no driver` and abort the whole import. It now **ties to 0** — simten's 2-state analog of how yosys/iverilog tolerate a floating wire (x/z) — and records a warning, so the (broken) design still imports and the user can see it.

- Single conditional at the one choke point (`driverOf`); no scattered branching.
- `ImportResult` gains `warnings: string[]` (deduped per module).
- The Moore FSM now imports with one clean warning instead of a hard stop.

## (b) Surface warnings in the UI — `apps/web`
`/api/verilog-import` now returns `warnings`, combining the importer's notes with **yosys's own warnings** (already in the synth log — e.g. "wire `\ns` is assigned", which points straight at the misspelled-signal bug), location-stripped, deduped, capped at 12. `VerilogImportSheet` shows them in an amber "Imported with warnings" panel; the source still lands in the editor.

## Verified
- New `import-undriven.test.ts`: undriven nets tie to `Constant(0)`, warn, dedupe, and don't throw.
- Full core suite green (660), web build passes.

Changeset: `@simten/core` minor.