### PR TITLE
docs: explain the implicit clock model

### DIFF
--- a/apps/web/content/docs/component-model.mdx
+++ b/apps/web/content/docs/component-model.mdx
@@ -102,6 +102,8 @@ All support `width` parameter (default: 8).
 
 These components have **clocked state** that updates on the rising edge of `clk`.
 
+"Sequential" isn't a flag you set: a primitive is sequential exactly when it declares `state` (these two do), and a composite is sequential when it contains one. That same `state` declaration is what gives the circuit its single implicit clock, which is why you never wire `clk` yourself — see [How it works](/docs/how-it-works#3-sequential-vs-combinational).
+
 | Primitive | Inputs | Outputs | Parameters | Description |
 |-----------|--------|---------|------------|-------------|
 | <PrimitiveLink name="DFlipFlop" /> | `d: Bit` | `q: Bit`, `q_bar: Bit` | — | 1-bit register, captures `d` on clock edge |

--- a/apps/web/content/docs/how-it-works.mdx
+++ b/apps/web/content/docs/how-it-works.mdx
@@ -92,6 +92,12 @@ const DelayLine = circuit('DelayLine', {
 
 The DSL is the same shape — `inputs`, `outputs`, `nodes`, `connect`. Sequentiality comes from which primitives you pick (`DFlipFlop`, `Register`, `RAM`), not from a separate sub-language.
 
+Behind that is a single rule: a primitive is sequential when it declares `state`. `DFlipFlop` and `Register` do; `And` and `Adder` don't. There's no `sequential` flag and no base class — the `state` is the whole signal. A composite inherits it: your circuit is sequential the moment it holds something that is.
+
+That same declaration hands the circuit a clock. simten has exactly one. Every stateful element subscribes to a single `clk` the instant it declares `state`, so you never route it — there's no clock port on `Register`, no clock in `connect`. A register's own inputs — `data`, `we`, `rst` — are wires you draw. The clock is a broadcast every register already hears.
+
+So ▶ (or `tick()`) advances that one clock, and every register latches on the same edge. One clock, one tick, nothing to wire. It's also why simten is single-clock: no second domain, no dividers, no crossings. [Export](#5-export-to-verilog) reverses it — the exporter turns that implicit clock back into real `clk` and `rst_n` ports for the synthesizer.
+
 ## 4. The trace is the truth
 
 Every value, every wire, every cycle is recorded. When something goes wrong you scrub backward to the exact cycle the bug appeared — no `printf`, no rerun, no guessing.

--- a/apps/web/content/docs/simulator-engine.mdx
+++ b/apps/web/content/docs/simulator-engine.mdx
@@ -277,7 +277,7 @@ result is not the snapshot returned to the API — that comes from Phase 5, afte
 updateClockStates(circuit, seqState);
 ```
 
-Sets all clocks to rising edge. Currently all clocks tick simultaneously (single clock domain).
+Sets all clocks to rising edge. Currently all clocks tick simultaneously (single clock domain). There is only ever the one implicit clock every stateful primitive subscribes to — [How it works §3](/docs/how-it-works#3-sequential-vs-combinational) covers where it comes from and why circuits never wire it.
 
 ### Phase 3: Sequential State Computation
 


### PR DESCRIPTION
Adds a coherent explanation of how sequential vs combinational is derived and where the clock comes from — the connective tissue that was scattered across three pages before.

- **how-it-works §3** (the hub): a circuit is sequential because a primitive declares `state`; that same declaration creates the single implicit `clk` every register subscribes to, which is why you never wire a clock; single-clock by design; export reverses it.
- **component-model**: one-line derivation rule after the Sequential table, linking to §3.
- **simulator-engine**: pointer from the Clock Update phase back to §3 for the 'why'.

No code changes; `apps/web` is ignored by changesets so no changeset needed.