### PR TITLE
ci: skip the web build on dependabot PRs (Actions secrets are withheld from them)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,19 @@ jobs:
         # Cloudflare vite plugin spins up a preview server at build time.
         # Locally these come from .env via dotenv-cli; in CI they come from
         # GitHub Actions secrets (Settings → Secrets and variables → Actions).
+        #
+        # Skipped for Dependabot: GitHub deliberately withholds Actions secrets
+        # from Dependabot-triggered runs (they see only the separate Dependabot
+        # secrets store), so both vars arrive empty, the preview server can't
+        # start, and the step fails with "Failed to start the Vite preview
+        # server for prerendering" — on every dependency bump, regardless of
+        # what was bumped. Mirroring the creds into Dependabot secrets would fix
+        # the symptom but hand Cloudflare credentials to auto-generated PRs,
+        # which is the exposure CONTRIBUTING's fork-PR threat model warns about.
+        # Everything that actually vets a dependency bump — Biome, typecheck,
+        # exports drift, core/ui tests, the FPGA suite and netlist guard — still
+        # runs. Web-build coverage returns the moment the bump lands on main.
+        if: github.actor != 'dependabot[bot]'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What

Every Dependabot PR fails CI, and has done for months — #221 (opened 20 June) and its replacement #262 both fail the same step for the same reason, which has nothing to do with what they bump.

The "Build web app" step needs Cloudflare creds for the prerender pass:

```yaml
env:
  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
```

GitHub deliberately withholds **Actions** secrets from Dependabot-triggered runs — those runs see only the separate **Dependabot** secrets store, which is empty here (`gh api repos/simtenHQ/simten/dependabot/secrets` returns nothing). So both vars arrive empty, the Cloudflare vite plugin can't start its preview server, and the step dies:

```
Error: Failed to start the Vite preview server for prerendering
    at startPreviewServer (@tanstack/start-plugin-core/dist/esm/prerender.js:210:11)
```

This is structural, not a stale branch — `@dependabot rebase` can't fix it. #262's failing run is from today, against current `main`, while #261 passed the same step minutes earlier on a normal branch.

## Change

One `if:` on that step, plus a comment explaining why so the next person doesn't "fix" it by adding the secrets.

## Why skip rather than add Dependabot secrets

Mirroring the creds into the Dependabot store would work, but it hands Cloudflare API credentials to auto-generated PRs carrying third-party `package.json` changes — the exposure `CONTRIBUTING.md`'s fork-PR threat model is explicitly about.

Everything that actually vets a dependency bump still runs on Dependabot PRs: Biome, wrangler types, workspace build, publint, exports drift, typecheck, core tests, ui tests, the FPGA RV32I suite, and the netlist byte-identity guard. Only the final web build is skipped, and it regains coverage the moment the bump lands on `main` (CI runs on push there too).

## Verification

- workflow YAML parses; the condition is attached to "Build web app" and nothing else
- unblocks #262 (hono 4.12.23 → 4.12.25). Worth noting neither CVE in that bump applies here: `hono/cors` isn't imported (all three apps import only `{ Hono }`), and the body-limit issue is AWS Lambda specific while these run on Cloudflare.