### PR TITLE
fix(core): trim shipped JSDoc and raise the .d.ts budget to 116 KB

### DIFF
--- a/packages/core/src/circuit/__tests__/dts-bundle.test.ts
+++ b/packages/core/src/circuit/__tests__/dts-bundle.test.ts
@@ -49,14 +49,17 @@ describe('dist/bundle.d.ts', () => {
     expect(bundle).toContain('_dependencies');
   });
 
-  it('stays under the 112 KB headroom budget', () => {
+  it('stays under the 116 KB headroom budget', () => {
     // Guard on the Monaco type-payload size (affects editor cold-load). Bump
     // deliberately when the public stdlib grows: raised 100 → 110 KB for the
     // four import-reconstruction components (Slice/Concat/SignExtend/ZeroExtend),
     // then 110 → 112 KB for the divide/remainder family (Divider/Modulo +
-    // Signed*). Trim JSDoc before bumping further.
+    // Signed*), then 112 → 116 KB for `PortOutputValues` — after trimming the
+    // JSDoc that came with it and with `registerCircuitEval`, which together
+    // pushed past 112 and, having landed in separate PRs, were each measured
+    // against a base without the other. Trim JSDoc before bumping further.
     const { size } = statSync(bundlePath);
-    expect(size).toBeLessThan(112 * 1024);
+    expect(size).toBeLessThan(116 * 1024);
   });
 });
 

--- a/packages/core/src/circuit/eval-registry.ts
+++ b/packages/core/src/circuit/eval-registry.ts
@@ -24,22 +24,11 @@ export interface EvalEntry {
 const registry = new Map<string, EvalEntry>();
 
 /**
- * Record a component's behaviour. Last definition wins.
- *
- * This used to keep the first registration and silently drop later ones, which
- * made a redefined primitive un-editable: the browser editor re-executes source
- * in the same realm, so this module-level Map survives a "reload", and changing
- * `eval: ({a, b}) => ({out: a & b})` to `a ^ b` left the circuit still computing
- * AND. Nothing surfaced the discrepancy — the source said one thing and the
- * simulation did another.
- *
- * Overwriting means a circuit sharing a name with a stdlib component now shadows
- * it for the rest of the session rather than being ignored. That is the more
- * predictable of the two surprises: the definition you can see in front of you
- * is the one that runs.
- *
- * Callers deriving caches from these entries must invalidate on identity change
- * — see `ensureEvaluatorRegistered`.
+ * Record a component's behaviour. Last definition wins — the editor re-executes
+ * source in the same realm, so keeping the first registration left a redefined
+ * primitive running its original eval. A name shared with a stdlib component
+ * now shadows it for the session. Callers caching from these entries must
+ * invalidate on identity change; see `ensureEvaluatorRegistered`.
  */
 export function registerCircuitEval(name: string, entry: EvalEntry): void {
   registry.set(name, entry);

--- a/packages/core/src/circuit/types.ts
+++ b/packages/core/src/circuit/types.ts
@@ -136,25 +136,18 @@ export type ConnectArg<
 // Eval function types
 // ============================================================================
 
-/** Convert a port map to numeric values (what `eval` receives). Inputs are read
- *  out of the simulator's typed arrays, so they are always numbers. */
+/** Port map → numeric values. What `eval` receives; always numbers. */
 export type PortValues<M> = {
   [K in keyof M]: number;
 };
 
 /**
- * What `eval` may return: numbers everywhere, and booleans on 1-bit ports.
+ * What `eval` may return: numbers everywhere, booleans on 1-bit ports (they
+ * coerce to 1/0 in the typed array, so `{ out: !(a | b) }` is legal).
  *
- * The runtime has always accepted a boolean — it lands in a typed array, where
- * `true`/`false` coerce to 1/0 — so `eval: ({ a, b }) => ({ out: !(a | b) })`
- * ran correctly while failing to type-check, and the natural way to write a NOR
- * had to be spelled `(a | b) ? 0 : 1`.
- *
- * Widened only for `bit`, deliberately. The Verilog exporter emits JS `!` as
- * `~` (eval-synth), which agrees with logical negation at one bit and diverges
- * above it: `!(2 | 0)` simulates to 0 while `~8'd2` is 253. Keeping the
- * requirement to return a number on `bus` ports is what stops that divergence
- * being reachable — the type error there is load-bearing, not tidiness.
+ * Widened only for `bit`. The exporter emits JS `!` as Verilog `~`, which
+ * matches at one bit and diverges above it, so requiring a number on `bus`
+ * ports is what keeps that unreachable.
  */
 export type PortOutputValues<M> = {
   [K in keyof M]: M[K] extends BitType ? number | boolean : number;


### PR DESCRIPTION
## main is currently red

`pnpm --filter @simten/core test` fails on a clean checkout of `main`:

```
FAIL src/circuit/__tests__/dts-bundle.test.ts > stays under the 112 KB headroom budget
AssertionError: expected 115484 to be less than 114688
```

## How it got through CI

#267 and #268 each added JSDoc to an **exported** declaration — `registerCircuitEval` and `PortOutputValues` — which lands in `dist/bundle.d.ts`, the type payload shipped to Monaco. Each PR was measured against a base that did not contain the other, so both passed at ~113 KB and their sum crossed the ceiling only once both were on `main`.

Worth noting as a CI gap in general: a size budget can't be enforced per-PR when contributions are additive and merged independently.

## Fix

The budget test says "Trim JSDoc before bumping further", so:

1. **Trimmed**, since the bloat was mine — the `registerCircuitEval` block went from 17 lines to 6, `PortOutputValues` from 13 to 7, and the `PortValues` one-liner I had expanded went back to one line. The reasoning survives; the worked examples and measurements belong in the PRs and tests, not in every browser's type payload.
2. **Bumped 112 → 116 KB** for the remainder, which is a genuinely new exported type. Trimming alone landed at 114,498 of 114,688 — 190 bytes of headroom, which is not headroom.

Result: 114,498 bytes against a 118,784 ceiling.

The budget comment records the reason in the same style as the previous two bumps, including the separate-PR interaction, so the next person hitting this has the context.

## Verification

core 681 passed, lint at the 590-warning baseline, typecheck clean.