### PR TITLE
fix(core): publish the ./rtl and ./import subpaths, and gate exports drift in CI

### DIFF
--- a/.changeset/wild-donkeys-shake.md
+++ b/.changeset/wild-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'@simten/core': patch
+---
+
+Fix the `@simten/core/rtl` and `@simten/core/import` subpaths on the published package. Both were declared in `exports` but missing from `publishConfig.exports`, so they resolved in-repo and failed for anyone installing from npm — which put the Verilog importer out of reach of the published build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ name: CI
 #   8. publish-readiness lint (publint)        — validates package.json shape +
 #                                              exports paths against the built
 #                                              dist/ for each publishable package
-#   9. web production build                   — proves the web app + Cloudflare
+#   9. exports drift check                    — keeps `exports` (src, for dev)
+#                                              and `publishConfig.exports`
+#                                              (dist, for npm) in correspondence
+#  10. web production build                   — proves the web app + Cloudflare
 #                                              Workers bundle compiles end to end
 #
 # Deferred coverage (TODO before this is "real" CI):
@@ -132,6 +135,15 @@ jobs:
           for pkg in core ui embed mcp; do
             pnpm dlx publint "packages/$pkg"
           done
+
+      - name: Exports drift check
+        # Guards the dev/publish export duality: every package's `exports`
+        # points at ./src/*.ts for local dev while `publishConfig.exports`
+        # points at ./dist/*.js. A subpath added to one and not the other
+        # works in-repo and 404s for anyone installing from npm. This is the
+        # first thing root `pnpm test` runs, but CI runs the per-package test
+        # scripts directly, so it needs its own step.
+        run: pnpm check-exports
 
       - name: Typecheck
         run: pnpm typecheck

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,6 +69,14 @@
         "types": "./dist/std/index.d.ts",
         "import": "./dist/std/index.js"
       },
+      "./rtl": {
+        "types": "./dist/rtl/index.d.ts",
+        "import": "./dist/rtl/index.js"
+      },
+      "./import": {
+        "types": "./dist/import/index.d.ts",
+        "import": "./dist/import/index.js"
+      },
       "./sim": {
         "types": "./dist/sim/index.d.ts",
         "import": "./dist/sim/index.js"


### PR DESCRIPTION
## What

`@simten/core` declares `./rtl` and `./import` in `exports` but not in `publishConfig.exports`. Since dev `exports` points at `./src/*.ts` and `publishConfig.exports` points at `./dist/*.js`, both subpaths resolve fine in-repo and fail for anyone installing from npm:

```ts
import { importNetlist } from '@simten/core/import'   // works here, 404s from npm
```

That puts the Verilog importer out of reach of the published package.

## Why it wasn't caught

`scripts/check-exports.ts` exists precisely to catch this, and it's the first thing root `pnpm test` runs. But CI invokes the per-package test scripts directly (`pnpm --filter @simten/core test`), so the drift lint never ran. It has been failing on `main`.

## Changes

- `packages/core/package.json` — add the two missing `publishConfig.exports` entries
- `.github/workflows/ci.yml` — new "Exports drift check" step so this can't regress, placed with publint since both are packaging concerns
- changeset (patch) — this fixes published behaviour

## Verification

- `pnpm check-exports` → 4 packages clean (was 2 failures on `main`)
- `pnpm dlx publint packages/core` → all good
- both `dist/rtl/index.{js,d.ts}` and `dist/import/index.{js,d.ts}` confirmed present in the build

The header comment listing CI steps is renumbered to match.