### PR TITLE
fix(sandbox): stop rebuilt stdlib evals from clobbering the real ones

### DIFF
--- a/apps/sandbox/src/main.ts
+++ b/apps/sandbox/src/main.ts
@@ -52,8 +52,27 @@
 
 import type { BitValue, BusValue, Circuit, SimulatorSnapshot } from '@simten/core';
 import { createSimulator, elaborate } from '@simten/core';
-import { registerCircuitEval } from '@simten/core/circuit';
+import { getAllCircuitEvals, registerCircuitEval } from '@simten/core/circuit';
 import { captureEnvironmentalState, type EnvironmentalStateValue } from '@simten/core/simulator';
+
+/**
+ * Stdlib component names, captured before any user code runs.
+ *
+ * Evals arrive here as source *text* and are rebuilt with `new Function`, which
+ * keeps the body but not the closure. That is fine for user circuits, whose
+ * evals are self-contained, and wrong for the stdlib: `Adder` is written
+ * `({ a, b, carry_in, width: w = width }) => …`, where the default reads the
+ * factory's `width`. Rebuilt from text, `width` is a free variable and the
+ * evaluator throws "width is not defined" the moment it runs.
+ *
+ * Importing `@simten/core` above already registered the real ones, closures and
+ * all, so the rebuilt copies are never needed — they used to be discarded by a
+ * first-write-wins guard inside `registerCircuitEval`, until that guard was
+ * removed so the editor could redefine a primitive. Skipping stdlib names here
+ * keeps both: the stdlib stays intact, and a user circuit still replaces its own
+ * previous definition.
+ */
+const STDLIB_EVAL_NAMES: ReadonlySet<string> = new Set(getAllCircuitEvals().keys());
 
 /** Serialized eval entry — source strings reconstructed via new Function() */
 interface EvalSource {
@@ -429,6 +448,7 @@ async function handleCompile(id: string, source: string, slotId: string = DEFAUL
     // This avoids re-executing the module (which may contain npm imports that only
     // the worker can load via esm.sh) on the main thread.
     for (const [name, info] of Object.entries(evalSources)) {
+      if (STDLIB_EVAL_NAMES.has(name)) continue;
       try {
         const evalFn = new Function('return (' + info.evalSource + ')')() as (
           inputs: Record<string, any>,
@@ -775,6 +795,7 @@ function handleCompileIR(
     // This is how the embed transfers eval functions from the main frame to the sandbox.
     if (evalSources) {
       for (const [name, info] of Object.entries(evalSources)) {
+        if (STDLIB_EVAL_NAMES.has(name)) continue;
         try {
           const evalFn = new Function('return (' + info.evalSource + ')')() as (
             inputs: Record<string, any>,

--- a/packages/core/src/std/__tests__/eval-source-roundtrip.test.ts
+++ b/packages/core/src/std/__tests__/eval-source-roundtrip.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Stdlib evals and the source round-trip.
+ *
+ * The sandbox receives evals as source *text* and rebuilds them with
+ * `new Function`, which preserves the body but not the closure. An eval that
+ * reads a variable from its factory scope therefore throws the moment it runs
+ * there — `Adder` is written `({ a, b, carry_in, width: w = width })`, where
+ * the default reads the factory's `width`, and a bare `Adder()` supplies no
+ * `width` argument, so the default always fires.
+ *
+ * That crashed Snake and Pong with "width is not defined" once
+ * `registerCircuitEval` became last-write-wins: the rebuilt copies started
+ * replacing the real ones instead of being discarded. The sandbox now skips
+ * stdlib names, so nothing is broken today.
+ *
+ * This test exists so the hazard cannot grow silently. KNOWN_CLOSURE_DEPS is a
+ * list that may only shrink: a new component written in the same style fails
+ * here immediately, and fixing an existing one (give the destructure a literal
+ * default instead of reading the factory variable) means deleting its line.
+ *
+ * A closure dependency surfaces as ReferenceError specifically, which is what
+ * separates it from an eval that merely dislikes this test's synthetic inputs.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getAllCircuitEvals } from '../../circuit/index.js';
+import '../index.js';
+
+/**
+ * Evals that cannot be rebuilt from their own source because they close over a
+ * factory variable (`width`, `inWidth`, `loWidth`, …). May only shrink.
+ */
+const KNOWN_CLOSURE_DEPS = [
+  'Adder',
+  'BusNot',
+  'BusXnor',
+  'Concat',
+  'Divider',
+  'DynamicSlice',
+  'LeftShifter',
+  'Modulo',
+  'ReduceAnd',
+  'RightShifter',
+  'SignExtend',
+  'SignedComparator',
+  'SignedDivider',
+  'SignedModulo',
+  'SignedRightShifter',
+  'Slice',
+  'Subtractor',
+  'WrappingMultiplier',
+  'ZeroExtend',
+];
+
+/** Rebuild an eval the way the sandbox does, and run it. */
+function survivesRoundTrip(entry: {
+  evalFn: unknown;
+  inputNames: string[];
+  stateKeys?: string[];
+}): { ok: true } | { ok: false; reference: boolean; message: string } {
+  try {
+    const rebuilt = new Function(`return (${String(entry.evalFn)})`)() as (
+      inputs: Record<string, unknown>,
+    ) => unknown;
+    const inputs: Record<string, unknown> = {};
+    for (const port of entry.inputNames) inputs[port] = 1;
+    for (const key of entry.stateKeys ?? []) inputs[key] = new Map();
+    rebuilt(inputs);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      reference: error instanceof ReferenceError,
+      message: (error as Error).message,
+    };
+  }
+}
+
+describe('stdlib evals rebuilt from source', () => {
+  const closureDeps: string[] = [];
+  for (const [name, entry] of getAllCircuitEvals()) {
+    const result = survivesRoundTrip(entry);
+    if (!result.ok && result.reference) closureDeps.push(name);
+  }
+
+  it('has no closure dependency outside the known list', () => {
+    const unexpected = closureDeps.filter((n) => !KNOWN_CLOSURE_DEPS.includes(n)).sort();
+    expect(
+      unexpected,
+      'A new stdlib eval reads a variable from its factory scope. It cannot be rebuilt ' +
+        'from source, so it breaks in the sandbox if anything registers it from text. ' +
+        'Give the destructured parameter a literal default instead of reading the ' +
+        'factory variable — e.g. `width: w = 8` rather than `width: w = width`.',
+    ).toEqual([]);
+  });
+
+  it('keeps the known list honest — fixed components must be removed from it', () => {
+    const fixed = KNOWN_CLOSURE_DEPS.filter((n) => !closureDeps.includes(n)).sort();
+    expect(
+      fixed,
+      'These no longer depend on their closure. Delete them from KNOWN_CLOSURE_DEPS.',
+    ).toEqual([]);
+  });
+
+  it('rebuilds the majority of stdlib evals cleanly', () => {
+    const total = [...getAllCircuitEvals()].length;
+    expect(total).toBeGreaterThan(50);
+    expect(closureDeps.length).toBeLessThan(total / 2);
+  });
+});


### PR DESCRIPTION
Regression from #267. Snake, Pong and anything using `Adder`, `Comparator` or `Mux` failed to load in the editor with `width is not defined`.

The sandbox receives evals as source *text* and rebuilds them with `new Function`, which keeps the body but not the closure. That's fine for user circuits — theirs are self-contained — and wrong for the stdlib, where `Adder` is written:

```js
({ a, b, carry_in, width: w = width }) => …
                          ^^^^^^^^^ default reads the factory's `width`
```

Rebuilt from text, `width` is a free variable, so the evaluator throws the moment it runs. A bare `Adder()` records `arguments: {}`, so the default always fires.

This never surfaced because `registerCircuitEval` was first-write-wins: importing `@simten/core` had already registered the real evals, closures intact, and the rebuilt copies were silently discarded. #267 made it last-write-wins so the editor could redefine a primitive — and the rebuilt copies started winning. That guard was load-bearing in a way I didn't spot.

Fix is at the call site rather than the registry: the sandbox captures stdlib names before any user code runs and skips those. A blanket "skip if already registered" would have reinstated the original bug, since redefining a user primitive must still take effect.

Verified in the browser:

- bare `Adder()` circuit: renders, no errors (was `width is not defined`)
- Snake: renders all five nodes (was "No circuit")
- redefinition still works — same circuit as `a & b` lights the LED, edited to `a ^ b` it goes dark, so #267's fix is intact

core 681, ui passing, typecheck clean, lint at the 590-warning baseline.

No changeset: `@simten/sandbox` is private and in the changesets ignore list.