### PR TITLE
fix(ui): re-run canvas layout on every change when autoLayout is set

### DIFF
--- a/.changeset/canvas-auto-layout.md
+++ b/.changeset/canvas-auto-layout.md
@@ -1,0 +1,11 @@
+---
+'@simten/ui': minor
+---
+
+Add `autoLayout` to `CircuitCanvas`, for canvases where nobody drags nodes.
+
+The layout engine only re-runs when nodes are added or removed. That is right for the editor — people drag nodes there, and a rename should leave them where they were — but the check keys on node ids alone, so adding a *wire* between two existing nodes counts as no change at all. The nodes stay in a layout computed before that wire existed, and the new edge takes a long detour to reach a node that should have moved.
+
+A read-only canvas has no hand-placed positions worth keeping. `autoLayout` re-runs the layout on every structural change, so the diagram always reflects the circuit as it is now.
+
+Defaults to `false`; the editor's behaviour is unchanged.

--- a/apps/game/src/routes/play.$levelId.tsx
+++ b/apps/game/src/routes/play.$levelId.tsx
@@ -191,6 +191,12 @@ function PlayLevel() {
               portValues={preview.portValues}
               theme="dark"
               showControls
+              // Re-lay out on every change. The default only re-runs the
+              // layout when nodes appear or disappear, so adding the last wire
+              // — which changes no nodes — left the lamp sitting where it had
+              // been while unconnected, with the new edge detouring to reach
+              // it. A level's diagram should always read as the circuit is now.
+              autoLayout
               // The harness switches are clickable, so the player can drive
               // their own circuit and see it light up before submitting.
               onToggleNode={preview.toggleNode}

--- a/packages/ui/src/canvas/CircuitCanvas.tsx
+++ b/packages/ui/src/canvas/CircuitCanvas.tsx
@@ -93,6 +93,20 @@ export interface CircuitCanvasProps {
   sequentialState?: FlatSequentialState | null;
   draggable?: boolean;
   /**
+   * Re-run the layout engine on every structural change, instead of only when
+   * nodes are added or removed.
+   *
+   * Positions are preserved by default because the editor lets people drag
+   * nodes, and #111 wanted a rename to leave them where they were. But that
+   * keys on node ids alone, so adding a *wire* between existing nodes leaves
+   * them in a layout computed before the wire existed — the new edge takes a
+   * long detour to a node that should have moved.
+   *
+   * A read-only canvas has no dragged positions worth keeping, so it wants the
+   * fresh layout every time. @default false
+   */
+  autoLayout?: boolean;
+  /**
    * Pre-computed node positions keyed by node label (or id, as fallback).
    * When provided, the layout engine is skipped entirely.
    * When absent, positions are computed by the layout engine on mount.
@@ -149,6 +163,7 @@ function CircuitCanvasInner({
   portValues,
   sequentialState,
   draggable = true,
+  autoLayout = false,
   layout,
   onToggleNode,
   onSetNodeValue,
@@ -367,7 +382,7 @@ function CircuitCanvasInner({
     for (const id of newIdSet) if (!prevIdSet.has(id)) added++;
     let removed = 0;
     for (const id of prevIdSet) if (!newIdSet.has(id)) removed++;
-    const relayout = (added > 0 && removed === 0) || (removed > 0 && added === 0);
+    const relayout = autoLayout || (added > 0 && removed === 0) || (removed > 0 && added === 0);
 
     setNodes((currentNodes) => {
       const prevById = new Map(currentNodes.map((n) => [n.id, n]));
@@ -417,7 +432,7 @@ function CircuitCanvasInner({
     if (projectedNodes.length > 0 && !fullReset && (wasBlank || relayout)) {
       requestAnimationFrame(() => fitView({ padding: 0.3 }));
     }
-  }, [projectedNodes, projectedEdges]);
+  }, [projectedNodes, projectedEdges, autoLayout]);
 
   const onNodesChange: OnNodesChange = useCallback((changes) => {
     setNodes((nds) => applyNodeChanges(changes, nds));

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import * as React from 'react';
+import type * as React from 'react';
 
 import { cn } from '../lib/utils';
 


### PR DESCRIPTION
Solving level 1 landed on a diagram that looked broken: the wire you just added took a long detour to reach a lamp still sitting where it had been while unconnected.

The circuit was fine — the layout was stale. `CircuitCanvas` decides whether to re-run dagre by counting node ids that appeared or disappeared (`CircuitCanvas.tsx:384`). Adding a wire between two existing nodes changes no node ids, so it scored "nothing changed" and every node kept its old position.

That is deliberate for the editor: people drag nodes there, and #111 asked that a rename leave them where they were. It is wrong for a canvas that is only ever generated, where there are no hand-placed positions to protect and the stale layout actively misleads.

## The change

`CircuitCanvas` gains an opt-in `autoLayout` prop that re-runs the layout on every structural change. The game passes it.

**Nothing else is affected.** It defaults to `false`, and the game is the only caller — `/circuit`, the blog embeds and the MCP viewer keep their current behaviour exactly. The Pong sections pass an explicit `layout`, which skips the layout engine entirely regardless.

## Considered and rejected

Tracking which nodes the user has dragged and preserving only those. It is the more principled rule — the id-churn count was always a proxy for "did a person place this" — and it would fix `/circuit` too, where a user who has never dragged anything gets the same stale detour.

Rejected for now because it needs new state plus a heuristic for the case where a pinned node ends up overlapping a re-flowed one, and it changes `/circuit` behaviour nobody has complained about. The prop is the smaller change and the escape hatch stays open.

## Verification

check-exports clean · core 687 · ui 110 · mcp 110 · embed 6 · web 2 · game 34 · typecheck clean · lint 590
