### PR TITLE
fix(ui): give port labels room inside the node when they are shown

### DIFF
--- a/.changeset/olive-clocks-smile.md
+++ b/.changeset/olive-clocks-smile.md
@@ -1,0 +1,5 @@
+---
+'@simten/ui': patch
+---
+
+Give port labels room when `showPortLabels` is on. The labels render inside the node, and on a two-input gate — roughly 88px wide — a symbol plus `a`, `b` and `out` did not fit: the side labels sat against the border and `out` overlapped the gate symbol. Node content now takes wider horizontal padding while labels are shown, and the default spacing is unchanged when they are not.

--- a/packages/ui/src/nodes/BaseNode.tsx
+++ b/packages/ui/src/nodes/BaseNode.tsx
@@ -98,7 +98,10 @@ export function BaseNode({
       })}
 
       {/* Node Content */}
-      <div className="relative px-3 py-2">{children}</div>
+      {/* Port labels sit inside the node, so the content needs to give them
+          room or they collide with it — on a two-input gate the box is ~88px
+          wide, and a symbol plus `a`/`b`/`out` does not fit in that. */}
+      <div className={cn('relative py-2', showPortLabels ? 'px-8' : 'px-3')}>{children}</div>
 
       {/* Output Ports (Right Side) */}
       {outputPorts.map((port) => {


### PR DESCRIPTION
`showPortLabels` already existed and was plumbed end to end — `CircuitCanvas` → `NodeData` → `BaseNode` — but turning it on looked broken. Labels render *inside* the node, and a two-input gate is about 88px wide: `a` and `b` sat against the left border and `out` overlapped the gate symbol.

Content padding now widens while labels are shown, and is unchanged when they aren't.

Verified in the browser on a `Switch → Nand → Led` circuit. Measured after: node widths 145 / 128 / 119, all still under the widths `NODE_DIMENSIONS` declares to dagre, and no horizontal overlap between nodes.

Context: this matters for a puzzle/game surface, where the player has to discover that `nand.b` exists in order to wire it. With labels on, the canvas shows `b` named and visibly unconnected — so the diagram carries the hint and the starter code can stay minimal.

CSS-only, so there's no meaningful unit test; it's verified visually and by measuring the rendered geometry.