### PR TITLE
fix(core): redefining a primitive replaces its behaviour instead of being ignored

### DIFF
--- a/packages/core/src/circuit/eval-registry.ts
+++ b/packages/core/src/circuit/eval-registry.ts
@@ -23,10 +23,26 @@ export interface EvalEntry {
 
 const registry = new Map<string, EvalEntry>();
 
+/**
+ * Record a component's behaviour. Last definition wins.
+ *
+ * This used to keep the first registration and silently drop later ones, which
+ * made a redefined primitive un-editable: the browser editor re-executes source
+ * in the same realm, so this module-level Map survives a "reload", and changing
+ * `eval: ({a, b}) => ({out: a & b})` to `a ^ b` left the circuit still computing
+ * AND. Nothing surfaced the discrepancy — the source said one thing and the
+ * simulation did another.
+ *
+ * Overwriting means a circuit sharing a name with a stdlib component now shadows
+ * it for the rest of the session rather than being ignored. That is the more
+ * predictable of the two surprises: the definition you can see in front of you
+ * is the one that runs.
+ *
+ * Callers deriving caches from these entries must invalidate on identity change
+ * — see `ensureEvaluatorRegistered`.
+ */
 export function registerCircuitEval(name: string, entry: EvalEntry): void {
-  if (!registry.has(name)) {
-    registry.set(name, entry);
-  }
+  registry.set(name, entry);
 }
 
 export function getCircuitEval(name: string): EvalEntry | undefined {

--- a/packages/core/src/simulator/__tests__/redefine-primitive.test.ts
+++ b/packages/core/src/simulator/__tests__/redefine-primitive.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Redefining a primitive replaces its behaviour.
+ *
+ * Component behaviour is cached in two places keyed by name: the eval-registry
+ * (written by `circuit()` at definition time) and the compiled EVALUATORS table
+ * (built from a registry entry at compile time). Both used to keep the *first*
+ * value for a given name and silently drop later ones.
+ *
+ * That is invisible in a normal build — each name is defined once — but the
+ * browser editor re-executes source in the same realm, so these module-level
+ * caches survive a re-run. Editing `eval: ({a, b}) => ({out: a & b})` to
+ * `a ^ b` left the circuit computing AND, with the source on screen disagreeing
+ * with the simulation and nothing reporting a conflict.
+ *
+ * `onTick` had the same problem through its own cache, so the sequential case
+ * is covered too.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { bit, bus, circuit, reg } from '../../circuit/index.js';
+import { simulate } from '../../sim/index.js';
+import '../../std/index.js';
+
+function evaluate(
+  built: Parameters<typeof simulate>[0],
+  inputs: Record<string, number>,
+  output: string,
+  ticks = 0,
+) {
+  const sim = simulate(built);
+  try {
+    sim.set(inputs);
+    for (let i = 0; i < ticks; i++) sim.tick();
+    return sim.get(output);
+  } finally {
+    sim.dispose();
+  }
+}
+
+describe('redefining a primitive under the same name', () => {
+  it('uses the new eval, not the first one registered', () => {
+    const asAnd = circuit('RedefEvalGate', {
+      inputs: { a: bit, b: bit },
+      outputs: { out: bit },
+      eval: ({ a, b }) => ({ out: a & b }),
+    });
+    expect(evaluate(asAnd, { a: 1, b: 0 }, 'out')).toBe(0);
+    expect(evaluate(asAnd, { a: 1, b: 1 }, 'out')).toBe(1);
+
+    const asXor = circuit('RedefEvalGate', {
+      inputs: { a: bit, b: bit },
+      outputs: { out: bit },
+      eval: ({ a, b }) => ({ out: a ^ b }),
+    });
+    expect(evaluate(asXor, { a: 1, b: 0 }, 'out')).toBe(1);
+    expect(evaluate(asXor, { a: 1, b: 1 }, 'out')).toBe(0);
+  });
+
+  it('uses the new onTick, not the first one registered', () => {
+    const increment = circuit('RedefTickCounter', {
+      inputs: { unused: bus(8) },
+      outputs: { q: bus(8) },
+      state: { v: reg(8) },
+      eval: ({ v }) => ({ q: v }),
+      onTick: ({ v }) => ({ v: v + 1 }),
+    });
+    expect(evaluate(increment, { unused: 0 }, 'q', 3)).toBe(3);
+
+    const double = circuit('RedefTickCounter', {
+      inputs: { unused: bus(8) },
+      outputs: { q: bus(8) },
+      state: { v: reg(8, 1) },
+      eval: ({ v }) => ({ q: v }),
+      onTick: ({ v }) => ({ v: v * 2 }),
+    });
+    expect(evaluate(double, { unused: 0 }, 'q', 3)).toBe(8);
+  });
+
+  it('keeps a redefinition working when the port shape changes too', () => {
+    const oneBit = circuit('RedefWidth', {
+      inputs: { a: bit },
+      outputs: { out: bit },
+      eval: ({ a }) => ({ out: a }),
+    });
+    expect(evaluate(oneBit, { a: 1 }, 'out')).toBe(1);
+
+    const wide = circuit('RedefWidth', {
+      inputs: { a: bus(8) },
+      outputs: { out: bus(8) },
+      eval: ({ a }) => ({ out: (a << 1) & 0xff }),
+    });
+    expect(evaluate(wide, { a: 3 }, 'out')).toBe(6);
+  });
+
+  it('leaves an unrelated component alone', () => {
+    const stable = circuit('RedefBystander', {
+      inputs: { a: bit },
+      outputs: { out: bit },
+      eval: ({ a }) => ({ out: a ? 0 : 1 }),
+    });
+    expect(evaluate(stable, { a: 1 }, 'out')).toBe(0);
+
+    circuit('RedefOther', {
+      inputs: { a: bit },
+      outputs: { out: bit },
+      eval: ({ a }) => ({ out: a }),
+    });
+
+    expect(evaluate(stable, { a: 1 }, 'out')).toBe(0);
+    expect(evaluate(stable, { a: 0 }, 'out')).toBe(1);
+  });
+});

--- a/packages/core/src/simulator/eval-bridge.ts
+++ b/packages/core/src/simulator/eval-bridge.ts
@@ -14,6 +14,7 @@
  * 4. Write output object properties back to typed arrays by index
  */
 
+import type { EvalEntry } from '../circuit/eval-registry.js';
 import { getAllCircuitEvals, getCircuitEval } from '../circuit/eval-registry.js';
 import { EVALUATORS } from './evaluators/index.js';
 import type { EvalContext, NumericEvaluator } from './evaluators/types.js';
@@ -202,23 +203,38 @@ export function generateEvalWrapper(
 // ============================================================================
 
 /**
+ * The registry entry each compiled evaluator was built from, so a redefinition
+ * can be detected. Keyed by type index, matching EVALUATORS.
+ */
+const evaluatorSource = new Map<number, EvalEntry>();
+
+/**
  * Ensure the EVALUATORS table has an entry for the given component name.
  * Reads from the eval-registry (populated at circuit() definition time).
- * No-op if already registered or no eval exists for this name.
+ *
+ * The compiled wrapper closes over the entry's `evalFn`, so it has to be
+ * regenerated when that function changes — otherwise redefining a primitive
+ * (which the browser editor does on every re-run, in the same realm) leaves the
+ * old behaviour compiled in. Identity of the registry entry is the signal:
+ * `circuit()` builds a fresh object per definition, so a differing reference
+ * means the source changed. Same reference is the common case and still costs
+ * only a Map lookup, at compile time rather than per evaluation.
  */
 export function ensureEvaluatorRegistered(name: string): number {
   const idx = getOrAllocateTypeIndex(name);
 
-  // Already registered (static stdlib evaluator or previously resolved)
-  if (EVALUATORS[idx] != null) return idx;
-
   const entry = getCircuitEval(name);
   if (!entry) {
+    // Evaluators registered directly through registerEvalFunction have no
+    // registry entry; keep whatever is already compiled.
+    if (EVALUATORS[idx] != null) return idx;
     console.warn(`[eval-bridge] No eval-registry entry for '${name}' — getAllCircuitEvals:`, [
       ...(getAllCircuitEvals() as Map<string, any>).keys(),
     ]);
     return idx;
   }
+
+  if (EVALUATORS[idx] != null && evaluatorSource.get(idx) === entry) return idx;
 
   while (EVALUATORS.length <= idx) EVALUATORS.push(null);
   EVALUATORS[idx] = generateEvalWrapper(
@@ -227,6 +243,9 @@ export function ensureEvaluatorRegistered(name: string): number {
     entry.evalFn,
     entry.stateKeys,
   );
+  evaluatorSource.set(idx, entry);
+  // Derived from the same entry, so it is stale for the same reason.
+  onTickRegistry.delete(name);
 
   return idx;
 }


### PR DESCRIPTION
## The bug

Reported from the editor: change a primitive's `eval` from `a & b` to `a ^ b`, re-run, and the circuit still computes AND. Reproduced in twelve lines — same circuit name, new eval:

```
v1 (a & b) with a=1,b=0 -> 0   correct
v2 (a ^ b) with a=1,b=0 -> 0   still running a & b
```

The source on screen and the running simulation disagree, and nothing reports it.

## Cause

Component behaviour is cached by **name** in two places, and both kept the first value and silently dropped later ones:

- `circuit/eval-registry.ts` — `registerCircuitEval` guarded with `if (!registry.has(name))`
- `simulator/eval-bridge.ts` — `ensureEvaluatorRegistered` returned early on `EVALUATORS[idx] != null`, so the compiled wrapper (which closes over `evalFn`) was reused even once the registry was fixed

Invisible in a normal build, where each name is defined once. The editor re-executes source via `executeCircuitCode` — sucrase plus `new Function`, in the *same realm* — so these module-level caches survive what looks like a reload.

`onTick` had the same problem through `onTickRegistry`, so sequential primitives were affected too.

## Fix

`registerCircuitEval` now overwrites. `ensureEvaluatorRegistered` records which registry entry each compiled evaluator came from and regenerates when the reference differs — `circuit()` builds a fresh entry object per definition, so identity is the signal. It also drops the `onTickRegistry` line for that name, since it derives from the same entry.

Cost is one Map lookup at compile time, not per evaluation. Nothing changes in the propagate loop.

**Behavioural consequence worth a look:** a circuit sharing a name with a stdlib component now shadows it for the session instead of being ignored. I think that is the better of the two surprises — the definition in front of you is the one that runs — but it is a real change and you may disagree.

## Verification

- new `redefine-primitive.test.ts` — eval redefinition, onTick redefinition, redefinition that also changes port widths, and a bystander component staying put
- core 677 passed, ui 110 passed
- `fpga:test` 69/69, and **`fpga:netlist-check` still matches the golden** — RV32I elaborates byte-identically, which is the check I most wanted to see green for a change in this area
- lint at the 590-warning baseline, typecheck clean

## Left alone

`registerEvalFunction` and `registerOnTickFunction` (both marked "keep for backwards compat — simulate.ts still calls these") retain their first-wins guards. They take raw functions rather than registry entries, so there is no identity to compare, and they are not on the path this bug reports. Flagging rather than changing them.