### PR TITLE
refactor(core): make propagation tracing reachable, drop the pc_lo debug block

### DIFF
--- a/packages/core/src/simulator/__tests__/debug-state-update.test.ts
+++ b/packages/core/src/simulator/__tests__/debug-state-update.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression: `setDebugStateUpdate` must stay reachable from the simulator
+ * barrel.
+ *
+ * The propagation tracing it gates is the only view into a circuit once
+ * elaboration has flattened it to typed arrays — but the setter was exported
+ * from propagate.ts and never re-exported from simulator/index.ts, so nothing
+ * outside that module could flip the flag. The tracing existed and could not
+ * be switched on by anyone.
+ *
+ * Importing through '../index.js' here (not '../propagate.js') is the point:
+ * it is the barrel re-export that regressed, and only a barrel import catches
+ * that.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { bit, circuit } from '../../circuit/index.js';
+import { simulate } from '../../sim/index.js';
+import { Register } from '../../std/index.js';
+import { setDebugStateUpdate } from '../index.js';
+
+const Dut = circuit('DebugFlagDut', {
+  inputs: { d: bit, we: bit },
+  outputs: { q: bit },
+  nodes: { r: Register({ width: 1 }) },
+  connect: ({ inputs, outputs, nodes: { r } }) => [
+    inputs.d.to(r.data),
+    inputs.we.to(r.we),
+    r.q.to(outputs.q),
+  ],
+});
+
+function tickCapturingLogs(): string[] {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const h = simulate(Dut);
+  try {
+    h.set({ d: 1, we: 1 });
+    h.tick();
+    return spy.mock.calls.map((args) => String(args[0]));
+  } finally {
+    h.dispose();
+    spy.mockRestore();
+  }
+}
+
+describe('setDebugStateUpdate', () => {
+  afterEach(() => {
+    setDebugStateUpdate(false);
+  });
+
+  it('is reachable from the simulator barrel', () => {
+    expect(typeof setDebugStateUpdate).toBe('function');
+  });
+
+  it('emits no propagation tracing when off (the default)', () => {
+    expect(tickCapturingLogs()).toEqual([]);
+  });
+
+  it('emits seed and propagate tracing when on', () => {
+    setDebugStateUpdate(true);
+    const logs = tickCapturingLogs();
+    expect(logs.some((l) => l.includes('[seedInitialQueue]'))).toBe(true);
+    expect(logs.some((l) => l.includes('[propagate]'))).toBe(true);
+  });
+
+  it('stops tracing again once turned off', () => {
+    setDebugStateUpdate(true);
+    expect(tickCapturingLogs().length).toBeGreaterThan(0);
+    setDebugStateUpdate(false);
+    expect(tickCapturingLogs()).toEqual([]);
+  });
+});

--- a/packages/core/src/simulator/index.ts
+++ b/packages/core/src/simulator/index.ts
@@ -177,6 +177,7 @@ export {
   propagateToTopLevelOutputs,
   seedInitialQueue,
   seedStateOutputNodes,
+  setDebugStateUpdate,
   toFlatPortValueMap,
   updateClockStates,
   updateSequentialStates,

--- a/packages/core/src/simulator/propagate.ts
+++ b/packages/core/src/simulator/propagate.ts
@@ -244,8 +244,27 @@ export function updateClockStates(
   }
 }
 
-// Debug flag - set to true to enable state update logging
 let DEBUG_STATE_UPDATE = false;
+
+/**
+ * Enable propagation tracing on stderr. Off by default.
+ *
+ * Answers the two questions you need when an output is stale or a register
+ * won't update, neither of which is visible once the circuit has been
+ * flattened to typed arrays:
+ *
+ *   [seedInitialQueue] Seeded 47 nodes (source=12, stateOutput=8, topLevel=27)
+ *   [propagate] 312 evals, 89 changed
+ *
+ * The seed line is the one that catches silent staleness: propagation is
+ * event-driven, so a node that is never seeded and never enqueued by a
+ * changed dependency simply doesn't run. The eval/changed counts show
+ * whether a pass converged — a `changed` that stays high across passes is
+ * oscillation heading for MAX_PROPAGATION_ITERATIONS.
+ *
+ * Global and not thread-safe; intended for a failing test or a one-off
+ * script, not production code.
+ */
 export function setDebugStateUpdate(enabled: boolean) {
   DEBUG_STATE_UPDATE = enabled;
 }
@@ -286,19 +305,7 @@ export function updateSequentialStates(
           }
         }
       } else if (srcPortIdx >= 0) {
-        const value = values.values[srcPortIdx];
-        inputs.set(portName, value);
-
-        // Debug logging
-        if (
-          DEBUG_STATE_UPDATE &&
-          node.id.includes('pc_lo') &&
-          !node.id.includes('temp') &&
-          portName === 'data'
-        ) {
-          const srcKey = circuit.indexToPortKey[srcPortIdx];
-          console.log(`  [data input] srcPortIdx=${srcPortIdx}, srcKey=${srcKey}, value=${value}`);
-        }
+        inputs.set(portName, values.values[srcPortIdx]);
       }
     }
 


### PR DESCRIPTION
## What

`propagate.ts` has propagation tracing behind a `DEBUG_STATE_UPDATE` flag, with a `setDebugStateUpdate()` setter to flip it. The setter was exported from `propagate.ts` but never re-exported from `simulator/index.ts`, and nothing anywhere called it — so the flag was a `let` initialised to `false` that no caller could change. The tracing existed and could not be switched on.

Turning it on meant editing `propagate.ts`, rebuilding core, running, and reverting.

## Why the tracing is worth having

After `elaborate()` + `compileForSimulation()`, the circuit is integer indices into typed arrays — no component objects, no signal names. When an output is stale or a register won't update, these two lines are the view in:

```
[seedInitialQueue] Seeded 47 nodes (source=12, stateOutput=8, topLevel=27)
[propagate] 312 evals, 89 changed
```

The seed line catches silent staleness: propagation is event-driven, so a node that is never seeded and never enqueued by a changed dependency just doesn't run. The counts show whether a pass converged — a `changed` that stays high is oscillation heading for `MAX_PROPAGATION_ITERATIONS`.

This is the gap you hit whenever `fpga:verify` or `verify_circuit` reports a divergence and the next question is "which node stopped propagating".

## Changes

- re-export `setDebugStateUpdate` from `simulator/index.ts` so it can actually be called
- document what the flag is for and that it is global / not thread-safe
- delete the third debug block: it fired only for node ids containing `pc_lo`, excluding `temp`, on a port named `data` — one RV32I bring-up breakpoint hardcoded into the engine that runs every circuit. The two generic counters stay.

## Verification

- new `debug-state-update.test.ts` — asserts silence when off, `[seedInitialQueue]` + `[propagate]` when on, silence again after. It imports through `../index.js` rather than `../propagate.js` on purpose, since the barrel re-export is what regressed. Confirmed it fails (4/4) when the barrel export is removed.
- exercised end-to-end against a real `simulate()` handle before writing the test
- core suite: 669 passed, 5 expected-fail, 35 skipped
- `tsc --noEmit` clean workspace-wide; `pnpm lint` at the unchanged 590-warning baseline

No changeset: `setDebugStateUpdate` becoming reachable is additive, and nothing existing changes shape.