### PR TITLE
feat(game): show a per-level completion dialog when a level is solved

### DIFF
--- a/.changeset/ui-dialog-primitive.md
+++ b/.changeset/ui-dialog-primitive.md
@@ -1,0 +1,7 @@
+---
+'@simten/ui': minor
+---
+
+Add `@simten/ui/primitives/dialog` — the shadcn Dialog wrapper.
+
+Built on `@radix-ui/react-dialog`, which `Sheet` already depends on, so this adds no new dependency; a Sheet is a Dialog pinned to an edge. Use `Dialog` when the content is a moment with one obvious next action, and `Sheet` when it is a surface the page keeps working behind.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,162 @@
+# Handoff — Simten challenge game
+
+## Where things stand
+
+`apps/game` is a playable four-level campaign at `play.simten.dev` (dev: `localhost:3003`).
+All four levels have been solved end to end in a browser. The engine works.
+
+**Branch `feat/game-level-complete` has uncommitted work** that must be committed and
+PR'd before anything else:
+
+- `packages/ui/src/primitives/dialog.tsx` — new shadcn Dialog over Radix Dialog (the
+  same library `Sheet` already uses, so no new dependency). Exported as
+  `@simten/ui/primitives/dialog`, wired into `exports` **and** `publishConfig.exports`.
+- `apps/game/src/components/LevelComplete.tsx` — completion dialog.
+- Per-level `outro: { headline, body }` on the `Level` type, written for all four levels.
+- Level 2's stub now places `n1: Nand` and pre-wires `n1.out.to(out.in)`.
+- `SpecPanel` shows failures only; a pass belongs to the dialog.
+
+Needs a changeset for `@simten/ui` (minor — new export). Everything else is app-local.
+
+Merged already: #285 #286 #287 #289. PR #290 is an open Version Packages release.
+
+## The task
+
+Add Act 1's four missing levels to `apps/game/src/game/levels.ts`:
+
+```
+1  First Wire          (And given)     exists
+2  NOT from NAND                       exists
+3  AND from NAND       ADD  ~2 gates, 4 wires
+4  OR from NAND        ADD  ~3 gates, 5 wires   ← De Morgan, the insight of the act
+5  NOR from NAND       ADD  ~4 gates, 6 wires
+6  XOR from NAND                       exists (renumber after 5)
+7  XNOR from NAND      ADD  ~5 gates, 7 wires
+8  Making a Component                  exists (currently id `half-adder`, keep the id —
+                                       it is public URL surface)
+```
+
+Loosely follows Turing Complete's own order (NAND → NOT → {AND, NOR, OR} → XOR → XNOR).
+Each new level is a few minutes. This takes Act 1 from ten minutes to something with a
+shape, and fills the gap where the scaffolding currently drops sharply between levels 2
+and 3.
+
+## Design rules that were argued out — do not quietly reverse these
+
+**Levels are self-contained.** `Switch` nodes → your gates → `Led` nodes. **No `inputs`/
+`outputs` ports.** A circuit with ports gets wrapped by `autoHarness` and renders as one
+opaque `dut` box, which hides the gates the player just wrote — the entire feedback loop.
+`autoHarness` returns the circuit untouched when it declares no ports
+(`packages/core/src/circuit/auto-harness.ts:23`), so self-contained levels get the raw
+view for free. Level 8 is the deliberate exception: introducing ports *is* its lesson,
+and the black box is the point.
+
+**Composition is for ingredients, never for the dish.** What you build this level is
+always self-contained and fully visible. What you *reuse* from an earlier level is a box
+you can double-click into. Never let the thing under construction collapse.
+
+**Watch the wire budget.** Act 1 levels are 4–7 `.to()` lines. That is fine. A 4-bit
+adder written as raw gates is ~90 lines and would be unplayable; built from the player's
+own `FullAdder` it is ~12. Composition is not a nice-to-have arriving late — it is what
+decides whether Act 2 exists. Nothing today lets a level import a previous solution;
+**that is the real design work after this task.**
+
+**Skip TC's byte-widening grind.** Byte NAND / Byte NOT / Adding Bytes / Byte XOR exist
+in TC because wiring eight copies by hand is its difficulty. `bus(8)` makes eight bits
+one wire. Replace that whole band with a single parameterised-width level.
+
+**Names are fixed and that is fine** (LeetCode does the same). What was wrong was the
+silence — solved in #287: the editor warns inline on the exact line, the preview falls
+back to the last circuit defined so the canvas never blanks, and the panel always shows
+"Must define". Do not reintroduce a silent failure here.
+
+**Stubs use `export default circuit('Name', …)`.** One occurrence of the name, no unused
+`const`. Verified this registers identically to the `const` form — `stripExports`
+rewrites it to a bare expression.
+
+## How the pieces work
+
+**Level format** — `apps/game/src/game/types.ts`. A level is pure data: `id`, `title`,
+`brief`, `target` (circuit name), `inputs`/`outputs` (**bare signal-name arrays**, not
+port maps), `allowed` (primitive names), `stub`, `vectors`, `par?`, `outro`.
+Nothing executes, so levels can move to R2 later as plain JSON.
+
+**Grading** — `apps/game/src/game/grade.ts`, four ordered checks: circuit exists →
+exposes the named signals → built only from permitted primitives → truth table.
+The score is **positive**: `gates = nodes whose type ∈ allowed`. Counting everything and
+subtracting an exclusion list means a forgotten primitive silently inflates par; this way
+`Switch`/`Led` never count because they are not in `allowed`.
+
+**Runtime** — `apps/game/src/game/runtime.ts`. `GradeRuntime` is a narrow interface so
+the grader runs host-side in tests. Two traps already paid for:
+
+- `sandbox.compile` builds its simulator on the **last** circuit in the source, so
+  `select()` pins the target by name via `compileIR`. Without it a helper defined below
+  the answer gets graded instead.
+- Output keys differ between runtimes — the sandbox namespaces top-level ports under
+  `__top__.`, `@simten/core/sim` returns them bare. `resolveOutput` reads
+  `__top__.<name>` else `<name>.in`. A missing signal is an **error**, never a default
+  of 0; a `?? 0` fallback silently passed every row expecting 0, which is most of them.
+
+**The validation gate** — `apps/game/src/game/__tests__/levels.test.ts`. Every level
+ships a reference solution that must pass, **and** constant-0/constant-1 answers that
+must fail. The second direction catches a tautological grader and is invisible if you
+only test that solutions pass. **Add a reference solution for every new level** — the
+suite asserts the set matches `LEVELS` exactly.
+
+## Verification
+
+```
+pnpm --filter @simten/game test       # 47 currently; add ~4 per new level
+pnpm --filter @simten/game exec tsc --noEmit
+pnpm test                             # check-exports + all packages
+pnpm lint                             # 590-warning baseline, do not raise it
+```
+
+Browser is not optional. Every UI bug this session — blank canvas, stale layout, broken
+truth table, state surviving navigation — passed the test suite. Dev server is on
+**:3003**, run by the user; do not start your own. Drive it with the Playwright MCP:
+`window.monaco.editor.getModels()[0].setValue(...)` edits the editor,
+`document.querySelector('button.bg-primary').click()` submits.
+
+## Conventions
+
+Conventional Commits, **one line, no `Co-Authored-By`**. Biome runs first in CI, so
+`pnpm lint` before pushing. **Pull `main` and branch fresh before starting** — a stale
+branch cost a conflict this session. Every change to a published package
+(`@simten/core`, `@simten/ui`, `@simten/embed`, `@simten/mcp`) needs a changeset;
+apps are in the changesets ignore list.
+
+## Known, deliberately unfixed
+
+- Level briefs render as plain text, so backticks show literally.
+- No hint affordance. Levels 2–3 are where someone will stall; this is the highest-value
+  UX addition after the levels themselves.
+- No persistence — refresh loses everything. localStorage was designed but not built:
+  `simten:game:progress` (solved + gates) and `simten:game:drafts` (source per level),
+  behind a narrow module so D1 can replace it later. Guard SSR, wrap the parse, include a
+  `version` field. Do this before any playtest, or lost progress will read as "broken".
+- No level map. The intent is that it *is* a circuit — solved levels as `Switch` nodes,
+  prerequisites as real `And` gates, unlock state as the simulator's actual output. TC's
+  map only looks like circuitry; ours would run. Edges should mean genuine dependency
+  ("this level imports the XOR you built"), not just suggested order.
+- Embed utility classes are unprefixed, so a host page also running Tailwind gets two
+  definitions of `.flex`. Deliberate: needs a divergent Tailwind config before anything
+  breaks, and scoping the sheet risks the `.dark` trigger that intentionally matches the
+  host's element.
+- `pnpm --filter @simten/web build` fails at prerendering on a Cloudflare API auth error,
+  after both Vite bundles build fine. Pre-existing and unrelated; matches the note about
+  wrangler defaulting to the wrong account.
+
+## Honest assessment, so the next agent does not oversell it
+
+It is satisfying, not yet fun. The victory sweep — the lamp following the truth table,
+driven by the player's own circuit — is the best thing in it and should be protected.
+But two of four levels have no puzzle (level 1 hands you the answer, level 8 is level 6
+retyped), there is no reason to solve anything twice, and there is no viral loop at all:
+no share, no score comparison, no persistence, no map.
+
+The gap to "game" is mostly **content**, which is human-authored and cannot be shortcut.
+Before paying that cost, the cheapest useful thing is to put the existing levels in front
+of five people and watch — specifically whether the typing feels like thinking or like
+typing, which is the bet the whole code-only decision rests on.

