### PR TITLE
refactor(core): collapse duplicate NumericSequentialState into one declaration

### DIFF
--- a/apps/web/content/docs/known-issues.mdx
+++ b/apps/web/content/docs/known-issues.mdx
@@ -126,3 +126,9 @@ This is a safety net for **combinational feedback loops with no register breakin
 
 **How to recognize it:** an internal port reads 0 even when wiring and logic say otherwise. **Workaround:** expose the value you need as a top-level output of the circuit under test (wrap it in a probe harness with the signal piped out).
 
+### Buses wider than 32 bits don't simulate
+
+The numeric engine stores every net in an `Int32Array` and evaluates with JavaScript bitwise operators — both 32-bit. A bus wider than 32 bits simulates to wrong values with no error: inputs truncate to their low 32 bits, a `Slice` at offset ≥ 32 aliases back to the low bits (JS shift counts wrap mod 32), and wide `Concat`/arithmetic overflow to 0. Export, import, and FPGA synthesis are unaffected — they carry the full width; only the in-engine simulator has the ceiling.
+
+**How to recognize it:** a circuit with a port or internal net wider than 32 bits (a 512-bit input, a 64-bit datapath) reads plausible-but-wrong values — or 0 — from `simulate()` / `verify_circuit`, while its exported Verilog checks out. Quick tell: a `Slice` at offset 32 returns the same bits as the same slice at offset 0. This is why imports of wide-bus designs (e.g. a matrix-vector unit) lift and export fine but can't be run through the TS simulator. **Workaround:** none in-engine — keep simulated buses ≤ 32 bits (split wide datapaths into ≤ 32-bit lanes), or verify wide designs through the Verilog path (export and cross-check against Icarus Verilog) instead of the TS simulator. A real fix means representing wide nets as `BigInt` or word arrays through the engine and evaluators.
+

--- a/packages/core/src/simulator/evaluators/index.ts
+++ b/packages/core/src/simulator/evaluators/index.ts
@@ -24,5 +24,6 @@ import type { NumericEvaluator } from './types.js';
 const maxIndex = Math.max(...Object.values(PRIMITIVE_TYPE_INDICES)) + 1;
 export const EVALUATORS: (NumericEvaluator | null)[] = new Array(maxIndex).fill(null);
 
-export type { EvalContext, NumericEvaluator, NumericSequentialState } from './types.js';
+export type { NumericSequentialState } from '../numeric-types.js';
+export type { EvalContext, NumericEvaluator } from './types.js';
 export { readInput, writeOutput } from './types.js';

--- a/packages/core/src/simulator/evaluators/types.ts
+++ b/packages/core/src/simulator/evaluators/types.ts
@@ -5,29 +5,9 @@
  * the evaluator table. No Map allocations in the hot path.
  */
 
-import type { PrimitiveState } from '../../types/simulator.js';
 import type { NumericEventQueue } from '../numeric-event-queue.js';
-import type { NumericCircuit } from '../numeric-types.js';
+import type { NumericCircuit, NumericSequentialState } from '../numeric-types.js';
 import type { NumericPortValues } from '../numeric-values.js';
-
-/**
- * Numeric sequential state for fast simulation.
- * Uses arrays indexed by node index for O(1) access.
- * Memory components still use Map for sparse storage.
- */
-export interface NumericSequentialState {
-  /** Current state values indexed by node index */
-  currentState: (PrimitiveState | undefined)[];
-
-  /** Next state values indexed by node index */
-  nextState: (PrimitiveState | undefined)[];
-
-  /** Clock state for each clock (indexed by clock key string) */
-  clocks: Map<string, { value: boolean; edge: 'rising' | 'falling' | 'none' }>;
-
-  /** Cycle count */
-  cycleCount: number;
-}
 
 /**
  * Evaluation context passed to all evaluators.


### PR DESCRIPTION
## What

`NumericSequentialState` was declared twice, identically, in `simulator/numeric-types.ts` and `simulator/evaluators/types.ts`. Both were live — it was a producer/consumer split rather than a dead copy:

- **`numeric-types.ts`** — the producer. Built by `createNumericSequentialState()`, threaded through `propagate.ts` and `simulator/index.ts` (18 references across three files).
- **`evaluators/types.ts`** — the consumer. Used once, to type `EvalContext.state`, the field every evaluator reads.

They meet at `propagate.ts:92` (`state: seqState`) and `trace.ts:51`, where a producer-typed object is assigned into a consumer-typed field. It compiles only because the two shapes are byte-identical.

TS does catch incompatible drift at that assignment, so this isn't a landmine — additive changes are the case that slips through (a field added to the producer's copy is simply invisible to evaluators). Mostly it's duplication with no upside and a muddled ownership story: two files each claiming to define the state contract.

## Changes

- delete the declaration in `evaluators/types.ts`, import it from `../numeric-types.js`
- drop the now-unused `PrimitiveState` import
- `evaluators/index.ts` re-exports from the real source, so the public surface is unchanged

## Verification

- `pnpm -r exec tsc --noEmit` clean across the workspace
- `pnpm lint` — 590 warnings, identical to the pre-existing baseline, 0 errors
- core tests: 665 passed, 5 expected-fail, 35 skipped
- type still emitted in `dist/simulator/*.d.ts`

No changeset — nothing consumer-visible changed.