### PR TITLE
fix(core): let eval return a boolean for 1-bit outputs

### DIFF
--- a/packages/core/src/circuit/__tests__/bit-output-booleans.test.ts
+++ b/packages/core/src/circuit/__tests__/bit-output-booleans.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `eval` may return a boolean for a 1-bit output.
+ *
+ * The runtime always accepted it — the value lands in a typed array, where
+ * `true`/`false` coerce to 1/0 — but `PortValues<Outs>` demanded a number, so
+ * the natural spelling of a NOR
+ *
+ *   eval: ({ a, b }) => ({ out: !(a | b) })
+ *
+ * simulated correctly while showing a red squiggle, and had to be written
+ * `(a | b) ? 0 : 1` to compile.
+ *
+ * The widening stops at one bit on purpose. The Verilog exporter emits JS `!`
+ * as `~` (see eval-synth), which matches logical negation at one bit and
+ * diverges above it — `!(2 | 0)` simulates to 0 while `~8'd2` is 253. So a
+ * boolean on a `bus` port stays a type error, and this file is where that
+ * intent is recorded: the tests below cover the runtime half, and `pnpm
+ * typecheck` covers the type half by compiling this file at all.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { simulate } from '../../sim/index.js';
+import { bit, bus } from '../bit-bus.js';
+import { circuit } from '../circuit.js';
+
+function evaluate(
+  built: Parameters<typeof simulate>[0],
+  inputs: Record<string, number>,
+  output: string,
+) {
+  const sim = simulate(built);
+  try {
+    sim.set(inputs);
+    return sim.get(output);
+  } finally {
+    sim.dispose();
+  }
+}
+
+describe('boolean returns on 1-bit outputs', () => {
+  it('coerces a negation to 1/0', () => {
+    const Nor = circuit('BoolNor', {
+      inputs: { a: bit, b: bit },
+      outputs: { out: bit },
+      eval: ({ a, b }) => ({ out: !(a | b) }),
+    });
+
+    expect(evaluate(Nor, { a: 0, b: 0 }, 'out')).toBe(1);
+    expect(evaluate(Nor, { a: 1, b: 0 }, 'out')).toBe(0);
+    expect(evaluate(Nor, { a: 0, b: 1 }, 'out')).toBe(0);
+    expect(evaluate(Nor, { a: 1, b: 1 }, 'out')).toBe(0);
+  });
+
+  it('coerces comparison results across several outputs', () => {
+    const Cmp = circuit('BoolCmp', {
+      inputs: { a: bit, b: bit },
+      outputs: { eq: bit, ne: bit },
+      eval: ({ a, b }) => ({ eq: a === b, ne: a !== b }),
+    });
+
+    expect(evaluate(Cmp, { a: 1, b: 1 }, 'eq')).toBe(1);
+    expect(evaluate(Cmp, { a: 1, b: 1 }, 'ne')).toBe(0);
+    expect(evaluate(Cmp, { a: 1, b: 0 }, 'eq')).toBe(0);
+    expect(evaluate(Cmp, { a: 1, b: 0 }, 'ne')).toBe(1);
+  });
+
+  it('agrees with the explicit ternary spelling the stdlib uses', () => {
+    const asBoolean = circuit('BoolStyleA', {
+      inputs: { a: bit, b: bit },
+      outputs: { out: bit },
+      eval: ({ a, b }) => ({ out: !(a & b) }),
+    });
+    const asTernary = circuit('BoolStyleB', {
+      inputs: { a: bit, b: bit },
+      outputs: { out: bit },
+      eval: ({ a, b }) => ({ out: a && b ? 0 : 1 }),
+    });
+
+    for (const a of [0, 1]) {
+      for (const b of [0, 1]) {
+        expect(evaluate(asBoolean, { a, b }, 'out'), `a=${a} b=${b}`).toBe(
+          evaluate(asTernary, { a, b }, 'out'),
+        );
+      }
+    }
+  });
+
+  it('still requires a number on a multi-bit output', () => {
+    // A boolean here would type-error, which is the point — `!` on a bus
+    // simulates as logical NOT but exports as Verilog `~`. Returning a number
+    // keeps simulation and synthesis in agreement.
+    const Wide = circuit('BoolWide', {
+      inputs: { a: bus(8), b: bus(8) },
+      outputs: { out: bus(8) },
+      eval: ({ a, b }) => ({ out: (a | b) === 0 ? 1 : 0 }),
+    });
+
+    expect(evaluate(Wide, { a: 0, b: 0 }, 'out')).toBe(1);
+    expect(evaluate(Wide, { a: 2, b: 0 }, 'out')).toBe(0);
+  });
+});

