### PR TITLE
fix(core): stop bare stdlib components inheriting another instance's width

### DIFF
--- a/.changeset/literal-eval-width-defaults.md
+++ b/.changeset/literal-eval-width-defaults.md
@@ -1,0 +1,7 @@
+---
+'@simten/core': patch
+---
+
+Fix bare stdlib components picking up the width of an unrelated instance. The eval registry keys behaviour by component name and the last definition wins, so nineteen components whose eval read a width default out of their factory closure — `width: w = width` — handed every bare `Adder()`, `Slice()`, `Concat()` and friends the width of whichever instance was defined last. `@simten/core/std` defines `Adder({ width: 32 })` at module scope, so in a bundle that ordered the stdlib after the app, `Adder()` stopped being 8 bits: `6 + 255` read as 261 instead of wrapping to 5. Module evaluation order differs between bundlers and node, which is why this showed up in the browser and not in tests.
+
+The defaults are now literals matching each factory's own default, and the mask and sign-extend arithmetic those evals used to call out to is inlined, so no stdlib eval reads its factory scope any more.

--- a/packages/core/src/std/__tests__/default-width.test.ts
+++ b/packages/core/src/std/__tests__/default-width.test.ts
@@ -1,0 +1,93 @@
+/**
+ * A bare `Adder()` must keep its own 8-bit default even when a 32-bit Adder is
+ * defined after it.
+ *
+ * The eval registry keys by component NAME and last write wins, so there is one
+ * registered lambda per name no matter how many widths get instantiated, and
+ * the simulator resolves it at `simulate()` time. An eval whose width default
+ * read the factory closure — `width: w = width` — therefore handed every bare
+ * instance the width of whichever instance was defined LAST.
+ *
+ * `@simten/core/std` re-exports rv32i-cpu.ts, which defines `Adder({ width: 32 })`
+ * at module scope, so a bundler that ordered the stdlib after the app silently
+ * widened every bare Adder in the app: 6 + 255 stopped wrapping to 5 and read
+ * as 261. That is what made Pong's paddle jump to the top on the -1 (0xFF)
+ * delta while +1 behaved. Module evaluation order differs between bundler and
+ * node, which is why it reproduced in the browser and not in tests.
+ *
+ * The layout below reproduces that order: the bare instances are built at
+ * module scope FIRST, the wide ones registered after, and only then does a test
+ * body simulate. Building the bare instance inside the test body instead would
+ * make it the last write and hide the bug.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { bit, bus, circuit } from '../../circuit/index.js';
+import { simulate } from '../../sim/index.js';
+import { Adder, Subtractor } from '../arithmetic.js';
+import { Concat } from '../routing.js';
+
+const bareAdder = circuit('BareAdderTop', {
+  inputs: { a: bus(8), b: bus(8) },
+  outputs: { sum: bus(8), carry_out: bit },
+  nodes: { add: Adder() },
+  connect: ({ inputs, outputs, nodes: { add } }: any) => [
+    inputs.a.to(add.a),
+    inputs.b.to(add.b),
+    add.sum.to(outputs.sum),
+    add.carry_out.to(outputs.carry_out),
+  ],
+} as any);
+
+const bareSubtractor = circuit('BareSubtractorTop', {
+  inputs: { a: bus(8), b: bus(8) },
+  outputs: { difference: bus(8), borrow_out: bit },
+  nodes: { sub: Subtractor() },
+  connect: ({ inputs, outputs, nodes: { sub } }: any) => [
+    inputs.a.to(sub.a),
+    inputs.b.to(sub.b),
+    sub.difference.to(outputs.difference),
+    sub.borrow_out.to(outputs.borrow_out),
+  ],
+} as any);
+
+const bareConcat = circuit('BareConcatTop', {
+  inputs: { high: bus(4), low: bus(4) },
+  outputs: { out: bus(8) },
+  nodes: { cat: Concat() },
+  connect: ({ inputs, outputs, nodes: { cat } }: any) => [
+    inputs.high.to(cat.high),
+    inputs.low.to(cat.low),
+    cat.out.to(outputs.out),
+  ],
+} as any);
+
+// The last write for each name — what importing the stdlib does to a bundle.
+Adder({ width: 32 });
+Subtractor({ width: 32 });
+Concat({ hiWidth: 32, loWidth: 32 });
+
+describe('bare stdlib factories keep their own default width', () => {
+  it('Adder() wraps at 8 bits: 6 + 255 = 5 carry 1', () => {
+    const sim = simulate(bareAdder);
+    sim.set({ a: 6, b: 255 });
+    expect(sim.get('sum')).toBe(5);
+    expect(sim.get('carry_out')).toBe(1);
+    sim.dispose();
+  });
+
+  it('Subtractor() wraps at 8 bits: 5 - 6 = 255 borrow 1', () => {
+    const sim = simulate(bareSubtractor);
+    sim.set({ a: 5, b: 6 });
+    expect(sim.get('difference')).toBe(255);
+    expect(sim.get('borrow_out')).toBe(1);
+    sim.dispose();
+  });
+
+  it('Concat() shifts the high half by its own 4-bit low half', () => {
+    const sim = simulate(bareConcat);
+    sim.set({ high: 0xa, low: 0x5 });
+    expect(sim.get('out')).toBe(0xa5);
+    sim.dispose();
+  });
+});

--- a/packages/core/src/std/__tests__/eval-source-roundtrip.test.ts
+++ b/packages/core/src/std/__tests__/eval-source-roundtrip.test.ts
@@ -4,19 +4,23 @@
  * The sandbox receives evals as source *text* and rebuilds them with
  * `new Function`, which preserves the body but not the closure. An eval that
  * reads a variable from its factory scope therefore throws the moment it runs
- * there — `Adder` is written `({ a, b, carry_in, width: w = width })`, where
- * the default reads the factory's `width`, and a bare `Adder()` supplies no
- * `width` argument, so the default always fires.
+ * there — `Adder` used to be written `({ a, b, carry_in, width: w = width })`,
+ * where the default reads the factory's `width`, and a bare `Adder()` supplies
+ * no `width` argument, so the default always fires.
  *
  * That crashed Snake and Pong with "width is not defined" once
  * `registerCircuitEval` became last-write-wins: the rebuilt copies started
- * replacing the real ones instead of being discarded. The sandbox now skips
- * stdlib names, so nothing is broken today.
+ * replacing the real ones instead of being discarded. The same last-write-wins
+ * rule made the closure wrong even in-process — one registry entry per name, so
+ * the last `Adder({ width: N })` defined anywhere set the fallback width for
+ * every bare `Adder()`, and importing `std` (which defines a 32-bit Adder in
+ * rv32i-cpu.ts) silently widened them all.
  *
- * This test exists so the hazard cannot grow silently. KNOWN_CLOSURE_DEPS is a
- * list that may only shrink: a new component written in the same style fails
- * here immediately, and fixing an existing one (give the destructure a literal
- * default instead of reading the factory variable) means deleting its line.
+ * This test exists so the hazard cannot come back. KNOWN_CLOSURE_DEPS is a list
+ * that may only shrink: a new component written in the same style fails here
+ * immediately. The fix is to give the destructure a literal default instead of
+ * reading the factory variable, and to inline any module-scope helper the body
+ * calls.
  *
  * A closure dependency surfaces as ReferenceError specifically, which is what
  * separates it from an eval that merely dislikes this test's synthetic inputs.
@@ -28,29 +32,10 @@ import '../index.js';
 
 /**
  * Evals that cannot be rebuilt from their own source because they close over a
- * factory variable (`width`, `inWidth`, `loWidth`, …). May only shrink.
+ * factory variable (`width`, `inWidth`, `loWidth`, …) or a module-scope helper.
+ * May only shrink — it is empty, and adding a name back is a regression.
  */
