### PR TITLE
chore: changesets for the core and ui fixes landed since 0.11.2

### DIFF
--- a/.changeset/olive-pets-shave.md
+++ b/.changeset/olive-pets-shave.md
@@ -1,0 +1,13 @@
+---
+'@simten/core': minor
+---
+
+Redefining a primitive now replaces its behaviour. Component behaviour was cached by name and kept the first registration, so editing a primitive's `eval` (or `onTick`) left the old function running — the source said one thing and the simulation did another. Affects any host that re-executes circuit source in one realm, which is what the browser editor does.
+
+`eval` may now return a boolean for a 1-bit output, so `({ a, b }) => ({ out: !(a | b) })` type-checks instead of needing `(a | b) ? 0 : 1`. Widened only for `bit`: the Verilog exporter emits JS `!` as `~`, which agrees at one bit and diverges above it, so `bus` outputs still require a number. Adds the `PortOutputValues` type.
+
+`setDebugStateUpdate` is now exported from `@simten/core/simulator`. It gates propagation tracing — seed counts and per-pass eval/changed totals — which is the only view into a circuit once elaboration has flattened it to typed arrays. The tracing existed but nothing could switch it on.
+
+**Verilog import now rejects derived clocks.** A flip-flop clocked by anything other than the module's clock port (a clock divider's `div[15]`, a ripple counter's previous stage, a gated clock) used to import cleanly and simulate as a different circuit — a 4-bit ripple counter came out as four flip-flops toggling together, counting 0, 15, 0. simten models a single synchronous clock domain and cannot represent those, so they now throw with a message naming the signal and pointing at the clock-enable rewrite. Designs that previously imported and behaved incorrectly will now fail loudly.
+
+`autoHarness` keeps its library entry in step with the circuit it wraps, so editing a circuit's ports no longer leaves the harness's `dut` node describing a different interface from the circuit the canvas resolves.

--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,9 @@
+---
+'@simten/ui': minor
+---
+
+Scaffold snippets for circuit source in the Monaco editor. Typing `circuit` expands the composite skeleton with the circuit name as a linked edit and node names propagating into the `connect` destructure; `circuit-primitive` and `circuit-sequential` cover the `eval` and `state`/`onTick` shapes. Registered automatically by `setupSimtenIntellisense` (disable with `snippets: false`), or directly via the new `registerSimtenSnippets` export. `SIMTEN_SNIPPETS` exposes the definitions.
+
+Handles and edges stay aligned when a circuit's ports change. Handles sit at a percentage of node height, so adding a port moves every handle on that node — but they animated to their new positions, and React Flow measures handle bounds once, immediately after the DOM updates. It caught them mid-animation and never re-measured, leaving edges routed to coordinates the handles had already left. Handle position is no longer transitioned.
+
+Nodes no longer overlap when a circuit gains or loses one. Surviving nodes kept positions from the previous layout while new nodes took the current one, so an added node could land exactly on top of an existing one and hide it. Positions now refresh when nodes are purely added or removed; a rename does both, so it still preserves positions. The viewport also refits in that case, since the diagram's extent changes.


### PR DESCRIPTION
Everything merged since #258 went in without a changeset, so `@simten/core` and `@simten/ui` are sitting at their published versions with the fixes unreleased. These two cover the accumulated changes.

**`@simten/core` — minor.** New public API (`setDebugStateUpdate`, `PortOutputValues`) plus a behaviour change: Verilog imports with derived clocks now throw where they previously succeeded and simulated as a different circuit. Also the primitive-redefinition fix, boolean returns on 1-bit outputs, and the harness library fix.

**`@simten/ui` — minor.** New public API (`registerSimtenSnippets`, `SIMTEN_SNIPPETS`, the `snippets` option), plus the canvas handle-alignment and node-collision fixes.

Not called out: the `NumericSequentialState` dedupe, the `StateFieldValue` rename and the JSDoc trim are internal with no consumer-visible effect.