### PR TITLE
fix(ui): handles and edges stay aligned when a circuit's ports change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ hardware/ulx3s/projects/cpu/cycle-diff.vcd
 # Verilog-import spike scratch/demo artifacts (local only)
 packages/core/import-demo.mts
 packages/core/*.imported.circuit.ts
+
+# Playwright MCP session artifacts (snapshots, console logs)
+.playwright-mcp/

--- a/packages/ui/src/canvas/CircuitCanvas.tsx
+++ b/packages/ui/src/canvas/CircuitCanvas.tsx
@@ -354,6 +354,21 @@ function CircuitCanvasInner({
     const wasBlank = prevNodeCountRef.current === 0;
     prevNodeCountRef.current = projectedNodes.length;
 
+    // Nodes purely added or purely removed — no rename in the mix. The
+    // preserved positions then belong to a layout computed for a different node
+    // count, while newly projected nodes carry the current one, so mixing the
+    // two put a new node exactly on top of a surviving one (adding an input
+    // landed its switch on the previous input's slot, hiding it entirely).
+    // Take the fresh layout for everything in that case.
+    //
+    // A rename removes an id *and* adds one, so it fails this test and keeps
+    // the preserved positions — which is what #111 asked for.
+    let added = 0;
+    for (const id of newIdSet) if (!prevIdSet.has(id)) added++;
+    let removed = 0;
+    for (const id of prevIdSet) if (!newIdSet.has(id)) removed++;
+    const relayout = (added > 0 && removed === 0) || (removed > 0 && added === 0);
+
     setNodes((currentNodes) => {
       const prevById = new Map(currentNodes.map((n) => [n.id, n]));
       return projectedNodes.map((node) => {
@@ -363,6 +378,7 @@ function CircuitCanvasInner({
           // and the user-dragged position; only refresh data/type from projection.
           return {
             ...prev,
+            position: relayout ? node.position : prev.position,
             type: node.type,
             data: node.data,
             selectable: node.selectable,

--- a/packages/ui/src/canvas/CircuitCanvas.tsx
+++ b/packages/ui/src/canvas/CircuitCanvas.tsx
@@ -408,9 +408,13 @@ function CircuitCanvasInner({
     }
 
     // After a paste-over the remount handles fitView via React Flow's
-    // own `fitView` prop. The remaining case is wasBlank without a
-    // remount (nodes appeared after an empty state on a stable canvas).
-    if (projectedNodes.length > 0 && wasBlank && !fullReset) {
+    // own `fitView` prop. The remaining cases are wasBlank without a
+    // remount (nodes appeared after an empty state on a stable canvas),
+    // and `relayout` — adding or removing a node re-runs the layout and
+    // changes the diagram's extent, so the old viewport no longer frames
+    // it (adding an input grows the switch column downward until it
+    // leaves the visible area).
+    if (projectedNodes.length > 0 && !fullReset && (wasBlank || relayout)) {
       requestAnimationFrame(() => fitView({ padding: 0.3 }));
     }
   }, [projectedNodes, projectedEdges]);

--- a/packages/ui/src/nodes/BaseNode.tsx
+++ b/packages/ui/src/nodes/BaseNode.tsx
@@ -61,7 +61,13 @@ export function BaseNode({
               position={Position.Left}
               id={`in-${port.name}`}
               className={cn(
-                'h-3 w-3 rounded-full border-2 transition-all duration-200',
+                // Transition colour and scale only. `transition-all` also animated
+                // `top`, and handles are positioned as a percentage of node
+                // height — so adding a port set every handle moving. React Flow
+                // measures handle bounds once, right after the DOM updates, and
+                // was catching them mid-flight: edges then routed to coordinates
+                // the handles had already left, and nothing re-measured.
+                'h-3 w-3 rounded-full border-2 transition-[background-color,border-color,transform] duration-200',
                 port.connected
                   ? 'bg-blue-500 border-blue-600'
                   : 'bg-[var(--embed-bg-tertiary)] border-[var(--embed-border-node)]',
@@ -116,7 +122,13 @@ export function BaseNode({
               position={Position.Right}
               id={`out-${port.name}`}
               className={cn(
-                'h-3 w-3 rounded-full border-2 transition-all duration-200',
+                // Transition colour and scale only. `transition-all` also animated
+                // `top`, and handles are positioned as a percentage of node
+                // height — so adding a port set every handle moving. React Flow
+                // measures handle bounds once, right after the DOM updates, and
+                // was catching them mid-flight: edges then routed to coordinates
+                // the handles had already left, and nothing re-measured.
+                'h-3 w-3 rounded-full border-2 transition-[background-color,border-color,transform] duration-200',
                 port.connected
                   ? 'bg-green-500 border-green-600'
                   : 'bg-[var(--embed-bg-tertiary)] border-[var(--embed-border-node)]',


### PR DESCRIPTION
Adding an input left the canvas wrong: a switch vanished, and wires for the *existing* inputs ended beside their dots. Reverting didn't recover. Two independent causes, both found by measuring in the browser with Playwright.

**Handles were animated.** They carry `transition-all duration-200` and sit at `(index + 1) / (count + 1)` of node height, so adding a port moves every handle. React Flow measures bounds once, right after the DOM updates — catching them mid-animation — and never re-measures. The new handle looked fine only because it has nothing to animate from. Fix: transition colour and transform, not `top`.

**New and surviving nodes came from different layouts.** `useLayout` recomputes dagre each change, but `setNodes` kept `prev.position` for survivors — so `b` held its 4-node slot while `c` took its 5-node one. Both landed on `563,303` and `c` drew over `b`. Fix: refresh positions on pure add/remove. A rename does both, so it keeps positions and #111 is intact. Also refits the viewport, since the extent changes.

I first tried deferring `updateNodeInternals` and not inheriting the previous node object. With the transition fixed, both proved unnecessary and were removed.

Verified in the browser at 2, 3, 6 and back to 2 inputs: every edge endpoint matches its handle exactly, nothing overlaps, everything stays framed. core 681, ui 110, lint at baseline.

Also gitignores `.playwright-mcp/`.