### PR TITLE
fix(game): read truth-table columns from the level's signal lists

### DIFF
--- a/apps/game/src/components/TruthTable.tsx
+++ b/apps/game/src/components/TruthTable.tsx
@@ -18,9 +18,22 @@ interface TruthTableProps {
   proven?: number;
 }
 
+/**
+ * Column names, as their own function so the table's read of the level shape
+ * is testable without a DOM.
+ *
+ * `level.inputs` is a list of signal names. It used to be a map, and this was
+ * `Object.keys(level.inputs)` — which on an array returns its indices, so the
+ * table silently rendered headers `0`, `1` and then looked up `v.inputs['0']`
+ * for every cell and found nothing. `Object.keys` on an array is legal
+ * TypeScript, so nothing failed; the table just went blank.
+ */
+export function columnsFor(level: Level): { inputNames: string[]; outputNames: string[] } {
+  return { inputNames: level.inputs, outputNames: level.outputs };
+}
+
 export function TruthTable({ level, active = null, proven = 0 }: TruthTableProps) {
-  const inputNames = Object.keys(level.inputs);
-  const outputNames = Object.keys(level.outputs);
+  const { inputNames, outputNames } = columnsFor(level);
 
   return (
     <table className="w-full font-mono text-sm">

--- a/apps/game/src/game/__tests__/truth-table.test.ts
+++ b/apps/game/src/game/__tests__/truth-table.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The truth table has to read the level shape correctly.
+ *
+ * When levels moved from `Record<string, PortSpec>` to a list of signal names,
+ * the table kept doing `Object.keys(level.inputs)` — which on an array returns
+ * indices. It rendered headers `0`, `1`, `0` and blank cells, and neither
+ * TypeScript nor the suite noticed, because `Object.keys` on an array is
+ * perfectly legal and nothing rendered the component.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { columnsFor } from '../../components/TruthTable';
+import { LEVELS } from '../levels';
+
+describe('columnsFor', () => {
+  it.each(LEVELS.map((l) => [l.id, l] as const))('%s names its signals', (_id, level) => {
+    const { inputNames, outputNames } = columnsFor(level);
+
+    // Never array indices.
+    for (const name of [...inputNames, ...outputNames]) {
+      expect(name).not.toMatch(/^\d+$/);
+    }
+
+    // Every column must actually resolve against the vectors it labels.
+    for (const v of level.vectors) {
+      for (const n of inputNames) expect(v.inputs[n]).toBeTypeOf('number');
+      for (const n of outputNames) expect(v.expect[n]).toBeTypeOf('number');
+    }
+  });
+});


### PR DESCRIPTION
The truth table on every level rendered headers `0`, `1`, `0` with blank cells underneath, instead of `a`, `b`, `out` and four rows.

Levels moved from `inputs: Record<string, PortSpec>` to `inputs: string[]` — a list of signal names — but `TruthTable` kept doing:

```ts
const inputNames = Object.keys(level.inputs);
```

`Object.keys` on an array returns its **indices**. So the columns were labelled `0` and `1`, and every cell then looked up `v.inputs['0']`, which does not exist.

Nothing caught it. `Object.keys` on an array is perfectly legal TypeScript, so the typechecker was happy, and no test rendered the component — the suite covered the grader and the levels, both of which were correct.

## The fix

Column derivation moves into an exported `columnsFor(level)`, so the component's read of the level shape can be tested without a DOM. It returns the signal lists directly.

`truth-table.test.ts` asserts, for every level, that no column name is a bare number and that each one resolves against the vectors it labels — so a column that does not correspond to real data fails rather than rendering blank. Verified it fails against the previous code.

## Verification

game 38 tests · typecheck clean · lint 590 (baseline)

## Note

This is the second data-shape change that slipped past the suite into the UI. The game has no component-level tests at all; adding jsdom and a render test would catch this class directly rather than via an extracted helper. Not done here — it adds dependencies and this fix did not need them — but worth doing before the UI grows.
