### PR TITLE
fix(game): warn inline when the circuit name diverges from the level's

### DIFF
--- a/.changeset/core-circuit-names.md
+++ b/.changeset/core-circuit-names.md
@@ -1,0 +1,11 @@
+---
+'@simten/core': minor
+---
+
+Add `circuitNameSites` and `firstCircuitName` to `@simten/core/circuit`, for finding `circuit('Name', …)` declarations in source text.
+
+Both sit alongside `stripTypes`/`stripImports`/`stripExports` — text utilities that run before, or instead of, executing circuit source. Two callers had grown near-identical regexes for this: share links in the web app, which title a page from the circuit it contains, and the challenge game, which warns when the circuit you have written is not the one a level grades.
+
+`circuitNameSites` returns every declaration with 1-based line and column bounding the name, so an editor can place a marker on it. `firstCircuitName` is the common "just give me a label" case.
+
+Best-effort by contract: it is a regex, so it is brittle on template literals, escaped quotes and names split across lines. Callers must have a fallback for the misses. Use `executeCircuitCode` when the answer has to be right.

--- a/apps/game/src/game/__tests__/level-name.test.ts
+++ b/apps/game/src/game/__tests__/level-name.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The name warning has to fire while you type, not on Submit.
+ *
+ * Renaming the circuit used to empty the canvas and say nothing until you
+ * submitted — the only way to learn the rule was to trip over it. These cover
+ * the cases that decide whether the warning is helpful or just noise.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { nameDiagnostics } from '../level-name';
+import { LEVELS } from '../levels';
+
+describe('nameDiagnostics', () => {
+  it('says nothing when the target is present', () => {
+    expect(nameDiagnostics(`circuit('And1', {})`, 'And1')).toEqual([]);
+  });
+
+  it('stays quiet on a source with no circuit yet', () => {
+    // Mid-keystroke. Nagging about a name nobody has written is not help.
+    expect(nameDiagnostics('// thinking', 'And1')).toEqual([]);
+  });
+
+  it('warns, and names both sides, when the name diverges', () => {
+    const [d] = nameDiagnostics(`export default circuit('MyAnd', {})`, 'And1');
+    expect(d.severity).toBe('warning');
+    expect(d.message).toContain('And1');
+    expect(d.message).toContain('MyAnd');
+    expect(d.line).toBe(1);
+  });
+
+  it('is a warning, never an error — the code is valid', () => {
+    const ds = nameDiagnostics(`circuit('Nope', {})`, 'And1');
+    expect(ds.every((d) => d.severity === 'warning')).toBe(true);
+  });
+});
+
+describe('every level stub satisfies its own target', () => {
+  it.each(LEVELS.map((l) => [l.id, l] as const))('%s', (_id, level) => {
+    expect(nameDiagnostics(level.stub, level.target)).toEqual([]);
+  });
+});

