### PR TITLE
feat(ui): scaffold snippets for circuit source in the Monaco editor

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -100,6 +100,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["**/monaco/snippets.ts", "**/monaco/snippets.test.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noTemplateCurlyInString": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/ui/src/monaco/index.ts
+++ b/packages/ui/src/monaco/index.ts
@@ -25,6 +25,12 @@ export {
 } from './SimtenCodeEditor';
 export { type IntellisenseOptions, setupSimtenIntellisense } from './setup';
 export {
+  registerSimtenSnippets,
+  SIMTEN_SNIPPETS,
+  type SimtenSnippet,
+  type SnippetOptions,
+} from './snippets';
+export {
   type RegisterThemesOptions,
   registerSimtenThemes,
   SIMTEN_DARK,

--- a/packages/ui/src/monaco/setup.ts
+++ b/packages/ui/src/monaco/setup.ts
@@ -30,6 +30,7 @@
 
 import type { Monaco } from '@monaco-editor/react';
 import { SIMTEN_CORE_GLOBALS, SIMTEN_CORE_TYPES } from './generated/core-types.gen';
+import { registerSimtenSnippets } from './snippets';
 
 /**
  * Importable `@simten/core` subpaths. The bundle is a flat aggregate of all of
@@ -67,6 +68,13 @@ export interface IntellisenseOptions {
    * `file:///node_modules/<pkg>/index.d.ts` path to make a module resolvable.
    */
   extraLibs?: Record<string, string>;
+  /**
+   * Offer the scaffold snippets (`circuit`, `circuit-primitive`, ...). These are
+   * the one thing the TS service can't derive: it already knows a node's ports
+   * and which refs carry `.to()`, but not the shape of an empty circuit.
+   * @default true
+   */
+  snippets?: boolean;
 }
 
 /**
@@ -74,7 +82,7 @@ export interface IntellisenseOptions {
  * Safe to call more than once — addExtraLib overwrites by path.
  */
 export function setupSimtenIntellisense(monaco: Monaco, options: IntellisenseOptions = {}): void {
-  const { globals = true, extraLibs } = options;
+  const { globals = true, extraLibs, snippets = true } = options;
   const ts = monaco.languages.typescript;
   const defaults = ts.typescriptDefaults;
 
@@ -112,4 +120,8 @@ export function setupSimtenIntellisense(monaco: Monaco, options: IntellisenseOpt
   for (const [path, contents] of Object.entries(extraLibs ?? {})) {
     defaults.addExtraLib(contents, path);
   }
+
+  // Idempotent per Monaco instance — unlike addExtraLib, a second
+  // registerCompletionItemProvider would list every snippet twice.
+  if (snippets) registerSimtenSnippets(monaco);
 }

--- a/packages/ui/src/monaco/snippets.test.ts
+++ b/packages/ui/src/monaco/snippets.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Snippet bodies are strings, not TypeScript, so nothing type-checks them — a
+ * stray brace or a mismatched tabstop default only shows up as a mangled
+ * insertion when a user triggers the snippet. These tests are that check, run
+ * against the data rather than a live Monaco (which would need a DOM).
+ *
+ * The subtle one is tabstop-default consistency. A repeated tabstop is a linked
+ * edit: `${1:MyCircuit}` in two places means typing the name once fills both.
+ * If the two occurrences carry *different* defaults, Monaco picks one and the
+ * scaffold silently disagrees with itself — the exact thing these snippets exist
+ * to prevent.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SIMTEN_SNIPPETS } from './snippets';
+
+/** Placeholder defaults per tabstop index, brace-matched so nesting survives. */
+function tabstopDefaults(body: string): Map<number, string[]> {
+  const found = new Map<number, string[]>();
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] !== '$' || body[i + 1] !== '{') continue;
+    const m = /^\$\{(\d+)[:}]/.exec(body.slice(i));
+    if (!m) continue;
+    const index = Number(m[1]);
+    let depth = 0;
+    let end = i + 1;
+    for (; end < body.length; end++) {
+      if (body[end] === '{') depth++;
+      else if (body[end] === '}' && --depth === 0) break;
+    }
+    const inner = body.slice(i + 2 + m[1].length, end);
+    const list = found.get(index) ?? [];
+    list.push(inner.startsWith(':') ? inner.slice(1) : '');
+    found.set(index, list);
+    i = i + 1 + m[1].length;
+  }
+  return found;
+}
+
+/** All tabstop indices, including bare `$0` / `$1` forms. */
+function tabstopIndices(body: string): Set<number> {
+  const out = new Set<number>();
+  for (const m of body.matchAll(/\$\{(\d+)[:}]/g)) out.add(Number(m[1]));
+  for (const m of body.matchAll(/\$(\d+)(?!\w)/g)) out.add(Number(m[1]));
+  return out;
+}
+
+/** Expand a snippet to the text a user gets if they tab straight through. */
+function expand(body: string): string {
+  let prev: string;
+  let text = body;
+  do {
+    prev = text;
+    text = text.replace(/\$\{(\d+):([^{}]*)\}/g, '$2');
+  } while (text !== prev);
+  return text.replace(/\$\{\d+\}/g, '').replace(/\$\d+(?!\w)/g, '');
+}
+
+const balanced = (s: string) => {
+  const pairs: Record<string, string> = { ')': '(', ']': '[', '}': '{' };
+  const stack: string[] = [];
+  let inString: string | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inString) {
+      if (c === inString && s[i - 1] !== '\\') inString = null;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') inString = c;
+    else if ('([{'.includes(c)) stack.push(c);
+    else if (')]}'.includes(c) && stack.pop() !== pairs[c]) return false;
+  }
+  return stack.length === 0 && inString === null;
+};
+
+describe('snippet catalogue', () => {
+  it('has unique labels', () => {
+    const labels = SIMTEN_SNIPPETS.map((s) => s.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it('describes every snippet', () => {
+    for (const s of SIMTEN_SNIPPETS) {
+      expect(s.detail.length, `${s.label} detail`).toBeGreaterThan(0);
+      expect(s.documentation.length, `${s.label} documentation`).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe.each(SIMTEN_SNIPPETS.map((s) => [s.label, s] as const))('%s', (label, snippet) => {
+  const body = snippet.body.join('\n');
+
+  it('places the final cursor with $0', () => {
+    expect(tabstopIndices(body).has(0), `${label} has no $0`).toBe(true);
+  });
+
+  it('numbers tabstops contiguously from 1', () => {
+    const stops = [...tabstopIndices(body)].filter((n) => n !== 0).sort((a, b) => a - b);
+    expect(stops, `${label} tabstops should be 1..${stops.length}`).toEqual(
+      stops.map((_, i) => i + 1),
+    );
+  });
+
+  it('gives every repeated tabstop the same default (linked edits must agree)', () => {
+    for (const [index, defaults] of tabstopDefaults(body)) {
+      const distinct = new Set(defaults.filter((d) => d !== ''));
+      expect(
+        distinct.size,
+        `${label} $${index} has conflicting defaults: ${[...distinct]}`,
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('expands to balanced source', () => {
+    expect(balanced(expand(body)), `${label} expands unbalanced:\n${expand(body)}`).toBe(true);
+  });
+
+  it('indents with spaces only', () => {
+    expect(body).not.toMatch(/\t/);
+  });
+
+  it('opens with an export so a testbench can import it', () => {
+    expect(body.startsWith('export const ')).toBe(true);
+  });
+});

--- a/packages/ui/src/monaco/snippets.ts
+++ b/packages/ui/src/monaco/snippets.ts
@@ -89,24 +89,6 @@ export const SIMTEN_SNIPPETS: readonly SimtenSnippet[] = [
       '});',
     ],
   },
-  {
-    label: 'circuit-factory',
-    detail: 'Parameterised circuit (width, etc.)',
-    documentation:
-      'The factory form: `circuit(name, opts => config)` returns a callable you specialise ' +
-      'at the use site — `MyComponent({ width: 16 })`. Per-instance arguments are recorded ' +
-      'on the node, so instances do not share state.',
-    body: [
-      'export const ${1:MyComponent} = circuit(',
-      "  '${1:MyComponent}',",
-      '  ({ width = ${2:8} }: { width?: number } = {}) => ({',
-      '    inputs: { ${3:a}: bus(width) },',
-      '    outputs: { ${4:out}: bus(width) },',
-      '    eval: ({ ${3:a} }) => ({ ${4:out}: ${0:${3:a}} }),',
-      '  }),',
-      ');',
-    ],
-  },
 ];
 
 /** Languages the provider registers against. */

--- a/packages/ui/src/monaco/snippets.ts
+++ b/packages/ui/src/monaco/snippets.ts
@@ -1,0 +1,174 @@
+/**
+ * Snippet completions for Simten circuit source.
+ *
+ * The TypeScript service already handles the parts that need type knowledge:
+ * `nodes.xor1.` lists that component's ports (ConnectArg is a mapped type over
+ * each node's shape), and `.to()` is only offered on source refs (SourcePortRef
+ * carries a brand the sink type lacks). What it cannot do is produce the
+ * scaffold — the six-key object literal every circuit opens with, where the
+ * circuit's name appears twice and every node name is written once in `nodes`
+ * and again in the `connect` destructure.
+ *
+ * These snippets are that scaffold. Repeated tabstops (`${1:...}` used more than
+ * once) are linked edits in Monaco, so typing the circuit name once fills both
+ * places, and a node name typed in `nodes` appears in the destructure as you go.
+ *
+ * Kept as plain data so the bodies can be validated without a DOM or a Monaco
+ * instance — see `snippets.test.ts`.
+ */
+
+import type { Monaco } from '@monaco-editor/react';
+import type { editor, Position } from 'monaco-editor';
+
+export interface SimtenSnippet {
+  /** Typed to trigger the completion. */
+  label: string;
+  /** One-line grey text beside the label in the suggest widget. */
+  detail: string;
+  /** Markdown shown in the expanded documentation pane. */
+  documentation: string;
+  /**
+   * Snippet body, newline-joined on registration. `${1:default}` is a tabstop
+   * pre-filled with `default`; repeating an index makes those positions a
+   * linked edit; `$0` is where the cursor lands last.
+   */
+  body: string[];
+}
+
+export const SIMTEN_SNIPPETS: readonly SimtenSnippet[] = [
+  {
+    label: 'circuit',
+    detail: 'Composite circuit (nodes + connect)',
+    documentation:
+      'A circuit built by wiring components together. The name is a linked edit — ' +
+      'type it once and both occurrences update. Node names likewise appear in both ' +
+      '`nodes` and the `connect` destructure.',
+    body: [
+      "export const ${1:MyCircuit} = circuit('${1:MyCircuit}', {",
+      '  inputs: { ${2:a}: ${3:bit}, ${4:b}: ${3:bit} },',
+      '  outputs: { ${5:out}: ${3:bit} },',
+      '  nodes: { ${6:g1}: ${7:And} },',
+      '  connect: ({ inputs, outputs, nodes: { ${6:g1} } }) => [',
+      '    inputs.${2:a}.to(${6:g1}.a),',
+      '    inputs.${4:b}.to(${6:g1}.b),',
+      '    ${6:g1}.out.to(outputs.${5:out}),$0',
+      '  ],',
+      '});',
+    ],
+  },
+  {
+    label: 'circuit-primitive',
+    detail: 'Primitive circuit (eval, no nodes)',
+    documentation:
+      'A leaf component whose behaviour is a function rather than a wiring diagram. ' +
+      '`eval` receives inputs by port name and returns outputs by port name. ' +
+      'Only primitives carry executable behaviour; composites expand into them at elaboration.',
+    body: [
+      "export const ${1:MyGate} = circuit('${1:MyGate}', {",
+      '  inputs: { ${2:a}: bit, ${3:b}: bit },',
+      '  outputs: { ${4:out}: bit },',
+      '  eval: ({ ${2:a}, ${3:b} }) => ({ ${4:out}: ${0:${2:a} & ${3:b}} }),',
+      "  meta: { category: '${5:logic}', description: '${6:What it does}' },",
+      '});',
+    ],
+  },
+  {
+    label: 'circuit-sequential',
+    detail: 'Sequential primitive (state + onTick)',
+    documentation:
+      'A primitive that holds state. Declaring `state` is what makes a circuit sequential — ' +
+      'there is no flag and no clock port. Every stateful element shares the one implicit ' +
+      'clock, so `onTick` runs on each `tick()` and returns the next state.',
+    body: [
+      "export const ${1:MyRegister} = circuit('${1:MyRegister}', {",
+      '  inputs: { ${2:d}: bus(${3:8}), we: bit },',
+      '  outputs: { ${4:q}: bus(${3:8}) },',
+      '  state: { ${5:value}: reg(${3:8}) },',
+      '  eval: ({ ${5:value} }) => ({ ${4:q}: ${5:value} }),',
+      '  onTick: ({ ${2:d}, we, ${5:value} }) => ({ ${5:value}: we ? ${2:d} : ${5:value} }),$0',
+      '});',
+    ],
+  },
+  {
+    label: 'circuit-factory',
+    detail: 'Parameterised circuit (width, etc.)',
+    documentation:
+      'The factory form: `circuit(name, opts => config)` returns a callable you specialise ' +
+      'at the use site — `MyComponent({ width: 16 })`. Per-instance arguments are recorded ' +
+      'on the node, so instances do not share state.',
+    body: [
+      'export const ${1:MyComponent} = circuit(',
+      "  '${1:MyComponent}',",
+      '  ({ width = ${2:8} }: { width?: number } = {}) => ({',
+      '    inputs: { ${3:a}: bus(width) },',
+      '    outputs: { ${4:out}: bus(width) },',
+      '    eval: ({ ${3:a} }) => ({ ${4:out}: ${0:${3:a}} }),',
+      '  }),',
+      ');',
+    ],
+  },
+];
+
+/** Languages the provider registers against. */
+const LANGUAGES = ['typescript', 'javascript'] as const;
+
+const REGISTERED = new WeakSet<object>();
+
+export interface SnippetOptions {
+  /**
+   * Register even if this Monaco instance already has the provider. Off by
+   * default: `beforeMount` can fire more than once for the same instance, and
+   * unlike `addExtraLib` (which overwrites by path) each registration adds
+   * another provider, so every snippet would appear twice in the suggest list.
+   */
+  force?: boolean;
+}
+
+/**
+ * Register Simten's scaffold snippets on a Monaco instance.
+ *
+ * Idempotent per instance unless `force` is set. Returns a disposable for
+ * callers that own the editor lifecycle; ignoring it is fine for the common
+ * case where Monaco outlives the component.
+ */
+export function registerSimtenSnippets(
+  monaco: Monaco,
+  options: SnippetOptions = {},
+): { dispose(): void } {
+  if (!options.force && REGISTERED.has(monaco)) return { dispose() {} };
+  REGISTERED.add(monaco);
+
+  const { CompletionItemKind, CompletionItemInsertTextRule } = monaco.languages;
+
+  const disposables = LANGUAGES.map((language) =>
+    monaco.languages.registerCompletionItemProvider(language, {
+      provideCompletionItems(model: editor.ITextModel, position: Position) {
+        const word = model.getWordUntilPosition(position);
+        const range = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
+        };
+        return {
+          suggestions: SIMTEN_SNIPPETS.map((s) => ({
+            label: s.label,
+            kind: CompletionItemKind.Snippet,
+            detail: s.detail,
+            documentation: { value: s.documentation },
+            insertText: s.body.join('\n'),
+            insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
+            range,
+          })),
+        };
+      },
+    }),
+  );
+
+  return {
+    dispose() {
+      REGISTERED.delete(monaco);
+      for (const d of disposables) d.dispose();
+    },
+  };
+}


### PR DESCRIPTION
## What

Four snippet completions in the editor: `circuit`, `circuit-primitive`, `circuit-sequential`, `circuit-factory`.

## Why these and not more

The TypeScript service already covers the parts that need type knowledge, and it does it well:

- `nodes.xor1.` lists that component's ports, because `ConnectArg<Ins, Outs, Nodes>` is a mapped type over each node's shape
- `.to()` is only offered on source refs, because `SourcePortRef` carries a brand the sink type lacks — so direction safety shows up as completion behaviour, not just as an error
- typing `(` already auto-closes; Monaco's default `autoClosingBrackets` covers it

What it can't derive is the scaffold: the object literal every circuit opens with, where the name appears twice and each node is written once in `nodes` and again in the `connect` destructure. That repetition is the actual friction, so that's what these do.

Repeated tabstops are linked edits, so the circuit name is typed once and fills both places, and a node name typed in `nodes` propagates into the destructure as you go.

Deliberately **not** included: a `.verify.ts` scaffold. Those are written through the MCP, not by hand in the editor.

## Wiring

`registerSimtenSnippets(monaco)` is called from `setupSimtenIntellisense`, gated on a new `snippets` option (default `true`), so `SimtenCodeEditor` picks it up with no change. Also exported from `@simten/ui/monaco` for headless users.

Registration is idempotent per Monaco instance. `beforeMount` can fire more than once, and unlike `addExtraLib` (which overwrites by path) a second `registerCompletionItemProvider` *adds* a provider — every snippet would appear twice in the suggest list. Returns a disposable for callers that own the lifecycle.

## Verification

Snippet bodies are strings, so nothing type-checks them — a stray brace or a mismatched tabstop shows up only as a mangled insertion. `snippets.test.ts` validates the data directly (26 tests, no DOM or Monaco needed):

- `$0` present; tabstops numbered contiguously from 1
- **repeated tabstops carry identical defaults** — the subtle one. Conflicting defaults on a linked edit mean Monaco picks one and the scaffold silently disagrees with itself
- each snippet expands to balanced source
- spaces only; every body opens with `export const` so a testbench can import it

I confirmed the tests aren't vacuous by breaking a linked-edit default in a scratch copy — it fails with `circuit $6 has conflicting defaults: gate1,g1`.

Suite: ui 116 passed, core 673 passed, typecheck clean, `check-exports` clean, lint back at the 590-warning baseline.

## The biome.json change

`lint/suspicious/noTemplateCurlyInString` fires on every snippet body — it exists to catch `"Hello ${name}"` where a backtick was meant, which is inherently wrong for a file whose whole content is `${1:...}` snippet syntax. Scoped `off` for the two snippet files rather than scattering ignore comments.