--- a/apps/game/src/components/LevelComplete.tsx
+++ b/apps/game/src/components/LevelComplete.tsx
@@ -1,0 +1,97 @@
+/**
+ * The moment a level is finished.
+ *
+ * Deliberately arrives *after* the victory run, not instead of it. The run —
+ * switches flipping, lamp following the truth table — is the proof; this is the
+ * receipt. Opening a dialog over a circuit still demonstrating itself would
+ * step on the better of the two.
+ *
+ * Dismissible on purpose. `par` only means something if you can close this,
+ * go back, and try to beat it — a completion screen whose only exit is "next"
+ * quietly says optimising was never the point.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@simten/ui/primitives/dialog';
+import { Link } from '@tanstack/react-router';
+import type { Level } from '../game/types';
+
+interface LevelCompleteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  level: Level;
+  gates: number;
+  /** The level after this one, or undefined at the end of the campaign. */
+  next: Level | undefined;
+  /** Position in the campaign, for the "3 of 4" line. */
+  position: number;
+  total: number;
+}
+
+export function LevelComplete({
+  open,
+  onOpenChange,
+  level,
+  gates,
+  next,
+  position,
+  total,
+}: LevelCompleteProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogDescription className="text-xs uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+            {level.title} · {position} of {total}
+          </DialogDescription>
+          <DialogTitle className="text-2xl">{level.outro.headline}</DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm leading-relaxed text-muted-foreground">{level.outro.body}</p>
+
+        <div className="flex items-baseline gap-2 rounded-lg border border-border bg-card/60 px-4 py-3">
+          <span className="font-mono text-3xl font-semibold tabular-nums leading-none">
+            {gates}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {gates === 1 ? 'gate' : 'gates'} used
+          </span>
+        </div>
+
+        <DialogFooter>
+          {/* Closing is a real choice, not a dismissal: it is how you go back
+              and try to beat par. */}
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="rounded-md border border-border px-4 py-2 text-sm font-medium"
+          >
+            Back to the circuit
+          </button>
+          {next ? (
+            <Link
+              to="/play/$levelId"
+              params={{ levelId: next.id }}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline"
+            >
+              Next: {next.title} →
+            </Link>
+          ) : (
+            <Link
+              to="/play"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline"
+            >
+              That is the last one — back to the levels
+            </Link>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/game/src/components/SpecPanel.tsx
+++ b/apps/game/src/components/SpecPanel.tsx
@@ -52,7 +52,10 @@ export function SpecPanel({ level, result, activeRow, provenRows, revealVerdict 
         <Field label="Signals">{[...level.inputs, ...level.outputs].join(', ')}</Field>
       </div>
 
-      {result && (
+      {/* Failures only. A pass gets the completion dialog, and the header keeps
+          a persistent "Solved · N" chip that reopens it — repeating the score
+          here as well would be the third place saying the same thing. */}
+      {result && result.status !== 'pass' && (
         <div className="min-w-[260px] shrink-0">
           <GradeReport result={result} level={level} revealed={revealVerdict} />
         </div>

--- a/apps/game/src/game/__tests__/levels.test.ts
+++ b/apps/game/src/game/__tests__/levels.test.ts
@@ -205,4 +205,13 @@ describe('level definitions', () => {
   it('ship a stub that names the target circuit', () => {
     for (const level of LEVELS) expect(level.stub).toContain(`'${level.target}'`);
   });
+
+  it('all carry completion copy', () => {
+    // The dialog reads straight from this, so a level without it finishes on
+    // an empty headline — and the failure would only show on a solve.
+    for (const level of LEVELS) {
+      expect(level.outro.headline.trim().length).toBeGreaterThan(0);
+      expect(level.outro.body.trim().length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -58,6 +58,10 @@ export default circuit('And1', {
       { inputs: { a: 1, b: 1 }, expect: { out: 1 } },
     ],
     par: 1,
+    outro: {
+      headline: "That's a circuit",
+      body: 'Two switches, a gate, and a lamp. Everything from here is that same idea repeated. Next you lose the AND gate: you get one gate from now on and build the rest yourself.',
+    },
   },
 
   {
@@ -69,18 +73,23 @@ export default circuit('And1', {
     inputs: ['a'],
     outputs: ['out'],
     allowed: ['Nand'],
-    stub: `// You choose the nodes now. Add what you need to \`nodes\`,
-// then wire it up.
+    stub: `// One gate from here on: NAND.
+// It outputs 0 only when both inputs are 1.
 //
-// Hint: a NAND has two inputs. Nothing says they have to be different.
+// The NAND is placed, and its output already
+// runs to the lamp. What is missing is the input.
+//
+// Hint: it has two inputs. Nothing says they
+// have to come from different places.
 
 export default circuit('Not1', {
   nodes: {
     a: Switch,
+    n1: Nand,
     out: Led,
   },
-  connect: ({ nodes: { a, out } }) => [
-    //
+  connect: ({ nodes: { a, n1, out } }) => [
+    n1.out.to(out.in),
   ],
 });
 `,
@@ -89,6 +98,10 @@ export default circuit('Not1', {
       { inputs: { a: 1 }, expect: { out: 0 } },
     ],
     par: 1,
+    outro: {
+      headline: 'One gate down',
+      body: 'You built NOT out of nothing but NAND. Every other gate works the same way. XOR is next, and it takes four of them.',
+    },
   },
 
   {
@@ -123,6 +136,10 @@ export default circuit('Xor1', {
       { inputs: { a: 1, b: 1 }, expect: { out: 0 } },
     ],
     par: 4,
+    outro: {
+      headline: 'Four NANDs, one XOR',
+      body: "That's the gate an adder is built from, so you'll be reaching for it again. Next you wrap it up so other circuits can use it without seeing inside.",
+    },
   },
 
   {
@@ -161,6 +178,10 @@ export default circuit('Xor2', {
       { inputs: { a: 1, b: 1 }, expect: { out: 0 } },
     ],
     par: 4,
+    outro: {
+      headline: "It's a component now",
+      body: 'Ports instead of switches, and the diagram collapsed into one box. That is what lets circuits build on each other, which is where this goes next.',
+    },
   },
 ];
 

--- a/apps/game/src/game/types.ts
+++ b/apps/game/src/game/types.ts
@@ -67,10 +67,22 @@ export interface Level {
    */
   vectors: Vector[];
   /**
-   * Gate count worth beating. Shown as a target, never enforced. `undefined`
-   * means the level has no interesting optimum.
+   * Gate count worth beating. Used for scoring; not shown on the completion
+   * dialog, where a par figure reads as a mark out of ten rather than an
+   * invitation. `undefined` means the level has no interesting optimum.
    */
   par?: number;
+  /**
+   * What the completion dialog says. Written per level so finishing one names
+   * what you just built and points at what is coming, instead of repeating a
+   * generic "solved" every time.
+   */
+  outro: {
+    /** The reaction, not the fact. Short. */
+    headline: string;
+    /** A sentence or two: what you made, and the hook into the next level. */
+    body: string;
+  };
 }
 
 /** Why a submission was rejected. Each case carries what the player needs to fix it. */

--- a/apps/game/src/routes/play.$levelId.tsx
+++ b/apps/game/src/routes/play.$levelId.tsx
@@ -22,6 +22,7 @@ import { Sheet, SheetContent, SheetTitle } from '@simten/ui/primitives/sheet';
 import { useSandboxContext } from '@simten/ui/sandbox';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { useCallback, useMemo, useState } from 'react';
+import { LevelComplete } from '../components/LevelComplete';
 import { SpecPanel } from '../components/SpecPanel';
 import { grade } from '../game/grade';
 import { nameDiagnostics } from '../game/level-name';
@@ -65,6 +66,9 @@ function PlayLevel({ level }: { level: Level }) {
   const [result, setResult] = useState<GradeResult | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [specOpen, setSpecOpen] = useState(true);
+  // Closing the completion dialog must not immediately reopen it, but a fresh
+  // submit should bring it back.
+  const [completeDismissed, setCompleteDismissed] = useState(false);
 
   // Preview the circuit the source describes. Pinned to the level's target by
   // name — the default picks the last circuit defined, which would follow a
@@ -106,6 +110,7 @@ function PlayLevel({ level }: { level: Level }) {
     try {
       const verdict = await grade(sandboxRuntime(sandbox), level, source);
       setResult(verdict);
+      setCompleteDismissed(false);
       // Submit is a request for a verdict, so show it — hidden, the spec sheet
       // swallowed both the failure message and the whole victory run.
       setSpecOpen(true);
@@ -142,20 +147,14 @@ function PlayLevel({ level }: { level: Level }) {
         </p>
 
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          {solved && victory.complete && next && (
-            <Link
-              to="/play/$levelId"
-              params={{ levelId: next.id }}
-              onClick={() => setResult(null)}
-              className="whitespace-nowrap rounded-md border border-border px-3 py-1.5 text-xs font-medium no-underline"
+          {solved && victory.complete && (
+            <button
+              type="button"
+              onClick={() => setCompleteDismissed(false)}
+              className="whitespace-nowrap rounded-md border border-emerald-500/50 px-3 py-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
             >
-              Next: {next.title} →
-            </Link>
-          )}
-          {solved && victory.complete && !next && (
-            <span className="whitespace-nowrap text-xs text-muted-foreground">
-              That is the last one for now — more coming.
-            </span>
+              Solved · {result?.status === 'pass' ? result.gates : 0}
+            </button>
           )}
           <button
             type="button"
@@ -242,6 +241,20 @@ function PlayLevel({ level }: { level: Level }) {
           whatever the modal setting says. Outside interaction does not dismiss
           it either: clicking a switch is not a request to close the spec.
           Focus stays where it was, so opening this never interrupts typing. */}
+      {result?.status === 'pass' && (
+        <LevelComplete
+          // Held back until the victory run has finished demonstrating the
+          // circuit — the run is the proof, this is the receipt.
+          open={victory.complete && !completeDismissed}
+          onOpenChange={(o) => setCompleteDismissed(!o)}
+          level={level}
+          gates={result.gates}
+          next={next}
+          position={position}
+          total={LEVELS.length}
+        />
+      )}
+
       <Sheet modal={false} open={specOpen} onOpenChange={setSpecOpen}>
         <SheetContent
           side="bottom"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,8 @@
     "./package.json": "./package.json",
     "./primitives/resizable": "./src/primitives/resizable.tsx",
     "./styles/theme.css": "./src/styles/theme.css",
-    "./primitives/sheet": "./src/primitives/sheet.tsx"
+    "./primitives/sheet": "./src/primitives/sheet.tsx",
+    "./primitives/dialog": "./src/primitives/dialog.tsx"
   },
   "publishConfig": {
     "exports": {
@@ -103,6 +104,10 @@
       "./primitives/sheet": {
         "types": "./dist/primitives/sheet.d.ts",
         "import": "./dist/primitives/sheet.js"
+      },
+      "./primitives/dialog": {
+        "types": "./dist/primitives/dialog.d.ts",
+        "import": "./dist/primitives/dialog.js"
       }
     },
     "access": "public"

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -1,0 +1,131 @@
+/**
+ * Modal dialog — the shadcn wrapper over Radix Dialog.
+ *
+ * Same primitive `Sheet` is built on, so this adds no dependency; a Sheet is
+ * a Dialog pinned to an edge. Use this when the content is a moment rather
+ * than a surface: a confirmation, a result, something with one obvious next
+ * action. Use `Sheet` when it is a panel the page keeps working behind.
+ */
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+import type * as React from 'react';
+
+import { cn } from '../lib/utils';
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & { showCloseButton?: boolean }) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -1,4 +1,16 @@
 export { Button, type ButtonProps, buttonVariants } from './button';
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
 export { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './resizable';
 export {
   Sheet,


### PR DESCRIPTION
Solving a level ended quietly: a `SOLVED` card appeared in the spec sheet and a Next link in the header. Now it finishes with a dialog that says what you built and points at what is coming.

## Per-level copy

Each level carries its own `outro: { headline, body }`. Level 1 is "That's a circuit", and warns you are about to lose the AND gate. Level 2 is "One gate down", and warns XOR takes four NANDs. The dialog reads from this, so finishing a level says something specific instead of repeating a generic result.

The validation gate now fails a level that ships without copy — otherwise the omission only surfaces when someone solves it.

## Par is gone from the dialog

As a line of copy, "Par is 1. Nothing wasted." reads like a mark out of ten rather than an invitation to try again. Still used for scoring, just not announced.

## Timing and dismissal

The dialog waits for the victory run to finish. The run — switches flipping, lamp following the truth table — is the proof; this is the receipt, and opening it over a circuit still demonstrating itself would step on the better of the two.

Dismissing is a real choice, not a formality: `par` only means anything if you can close this, go back, and try to beat it. A `Solved · N` chip stays in the header and reopens it.

## One surface per job

The score had started appearing in three places at once. The spec sheet now shows failures only; a pass belongs to the dialog, with the header chip as the persistent record.

## Level 2 is scaffolded further

The stub places `n1: Nand`, destructures it, and pre-wires `n1.out.to(out.in)`. What remains is the actual insight — that both NAND inputs can come from the same switch — so it solves in one line.

The better part is what it does to the canvas: the NAND's two inputs and the switch's output are all visibly dangling, so the diagram poses the question rather than illustrating an answer.

## @simten/ui

New `./primitives/dialog` export. Built on `@radix-ui/react-dialog`, which `Sheet` already depends on, so no new dependency — a Sheet is a Dialog pinned to an edge.

## Verified in the browser

- dialog holds off during the sweep, appears after
- dismiss keeps it dismissed; the header chip reopens it
- the sheet no longer repeats the pass verdict
- level 2 solves with the single added wire

game 47 tests · typecheck clean · check-exports clean

## Note

The outro copy is mine, not Charles's, and it is the most voice-dependent text in the product — worth rewriting before anyone sees it. Level 4's outro also promises "which is where this goes next" when there is no next level yet.