--- a/apps/game/src/game/level-name.ts
+++ b/apps/game/src/game/level-name.ts
@@ -1,0 +1,49 @@
+/**
+ * Telling the player, immediately, that their circuit is not the one being graded.
+ *
+ * A level grades a circuit with a specific name — the same contract LeetCode
+ * and Codewars use, where the signature is fixed and the body is yours. The
+ * problem was never the rule, it was the silence: renaming the circuit emptied
+ * the canvas and said nothing until Submit, so the only way to learn the rule
+ * was to trip over it.
+ *
+ * Finding the names is `@simten/core`'s job (`circuitNameSites`, which also
+ * backs share-link titles). What counts as wrong is this game's rule, so only
+ * that lives here.
+ */
+
+import { circuitNameSites } from '@simten/core/circuit';
+
+export interface NameDiagnostic {
+  message: string;
+  line: number;
+  column: number;
+  endColumn: number;
+  severity: 'warning';
+}
+
+/**
+ * A warning when nothing in the source carries the name the level grades.
+ *
+ * Deliberately a warning, not an error: the code is valid and the circuit may
+ * be perfectly correct. It just is not the one that will be marked.
+ *
+ * Silent when the source declares no circuit at all — that is someone
+ * mid-keystroke, and nagging them about a name is not help.
+ */
+export function nameDiagnostics(source: string, target: string): NameDiagnostic[] {
+  const sites = circuitNameSites(source);
+  if (sites.length === 0) return [];
+  if (sites.some((s) => s.name === target)) return [];
+
+  const found = sites.map((s) => s.name).join(', ');
+  return sites.map((s) => ({
+    message:
+      `This level grades a circuit called \`${target}\`, and this one is called \`${s.name}\`. ` +
+      `Rename it to \`${target}\` — the rest is yours. (Found: ${found}.)`,
+    line: s.line,
+    column: s.column,
+    endColumn: s.endColumn,
+    severity: 'warning' as const,
+  }));
+}

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -37,7 +37,7 @@ export const LEVELS: Level[] = [
 // done except for the last wire: the AND gate has its answer, but nothing
 // carries it to the lamp.
 
-export const And1 = circuit('And1', {
+export default circuit('And1', {
   nodes: {
     a: Switch,
     b: Switch,
@@ -74,7 +74,7 @@ export const And1 = circuit('And1', {
 //
 // Hint: a NAND has two inputs. Nothing says they have to be different.
 
-export const Not1 = circuit('Not1', {
+export default circuit('Not1', {
   nodes: {
     a: Switch,
     out: Led,
@@ -105,7 +105,7 @@ export const Not1 = circuit('Not1', {
 // A signal can drive more than one port:
 //   a.out.to(n1.a, n2.a)
 
-export const Xor1 = circuit('Xor1', {
+export default circuit('Xor1', {
   nodes: {
     a: Switch,
     b: Switch,
@@ -143,7 +143,7 @@ export const Xor1 = circuit('Xor1', {
 // attached. That is the point: it is a component now, and a component is
 // something other circuits can use without knowing how it works.
 
-export const Xor2 = circuit('Xor2', {
+export default circuit('Xor2', {
   inputs: { a: bit, b: bit },
   outputs: { out: bit },
   nodes: {

--- a/apps/game/src/routes/play.$levelId.tsx
+++ b/apps/game/src/routes/play.$levelId.tsx
@@ -24,6 +24,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { GradeReport } from '../components/GradeReport';
 import { TruthTable } from '../components/TruthTable';
 import { grade } from '../game/grade';
+import { nameDiagnostics } from '../game/level-name';
 import { LEVELS, LEVELS_BY_ID, levelIndex, nextLevel } from '../game/levels';
 import { sandboxRuntime } from '../game/runtime';
 import type { GradeResult, Level } from '../game/types';
@@ -68,7 +69,11 @@ function PlayLevel({ level }: { level: Level }) {
   // name — the default picks the last circuit defined, which would follow a
   // player's helper instead of their answer. Same reason the grader does it.
   const select = useCallback(
-    (circuits: { name: string }[]) => circuits.find((c) => c.name === level.target),
+    (circuits: { name: string }[]) =>
+      // Fall back to the last circuit defined when nothing carries the target
+      // name. Only grading depends on the name; taking away the diagram as
+      // well turned a rule into a punishment, with no explanation until Submit.
+      circuits.find((c) => c.name === level.target) ?? circuits[circuits.length - 1],
     [level.target],
   );
 
@@ -107,15 +112,9 @@ function PlayLevel({ level }: { level: Level }) {
     }
   }, [sandbox, level, source, victory]);
 
-  // Circuit names the source defines right now — used to explain an empty
-  // canvas rather than leaving the player staring at one.
-  const defined = useMemo(
-    () =>
-      [...(source.matchAll(/circuit\(\s*['"]([^'"]+)['"]/g) as Iterable<RegExpMatchArray>)].map(
-        (m) => m[1],
-      ),
-    [source],
-  );
+  // Surfaced as a Monaco squiggle rather than a panel note: the problem is on
+  // a specific line, and that is where someone is looking.
+  const diagnostics = useMemo(() => nameDiagnostics(source, level.target), [source, level.target]);
 
   const solved = result?.status === 'pass';
   const next = useMemo(() => nextLevel(level.id), [level.id]);
@@ -209,6 +208,7 @@ function PlayLevel({ level }: { level: Level }) {
                     victory.reset();
                   }
                 }}
+                diagnostics={diagnostics}
                 beforeMount={registerSimtenThemes}
                 theme={SIMTEN_DARK}
                 options={{
@@ -246,20 +246,11 @@ function PlayLevel({ level }: { level: Level }) {
               onToggleNode={preview.toggleNode}
               onSetNodeValue={preview.setNodeValue}
               renderEmptyState={() => (
-                <div className="grid h-full place-items-center px-6 text-center text-sm text-muted-foreground">
-                  {/* The preview is pinned to the level's target by name, so a
-                      correct circuit under a different name renders nothing.
-                      Saying which name is missing beats an empty canvas that
-                      looks like the code is broken. */}
-                  {defined.length > 0 ? (
-                    <span>
-                      Nothing here is called <span className="font-mono">{level.target}</span>.
-                      {' This level previews and grades that name — found '}
-                      <span className="font-mono">{defined.join(', ')}</span>.
-                    </span>
-                  ) : (
-                    'Your circuit appears here as you write it.'
-                  )}
+                <div className="grid h-full place-items-center text-sm text-muted-foreground">
+                  {/* A name mismatch no longer lands here — the preview falls
+                      back to the last circuit defined, and the editor carries
+                      the warning. This is only ever an empty source. */}
+                  Your circuit appears here as you write it.
                 </div>
               )}
             />

--- a/apps/web/src/lib/extract-circuit-name.ts
+++ b/apps/web/src/lib/extract-circuit-name.ts
@@ -1,13 +1,18 @@
 /**
- * Best-effort extraction of the first `circuit('Name', ...)` invocation in a
- * source string, for SSR `<title>` / og:title. Brittle on template literals,
- * escaped quotes, multi-line declarations — that's intentional. Callers MUST
- * have a generic fallback for the misses.
+ * Best-effort extraction of the first `circuit('Name', ...)` in a source
+ * string, for SSR `<title>` / og:title.
+ *
+ * Brittle on template literals, escaped quotes and multi-line declarations —
+ * that is intentional, and callers MUST have a generic fallback for the misses.
+ * The scan itself lives in `@simten/core/circuit` so the editor, the game and
+ * this share the one implementation.
  */
+
+import { firstCircuitName } from '@simten/core/circuit';
+
 export function extractCircuitName(source: string): string | null {
   try {
-    const m = source.match(/\bcircuit\s*\(\s*['"]([A-Za-z_$][\w$]*)['"]/);
-    return m?.[1] ?? null;
+    return firstCircuitName(source);
   } catch {
     return null;
   }

--- a/packages/core/src/circuit/__tests__/circuit-names.test.ts
+++ b/packages/core/src/circuit/__tests__/circuit-names.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Source-text scanning for `circuit('Name', …)`.
+ *
+ * Backs share-link titles in apps/web and the level-name warning in the game,
+ * which previously carried a near-identical regex each. Best-effort by
+ * contract, so these pin what it does handle and document what it does not.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { circuitNameSites, firstCircuitName } from '../circuit-names.js';
+
+describe('circuitNameSites', () => {
+  it('brackets the name itself, not the call', () => {
+    const [site] = circuitNameSites(`export default circuit('And1', {`);
+    expect(site).toMatchObject({ name: 'And1', line: 1 });
+    expect(site.endColumn - site.column).toBe('And1'.length);
+    // Column lands on the name, past the opening quote.
+    expect(`export default circuit('And1', {`.slice(site.column - 1, site.endColumn - 1)).toBe(
+      'And1',
+    );
+  });
+
+  it('reports every declaration in source order, with line numbers', () => {
+    const src = "circuit('One', {})\n\nconst x = circuit('Two', {})";
+    expect(circuitNameSites(src).map((s) => [s.name, s.line])).toEqual([
+      ['One', 1],
+      ['Two', 3],
+    ]);
+  });
+
+  it('accepts double quotes and whitespace in the call', () => {
+    expect(circuitNameSites(`circuit  (  "Spaced" , {})`).map((s) => s.name)).toEqual(['Spaced']);
+  });
+
+  it('ignores names that are not valid identifiers', () => {
+    expect(circuitNameSites(`circuit('9lives', {})`)).toEqual([]);
+  });
+
+  it('returns nothing for source with no circuit', () => {
+    expect(circuitNameSites('const x = 1;')).toEqual([]);
+  });
+});
+
+describe('firstCircuitName', () => {
+  it('returns the first declaration', () => {
+    expect(firstCircuitName("circuit('A', {})\ncircuit('B', {})")).toBe('A');
+  });
+
+  it('returns null when there is none', () => {
+    expect(firstCircuitName('// nothing here')).toBeNull();
+  });
+});

--- a/packages/core/src/circuit/circuit-names.ts
+++ b/packages/core/src/circuit/circuit-names.ts
@@ -1,0 +1,53 @@
+/**
+ * Finding `circuit('Name', …)` declarations in source text.
+ *
+ * Sits with `stripTypes`/`stripImports`/`stripExports`: text utilities for
+ * circuit source that run before, or instead of, executing it. Callers use it
+ * to title a shared circuit, or to tell an author which circuit they have
+ * actually declared, without paying for a compile.
+ *
+ * Best-effort by design. It is a regex, so it is brittle on template literals,
+ * escaped quotes and names split across lines. Every caller MUST have a
+ * fallback for the misses — this is for labels and hints, never for anything
+ * that must be correct. Use `executeCircuitCode` when it must be.
+ */
+
+/** A `circuit('Name'` occurrence, with enough position to place an editor marker. */
+export interface CircuitNameSite {
+  name: string;
+  /** 1-based, matching editor conventions. */
+  line: number;
+  /** 1-based column of the name itself, excluding its quotes. */
+  column: number;
+  /** 1-based column just past the name. */
+  endColumn: number;
+}
+
+const CIRCUIT_CALL = /\bcircuit\s*\(\s*['"`]([A-Za-z_$][\w$]*)['"`]/g;
+
+/** Every circuit name the source declares, in source order. */
+export function circuitNameSites(source: string): CircuitNameSite[] {
+  const sites: CircuitNameSite[] = [];
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    CIRCUIT_CALL.lastIndex = 0;
+    let m: RegExpExecArray | null = CIRCUIT_CALL.exec(lines[i]);
+    while (m !== null) {
+      const name = m[1];
+      const nameStart = lines[i].indexOf(name, m.index);
+      sites.push({
+        name,
+        line: i + 1,
+        column: nameStart + 1,
+        endColumn: nameStart + 1 + name.length,
+      });
+      m = CIRCUIT_CALL.exec(lines[i]);
+    }
+  }
+  return sites;
+}
+
+/** The first circuit name declared, or null. For titles and labels. */
+export function firstCircuitName(source: string): string | null {
+  return circuitNameSites(source)[0]?.name ?? null;
+}

--- a/packages/core/src/circuit/index.ts
+++ b/packages/core/src/circuit/index.ts
@@ -10,6 +10,7 @@ export type { MemState, RegState, StateFieldType } from './bit-bus.js';
 export { bit, bus, mem, reg } from './bit-bus.js';
 export { buildFromIR } from './build-from-ir.js';
 export { circuit } from './circuit.js';
+export { type CircuitNameSite, circuitNameSites, firstCircuitName } from './circuit-names.js';
 export { CircuitToSourceError, circuitToSource } from './circuit-to-source.js';
 export type { EvalEntry } from './eval-registry.js';
 export { getAllCircuitEvals, getCircuitEval, registerCircuitEval } from './eval-registry.js';


### PR DESCRIPTION
Renaming the circuit in a level made the canvas vanish, with nothing explaining why until you pressed Submit. The rule — a level grades a circuit with a given name — is fine and standard; LeetCode and Codewars fix the signature too. The problem was that the only way to learn it was to trip over it.

Three changes, no architecture.

## The name appears once, not twice

`export const And1 = circuit('And1', …)` named the circuit twice and bound something no level references. Stubs now use `export default circuit('And1', …)`.

This needed no core change — `stripExports` already rewrites `export default X` to a bare expression, so the `circuit()` call registers exactly as before. Verified both forms produce identical results before switching.

## The preview never disappears

`select` falls back to the last circuit defined when nothing carries the target name. Only grading depends on the name; taking the diagram away as well turned a rule into a punishment.

## The editor says so, on the line, as you type

A warning marker on the circuit name when it does not match: *"This level grades a circuit called `And1`, and this one is called `MyAnd`. Rename it to `And1` — the rest is yours."*

A warning rather than an error, because the code is valid and the circuit may well be correct — it just is not the one being marked. Silent when the source declares no circuit at all, since that is someone mid-keystroke.

## Shared rather than duplicated

Finding `circuit('Name', …)` in source text moves to `@simten/core/circuit` as `circuitNameSites` / `firstCircuitName`, beside the existing `stripTypes`/`stripImports`/`stripExports` text helpers.

`apps/web/src/lib/extract-circuit-name.ts` already carried a near-identical regex for share-link titles, and this would have been the second copy. It is now a thin wrapper over the shared one. Only the *rule* — what counts as the wrong name for a level — stays in the game.

Best-effort by contract: it is a regex, brittle on template literals and escaped quotes, and callers must have a fallback. Documented on the export and covered by tests that pin both what it handles and what it does not.

## Verified in the browser

Renaming `And1` to `MyAnd`: warning marker on line 8 at severity `warning`, canvas still rendering all four nodes.

check-exports clean · core 694 · ui 110 · mcp 110 · embed 6 · web 2 · game 46 · typecheck clean · lint 590

## Noticed, not fixed

The stub trips TypeScript's "'out' is declared but its value is never read" hint, because the destructure names `out` while the wire that uses it is still a comment. Harmless, and it disappears the moment the level is solved — but it is a squiggle on the thing the player is about to use.
