### PR TITLE
refactor(core): rename the authoring StateValue to StateFieldValue

### DIFF
--- a/packages/core/src/circuit/types.ts
+++ b/packages/core/src/circuit/types.ts
@@ -140,8 +140,17 @@ export type PortValues<M> = {
   [K in keyof M]: number;
 };
 
-/** State value types: number (bus), boolean (bit), Map (memory), string (text buffers), or new declarative types */
-export type StateValue =
+/**
+ * What a `state:` field may hold as authored — number (bus), boolean (bit),
+ * Map (memory), string (text buffers), or a declarative `reg()` / `mem()`.
+ *
+ * Distinct from the `StateValue` in ../types/circuit.ts, which is the same
+ * concept *after* elaboration into the serialized IR: there, memory is a
+ * `MemoryValue` carrying its address/data widths rather than a bare Map, and
+ * the declarative forms have already been resolved. circuit() converts this
+ * into that. Pairs with `StateFieldType` in ./bit-bus.ts.
+ */
+export type StateFieldValue =
   | number
   | boolean
   | Map<number, number>
@@ -150,7 +159,7 @@ export type StateValue =
   | import('./bit-bus.js').MemState;
 
 /** State shape — plain object where each field is a state value */
-export type StateShape = Record<string, StateValue>;
+export type StateShape = Record<string, StateFieldValue>;
 
 // ============================================================================
 // Component metadata


### PR DESCRIPTION
## What

Two exported types named `StateValue` described the same concept at different pipeline stages:

- `circuit/types.ts` — what a `state:` field holds **as authored**: memory is a bare `Map<number, number>`, plus the declarative `reg()` / `mem()` forms
- `types/circuit.ts` — the same thing **after elaboration into the IR**: memory is a `MemoryValue` carrying its address/data widths, declarative forms already resolved

Both are correct; `circuit()` converts the first into the second. The problem was only the shared name. Inside `packages/core` an auto-import picked one of the two, and since they overlap on `boolean | number | string`, a wrong pick compiled fine until it reached memory — failing well away from the import that caused it.

## Scope

Smaller than it sounds. The authoring one had exactly **one** referent (`StateShape = Record<string, StateValue>`) and was never exported — only `StateShape` is, from `@simten/core/circuit`. The IR `StateValue` is the only one a consumer can import, via `@simten/core` and `@simten/core/simulator`, and is untouched.

So this is a one-line rename plus a doc comment explaining the distinction, so the next person doesn't try to merge the two.

`StateFieldValue` pairs with the existing `StateFieldType = RegState | MemState` in `circuit/bit-bus.ts`.

## Verification

- `tsc --noEmit` clean workspace-wide
- `pnpm lint` at the unchanged 590-warning baseline
- core suite: 669 passed, 5 expected-fail, 35 skipped
- `pnpm check-exports` → 4 packages clean
- `@simten/ui` builds; its generated Monaco type bundle regenerates cleanly (gitignored, so nothing to commit)
- emitted `dist/circuit/types.d.ts` shows `StateShape = Record<string, StateFieldValue>` as expected

No changeset: nothing consumer-visible changed — the renamed type was never part of the published surface.