--- a/packages/core/src/circuit/types.ts
+++ b/packages/core/src/circuit/types.ts
@@ -12,6 +12,7 @@
 
 import type {
   ArgumentValue,
+  BitType,
   BusType,
   Circuit,
   Node,
@@ -135,9 +136,28 @@ export type ConnectArg<
 // Eval function types
 // ============================================================================
 
-/** Convert a port map to numeric values (for eval input/output) */
+/** Convert a port map to numeric values (what `eval` receives). Inputs are read
+ *  out of the simulator's typed arrays, so they are always numbers. */
 export type PortValues<M> = {
   [K in keyof M]: number;
+};
+
+/**
+ * What `eval` may return: numbers everywhere, and booleans on 1-bit ports.
+ *
+ * The runtime has always accepted a boolean — it lands in a typed array, where
+ * `true`/`false` coerce to 1/0 — so `eval: ({ a, b }) => ({ out: !(a | b) })`
+ * ran correctly while failing to type-check, and the natural way to write a NOR
+ * had to be spelled `(a | b) ? 0 : 1`.
+ *
+ * Widened only for `bit`, deliberately. The Verilog exporter emits JS `!` as
+ * `~` (eval-synth), which agrees with logical negation at one bit and diverges
+ * above it: `!(2 | 0)` simulates to 0 while `~8'd2` is 253. Keeping the
+ * requirement to return a number on `bus` ports is what stops that divergence
+ * being reachable — the type error there is load-bearing, not tidiness.
+ */
+export type PortOutputValues<M> = {
+  [K in keyof M]: M[K] extends BitType ? number | boolean : number;
 };
 
 /**
@@ -281,7 +301,7 @@ export interface CircuitConfig<
   /** Combinational behavior — given input values (and current state), return
    *  output values. Use for primitives (gates, ALUs, decoders) whose output
    *  is a pure function of inputs. Pair with `onTick` for sequential logic. */
-  eval?: (inputs: PortValues<Ins> & S) => PortValues<Outs>;
+  eval?: (inputs: PortValues<Ins> & S) => PortOutputValues<Outs>;
   /** Sequential state. Map of named state fields, each a `reg(width)` or
    *  `mem(depth, width)` declaration (for synthesizable Verilog), or a raw
    *  number / boolean / Map for simulation-only state. Read inside `eval`,


### PR DESCRIPTION
## The problem

This is the natural way to write a NOR, it elaborates, and it simulates correctly:

```ts
eval: ({ a, b }) => ({ out: !(a | b) }),
```

But it shows a red squiggle in the editor — `PortValues<Outs>` demands a `number`, so it had to be spelled `(a | b) ? 0 : 1` to compile. The runtime never cared: the value lands in a typed array, where `true`/`false` coerce to 1/0.

So the source type-errored while the simulation was right, which is the wrong way round.

## Why the fix stops at one bit

The obvious change — widen `PortValues` to `number | boolean` — would open a real hole. `eval-synth.ts:817` emits JS `!` as Verilog `~`:

```ts
if (node.operator === '!') return `(~${emitExpr(tc, node.argument)})`;
```

Those agree at one bit and diverge above it. Measured:

| | simulation | exported Verilog |
|---|---|---|
| 1-bit `!(1\|0)` | 0 | `~1'b1` → 0 |
| 8-bit `!(2\|0)` | 0 | `~8'd2` → **253** |

Today that divergence is unreachable *because* the type rejects it. So the new type widens only where it is safe:

```ts
export type PortOutputValues<M> = {
  [K in keyof M]: M[K] extends BitType ? number | boolean : number;
};
```

- `bit` — booleans allowed; `!` and `~` are identical at one bit
- `bus` — still a type error, keeping simulation and synthesis in agreement

The width-awareness is load-bearing, not tidiness.

## Verification

- `!(a | b)`, `a === b`, and the stdlib's existing `? 1 : 0` style all compile; a boolean on a `bus` output still errors
- new `bit-output-booleans.test.ts` — negation truth table, comparisons across multiple outputs, and a check that the boolean spelling and the ternary spelling agree on all four input combinations
- core 677, ui 110, `fpga:test` 69/69, `fpga:netlist-check` matches golden, `check-exports` clean, typecheck clean, lint at the 590 baseline

Nothing in the stdlib changes — it keeps writing `? 1 : 0`, which still type-checks.

## Follow-up worth its own PR

`!` → `~` in eval-synth is wrong for multi-bit operands regardless of this change; Verilog has `!` for logical negation. Fixing that would make booleans safe on buses too, but it alters synthesis output for anything already using `!` in an eval, so it wants iverilog cross-validation rather than a quick patch.

Also noted: the confusing half of the original error (`'inputs' does not exist in type '(opts?) => CircuitConfig'`) is TypeScript reporting the first of the two `circuit()` overloads failing before it reaches the real mismatch. Inherent to the overload pair; not worth restructuring the API for.