-const KNOWN_CLOSURE_DEPS = [
-  'Adder',
-  'BusNot',
-  'BusXnor',
-  'Concat',
-  'Divider',
-  'DynamicSlice',
-  'LeftShifter',
-  'Modulo',
-  'ReduceAnd',
-  'RightShifter',
-  'SignExtend',
-  'SignedComparator',
-  'SignedDivider',
-  'SignedModulo',
-  'SignedRightShifter',
-  'Slice',
-  'Subtractor',
-  'WrappingMultiplier',
-  'ZeroExtend',
-];
+const KNOWN_CLOSURE_DEPS: string[] = [];
 
 /** Rebuild an eval the way the sandbox does, and run it. */
 function survivesRoundTrip(entry: {

--- a/packages/core/src/std/arithmetic.ts
+++ b/packages/core/src/std/arithmetic.ts
@@ -64,8 +64,11 @@ export const Adder = circuit(
     outputs: { sum: bus(width), carry_out: bit },
     meta: { category: 'arithmetic', icon: '+', description: 'N-bit adder with carry' },
     // `width` is read from inputs (bridge merges node.arguments) so a single
-    // registered lambda works for every Adder({width: N}) instance.
-    eval: ({ a, b, carry_in, width: w = width }) => {
+    // registered lambda works for every Adder({width: N}) instance. The
+    // fallback is the literal 8, not the factory's `width`: the registry keys
+    // by name and last write wins, so closing over it would let whichever
+    // Adder({width: N}) was defined last set the width for every bare Adder().
+    eval: ({ a, b, carry_in, width: w = 8 }) => {
       const wn = w as number;
       const mask = wn >= 32 ? 0xffffffff : (1 << wn) - 1;
       // a, b arrive as signed int32 from the typed-array store; coerce to
@@ -104,7 +107,7 @@ export const Subtractor = circuit('Subtractor', ({ width = 8 }: { width?: number
   inputs: { a: bus(width), b: bus(width), borrow_in: bit },
   outputs: { difference: bus(width), borrow_out: bit },
   meta: { category: 'arithmetic', icon: '−', description: 'N-bit subtractor with borrow' },
-  eval: ({ a, b, borrow_in, width: w = width }) => {
+  eval: ({ a, b, borrow_in, width: w = 8 }) => {
     const wn = w as number;
     const mask = wn >= 32 ? 0xffffffff : (1 << wn) - 1;
     const result = ((a as number) >>> 0) - ((b as number) >>> 0) - (borrow_in as number);
@@ -159,7 +162,7 @@ export const WrappingMultiplier = circuit(
       icon: '×↩',
       description: 'Wrapping multiplier (low width bits)',
     },
-    eval: ({ a, b, width: w = width }) => {
+    eval: ({ a, b, width: w = 8 }) => {
       const m = (w as number) >= 32 ? 0xffffffff : (1 << (w as number)) - 1;
       return { out: (Math.imul((a as number) >>> 0, (b as number) >>> 0) >>> 0) & m };
     },
@@ -177,7 +180,7 @@ export const Divider = circuit('Divider', ({ width = 8 }: { width?: number } = {
   inputs: { a: bus(width), b: bus(width) },
   outputs: { out: bus(width) },
   meta: { category: 'arithmetic', icon: '÷', description: 'Unsigned integer divider (a / b)' },
-  eval: ({ a, b, width: w = width }) => {
+  eval: ({ a, b, width: w = 8 }) => {
     const m = (w as number) >= 32 ? 0xffffffff : (1 << (w as number)) - 1;
     const bv = (b as number) >>> 0;
     const out = bv === 0 ? m : Math.floor(((a as number) >>> 0) / bv);
@@ -196,7 +199,7 @@ export const Modulo = circuit('Modulo', ({ width = 8 }: { width?: number } = {})
   inputs: { a: bus(width), b: bus(width) },
   outputs: { out: bus(width) },
   meta: { category: 'arithmetic', icon: '%', description: 'Unsigned integer remainder (a % b)' },
-  eval: ({ a, b, width: w = width }) => {
+  eval: ({ a, b, width: w = 8 }) => {
     const m = (w as number) >= 32 ? 0xffffffff : (1 << (w as number)) - 1;
     const av = (a as number) >>> 0;
     const bv = (b as number) >>> 0;
@@ -220,7 +223,7 @@ export const SignedDivider = circuit('SignedDivider', ({ width = 8 }: { width?: 
     icon: '÷±',
     description: 'Signed integer divider (a / b, truncates toward zero)',
   },
-  eval: ({ a, b, width: w = width }) => {
+  eval: ({ a, b, width: w = 8 }) => {
     // Sign interpretation inlined (no named inner fn) so the eval survives the
     // editor sandbox's new Function(fn.toString()) rebuild — a named arrow gets
     // wrapped in esbuild's __name(), which isn't defined there.
@@ -252,7 +255,7 @@ export const SignedModulo = circuit('SignedModulo', ({ width = 8 }: { width?: nu
     icon: '%±',
     description: 'Signed integer remainder (a % b, sign of dividend)',
   },
-  eval: ({ a, b, width: w = width }) => {
+  eval: ({ a, b, width: w = 8 }) => {
     // Sign interpretation inlined — see SignedDivider (sandbox __name issue).
     const wn = w as number;
     const m = wn >= 32 ? 0xffffffff : (1 << wn) - 1;
@@ -333,7 +336,7 @@ export const LeftShifter = circuit('LeftShifter', ({ width = 8 }: { width?: numb
   inputs: { value: bus(width), shift: bus(width) },
   outputs: { result: bus(width) },
   meta: { category: 'arithmetic', icon: '≪', description: 'Left bit shifter' },
-  eval: ({ value, shift, width: w = width }) => {
+  eval: ({ value, shift, width: w = 8 }) => {
     const wn = w as number;
     const sn = shift as number;
     const mask = wn >= 32 ? 0xffffffff : (1 << wn) - 1;
@@ -367,7 +370,7 @@ export const RightShifter = circuit('RightShifter', ({ width = 8 }: { width?: nu
   inputs: { value: bus(width), shift: bus(width) },
   outputs: { result: bus(width) },
   meta: { category: 'arithmetic', icon: '≫', description: 'Right bit shifter' },
-  eval: ({ value, shift, width: w = width }) => {
+  eval: ({ value, shift, width: w = 8 }) => {
     const wn = w as number;
     const sn = shift as number;
     return { result: sn >= wn ? 0 : (value as number) >>> sn };
@@ -388,7 +391,7 @@ export const SignedRightShifter = circuit(
     inputs: { value: bus(width), shift: bus(width) },
     outputs: { result: bus(width) },
     meta: { category: 'arithmetic', icon: '≫±', description: 'Arithmetic (signed) right shifter' },
-    eval: ({ value, shift, width: w = width }) => {
+    eval: ({ value, shift, width: w = 8 }) => {
       const wn = w as number;
       const mask = wn >= 32 ? 0xffffffff : (1 << wn) - 1;
       const half = 2 ** (wn - 1);
@@ -475,7 +478,7 @@ export const SignedComparator = circuit(
     outputs: { eq: bit, ne: bit, lt: bit, le: bit, gt: bit, ge: bit, lte: bit, gte: bit },
     meta: { category: 'arithmetic', icon: '±⋚', description: 'Signed comparator' },
     // width read from the bag so per-instance widths sign-extend correctly.
-    eval: ({ a, b, width: w = width }) => {
+    eval: ({ a, b, width: w = 8 }) => {
       const wn = w as number;
       const half = 2 ** (wn - 1);
       const whole = 2 ** wn;
@@ -616,7 +619,7 @@ export const BusNot = circuit('BusNot', ({ width = 8 }: { width?: number } = {})
   outputs: { out: bus(width) },
   meta: { category: 'bus-operations', icon: '¬8', description: 'Bitwise NOT on bus' },
   // width read from the bag so per-instance widths mask correctly (default 8).
-  eval: ({ in: a, width: w = width }) => {
+  eval: ({ in: a, width: w = 8 }) => {
     const m = ((w as number) >= 32 ? 0xffffffff : (1 << (w as number)) - 1) >>> 0;
     return { out: (~(a as number) >>> 0) & m };
   },
@@ -660,7 +663,7 @@ export const BusXnor = circuit('BusXnor', ({ width = 8 }: { width?: number } = {
   inputs: { a: bus(width), b: bus(width) },
   outputs: { out: bus(width) },
   meta: { category: 'bus-operations', icon: '⊙8', description: 'Bitwise XNOR on buses' },
-  eval: ({ a, b, width: w = width }) => {
+  eval: ({ a, b, width: w = 8 }) => {
     const m = ((w as number) >= 32 ? 0xffffffff : (1 << (w as number)) - 1) >>> 0;
     return { out: ((~((a as number) ^ (b as number)) >>> 0) & m) >>> 0 };
   },

--- a/packages/core/src/std/logic.ts
+++ b/packages/core/src/std/logic.ts
@@ -296,8 +296,6 @@ export const Buffer = circuit('Buffer', {
 // $logic_and/$logic_or/$logic_not and $reduce_* onto these (authoring stdlib).
 // ============================================================================
 
-const maskOf = (w: number) => (w >= 32 ? 0xffffffff : (1 << w) - 1) >>> 0;
-
 /**
  * Logical AND (&&) — nonzero operands. `out = (a != 0) && (b != 0)`, a single
  * bit. Operand widths are independent.
@@ -382,8 +380,11 @@ export const ReduceAnd = circuit('ReduceAnd', ({ width = 8 }: { width?: number }
     icon: '&a',
     description: 'Reduction AND (&a) — 1 iff all bits set',
   },
-  eval: ({ a, width: w = width }) => {
-    const m = maskOf(w as number);
+  // Literal default and an inlined mask, so nothing here reads the factory
+  // scope — the registry keys by name and last write wins (see Adder).
+  eval: ({ a, width: w = 8 }) => {
+    const wn = w as number;
+    const m = (wn >= 32 ? 0xffffffff : (1 << wn) - 1) >>> 0;
     // `& m` is a signed 32-bit op; coerce back to unsigned before comparing.
     return { out: (((a as number) >>> 0) & m) >>> 0 === m ? 1 : 0 };
   },

--- a/packages/core/src/std/reconstruction.ts
+++ b/packages/core/src/std/reconstruction.ts
@@ -13,6 +13,13 @@
  * structural args (`inWidth`/`offset`/`width`/`outWidth`) are read from the eval
  * input bag (fed from node.arguments by the bridge merge), never closed over.
  * Same contract as `Adder`/`Register`.
+ *
+ * That extends to the fallbacks and to the bodies: defaults are literals and
+ * mask/sign-extend arithmetic is spelled out inline rather than calling a
+ * module-scope helper. Last write wins in the registry, so a closed-over
+ * `width` would let the last-defined instance set the fallback for every
+ * bare one, and a closed-over helper cannot survive the sandbox's
+ * `new Function(fn.toString())` rebuild.
  */
 
 import { bit, bus } from '../circuit/bit-bus.js';
@@ -20,14 +27,6 @@ import { circuit } from '../circuit/circuit.js';
 
 /** width===1 → bit port, else bus(width). Mirrors the Mux/Constant convention. */
 const portOf = (width: number) => (width === 1 ? bit : bus(width));
-
-const maskOf = (w: number) => (w >= 32 ? 0xffffffff : (1 << w) - 1) >>> 0;
-
-/** Interpret an unsigned w-bit value as two's-complement signed. */
-const sext = (v: number, w: number): number => {
-  const u = v >>> 0;
-  return u >= 2 ** (w - 1) ? u - 2 ** w : u;
-};
 
 /**
  * Bus sub-range extract (in[offset +: width]) — reads bits
@@ -44,9 +43,11 @@ export const Slice = circuit(
   ({ inWidth = 8, width = 1 }: { inWidth?: number; offset?: number; width?: number } = {}) => ({
     inputs: { in: bus(inWidth) },
     outputs: { out: portOf(width) },
-    eval: ({ in: v, offset: off = 0, width: w = width }) => ({
-      out: (((v as number) >>> ((off as number) | 0)) & maskOf((w as number) | 0)) >>> 0,
-    }),
+    eval: ({ in: v, offset: off = 0, width: w = 1 }) => {
+      const wn = (w as number) | 0;
+      const mask = (wn >= 32 ? 0xffffffff : (1 << wn) - 1) >>> 0;
+      return { out: (((v as number) >>> ((off as number) | 0)) & mask) >>> 0 };
+    },
     meta: {
       category: 'utilities',
       icon: '⊂',
@@ -72,9 +73,14 @@ export const SignExtend = circuit(
   ({ inWidth = 8, outWidth = 16 }: { inWidth?: number; outWidth?: number } = {}) => ({
     inputs: { in: bus(inWidth) },
     outputs: { out: bus(outWidth) },
-    eval: ({ in: v, inWidth: iw = inWidth, outWidth: ow = outWidth }) => ({
-      out: (sext((v as number) >>> 0, iw as number) & maskOf(ow as number)) >>> 0,
-    }),
+    eval: ({ in: v, inWidth: iw = 8, outWidth: ow = 16 }) => {
+      const iwn = iw as number;
+      const own = ow as number;
+      const u = (v as number) >>> 0;
+      const signed = u >= 2 ** (iwn - 1) ? u - 2 ** iwn : u;
+      const mask = (own >= 32 ? 0xffffffff : (1 << own) - 1) >>> 0;
+      return { out: (signed & mask) >>> 0 };
+    },
     meta: { category: 'utilities', icon: '±⊳', description: 'Sign extension (replicate MSB)' },
   }),
 );
@@ -96,9 +102,11 @@ export const ZeroExtend = circuit(
   ({ inWidth = 8, outWidth = 16 }: { inWidth?: number; outWidth?: number } = {}) => ({
     inputs: { in: bus(inWidth) },
     outputs: { out: bus(outWidth) },
-    eval: ({ in: v, inWidth: iw = inWidth }) => ({
-      out: ((v as number) >>> 0) & maskOf(iw as number),
-    }),
+    eval: ({ in: v, inWidth: iw = 8 }) => {
+      const iwn = iw as number;
+      const mask = (iwn >= 32 ? 0xffffffff : (1 << iwn) - 1) >>> 0;
+      return { out: ((v as number) >>> 0) & mask };
+    },
     meta: {
       category: 'utilities',
       icon: '0⊳',
@@ -130,10 +138,12 @@ export const DynamicSlice = circuit(
   } = {}) => ({
     inputs: { in: bus(inWidth), shift: bus(shiftWidth) },
     outputs: { out: portOf(outWidth) },
-    eval: ({ in: v, shift: s, inWidth: iw = inWidth, outWidth: ow = outWidth }) => {
+    eval: ({ in: v, shift: s, inWidth: iw = 8, outWidth: ow = 1 }) => {
       const sh = (s as number) >>> 0;
       const shifted = sh >= (iw as number) ? 0 : ((v as number) >>> 0) >>> sh;
-      return { out: (shifted & maskOf(ow as number)) >>> 0 };
+      const own = ow as number;
+      const mask = (own >= 32 ? 0xffffffff : (1 << own) - 1) >>> 0;
+      return { out: (shifted & mask) >>> 0 };
     },
     meta: {
       category: 'utilities',

--- a/packages/core/src/std/routing.ts
+++ b/packages/core/src/std/routing.ts
@@ -243,8 +243,9 @@ export const Concat = circuit(
     outputs: { out: bus(hiWidth + loWidth) },
     meta: { category: 'utilities', icon: '||', description: 'Concatenate two buses ({high, low})' },
     // loWidth read from the bag (node.arguments) so per-instance widths are
-    // honoured; `* 2**lw` (not `<<`) stays correct above 32 bits.
-    eval: ({ high, low, loWidth: lw = loWidth }) => ({
+    // honoured; `* 2**lw` (not `<<`) stays correct above 32 bits. The fallback
+    // is the literal 4 rather than the factory's `loWidth` — see Adder.
+    eval: ({ high, low, loWidth: lw = 4 }) => ({
       out: (((high as number) >>> 0) * 2 ** ((lw as number) | 0) + ((low as number) >>> 0)) >>> 0,
     }),
   }),


### PR DESCRIPTION
Follow-up to #278, which fixed the crash but not the cause.

In Pong, ↑/W moved the paddle straight to the top while ↓/S moved it a pixel at a time. Up is a delta of -1, encoded as 255. `Adder` is 8-bit by default, so 6 + 255 wraps to 5 — one pixel up. It was returning 261, and the clamp reads anything above half-range as "went negative" and snaps to 0. Down is +1, never wraps, so it looked fine.

The width came from the wrong place. Nineteen stdlib evals took their width default out of the factory closure:

```js
({ a, b, carry_in, width: w = width }) => …
                          ^^^^^ the factory's `width`, not the argument
```

The eval registry keys by component *name*, so `Adder({ width: 32 })` and a bare `Adder()` share one entry, and since #267 the last write wins. Every `Adder({ width: N })` anywhere in the program registers a new closure under `Adder`, and whichever ran last sets the fallback for every instance that didn't pass a width. `@simten/core/std` re-exports `rv32i-cpu.ts`, which has `Adder({ width: 32 })` at module scope — so importing the stdlib widened them all. Instances that pass an explicit width were never affected; the bridge merges `node.arguments` and the default never fires.

Module evaluation order differs between bundler and node, which is why node looked correct and the browser didn't. Not Pong-specific — any circuit built from bare width-defaulting components.

## The fix

Each default becomes the literal that factory already documents — `width = 8` for `Adder`, `1` for `Slice`'s width, `4` for `Concat`'s `loWidth`, `8`/`16` for the extends, and so on. Defaults vary per component, so they're checked individually rather than swept.

Five of them (`Slice`, `SignExtend`, `ZeroExtend`, `DynamicSlice`, `ReduceAnd`) also called a module-scope `maskOf`/`sext`. That is the same class of bug one level down — it survives in-process but not the sandbox's `new Function(fn.toString())` rebuild — so the arithmetic is inlined and the now-unused helpers are gone.

`KNOWN_CLOSURE_DEPS` in `eval-source-roundtrip.test.ts` is now empty. That test fails in both directions, so it drove the work: a new offender fails it, and so does a stale entry.

## Tests

`default-width.test.ts` pins the behaviour rather than the source shape. It builds the bare instances at module scope *before* registering 32-bit ones, because that ordering is what reproduces the bug — building the bare instance inside the test body makes it the last write and the test passes either way. Checked against the unfixed source: 3/3 fail. With the fix: 3/3 pass.

- `@simten/core` — 687 passing
- `fpga:test` — 69/69
- `fpga:netlist-check` — matches golden
- lint at the 590-warning baseline, `tsc --noEmit` clean

The golden netlist is untouched because these evals never reached the RTL path: `extractParamNames` bails on any parameter with a default, so synthesis has always skipped them and still does.

Browser: `/blog/pong-in-hardware` — ↑ now moves the right paddle one pixel per frame instead of jumping to the top.

## The sandbox guard stays

#278's `STDLIB_EVAL_NAMES` skip is no longer the thing preventing a crash — rebuilt stdlib evals now run fine, which is exactly what the round-trip test asserts. It still earns its place: it blocks references a *bundler* introduces rather than ones we wrote (esbuild's `__name()` wrapper on named inner arrows is the known case, see the comment in `SignedDivider`), and it avoids needless evaluator recompiles from `EvalEntry` identity churn.
