### PR TITLE
fix(ui): colour wires correctly across composite boundaries

### DIFF
--- a/.changeset/composite-wire-colour.md
+++ b/.changeset/composite-wire-colour.md
@@ -1,0 +1,27 @@
+---
+'@simten/ui': patch
+---
+
+Fix wire colour across composite boundaries on the canvas
+
+A wire running between two composite components rendered as undefined — grey
+rather than green — even while the simulation carried a 1 along it. Elaboration
+and simulation were correct throughout; only the styling was wrong.
+
+Edges are projected from the *unelaborated* circuit, where a composite is one
+node with ports. `portValues` comes from the *flattened* netlist, where that
+boundary has been dissolved: a `HalfAdder` named `h1` contributes `h1.x1.out`
+and `h1.a1.out`, and no `h1.carry` at all. The lookup tried the connection's
+source and then its target, so a wire touching a primitive still resolved on
+that side — which is why only *some* composite wires looked dead, and why the
+bug was easy to miss.
+
+`resolvePortValue` now walks inward when a port is not in the flat map: for an
+output, it follows the internal connection that drives it; for an input, one it
+feeds; and it repeats until the path reaches something the map knows about. The
+path prefix is rebuilt as it descends (`m1` → `m1.i1` → `m1.i1.g`), which
+reconstructs exactly the naming the simulator produces, so arbitrary nesting
+depth resolves — verified against a real three-level elaboration.
+
+Strictly additive: the direct key is tried first, so every lookup that already
+worked takes the identical path.

--- a/packages/ui/src/canvas/__tests__/composite-wire-colour.test.ts
+++ b/packages/ui/src/canvas/__tests__/composite-wire-colour.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Wire colour across a composite boundary.
+ *
+ * Edges are projected from the unelaborated circuit, where a composite is one
+ * node with ports. `portValues` comes from the flattened netlist, where that
+ * boundary no longer exists — a `HalfAdder` named `h1` contributes `h1.x1.out`
+ * and `h1.a1.out`, and never `h1.carry`.
+ *
+ * So a wire running from one composite into another had neither endpoint in the
+ * map and drew as undefined, while the simulation was carrying a 1 along it.
+ * Wires touching a primitive escaped, because that side resolved — which is why
+ * only *some* composite wires looked dead, and why this needs a case with a
+ * composite at BOTH ends to be a real regression test.
+ */
+
+import type { Circuit } from '@simten/core';
+import type { FlatPortValueMap } from '@simten/core/simulator';
+import { describe, expect, it } from 'vitest';
+import { projectCircuitToReactFlow } from '../projection';
+
+const TRUE = '#22c55e';
+const UNDEFINED = '#cbd5e1';
+
+const halfAdder: Circuit = {
+  name: 'HalfAdder',
+  inputs: [
+    { name: 'a', portType: { kind: 'bit' } },
+    { name: 'b', portType: { kind: 'bit' } },
+  ],
+  outputs: [
+    { name: 'sum', portType: { kind: 'bit' } },
+    { name: 'carry', portType: { kind: 'bit' } },
+  ],
+  nodes: [
+    {
+      id: 'x1',
+      label: 'x1',
+      componentRef: 'Xor',
+      arguments: {},
+      inputs: [
+        { id: 'x1_a', name: 'a', portType: { kind: 'bit' } },
+        { id: 'x1_b', name: 'b', portType: { kind: 'bit' } },
+      ],
+      outputs: [{ id: 'x1_out', name: 'out', portType: { kind: 'bit' } }],
+    },
+    {
+      id: 'a1',
+      label: 'a1',
+      componentRef: 'And',
+      arguments: {},
+      inputs: [
+        { id: 'a1_a', name: 'a', portType: { kind: 'bit' } },
+        { id: 'a1_b', name: 'b', portType: { kind: 'bit' } },
+      ],
+      outputs: [{ id: 'a1_out', name: 'out', portType: { kind: 'bit' } }],
+    },
+  ],
+  connections: [
+    {
+      id: 'c1',
+      source: { nodeId: '', portName: 'a' },
+      target: { nodeId: 'a1', portName: 'a' },
+      portType: { kind: 'bit' },
+    },
+    {
+      id: 'c2',
+      source: { nodeId: 'a1', portName: 'out' },
+      target: { nodeId: '', portName: 'carry' },
+      portType: { kind: 'bit' },
+    },
+  ],
+  implementation: { kind: 'composite' },
+} as unknown as Circuit;
+
+/** Two half adders wired carry → a. Both endpoints are composite boundaries. */
+const top: Circuit = {
+  name: 'Top',
+  inputs: [],
+  outputs: [],
+  nodes: [
+    {
+      id: 'h1',
+      label: 'h1',
+      componentRef: 'HalfAdder',
+      arguments: {},
+      inputs: [{ id: 'h1_a', name: 'a', portType: { kind: 'bit' } }],
+      outputs: [{ id: 'h1_carry', name: 'carry', portType: { kind: 'bit' } }],
+    },
+    {
+      id: 'h2',
+      label: 'h2',
+      componentRef: 'HalfAdder',
+      arguments: {},
+      inputs: [{ id: 'h2_a', name: 'a', portType: { kind: 'bit' } }],
+      outputs: [{ id: 'h2_carry', name: 'carry', portType: { kind: 'bit' } }],
+    },
+  ],
+  connections: [
+    {
+      id: 'w1',
+      source: { nodeId: 'h1', portName: 'carry' },
+      target: { nodeId: 'h2', portName: 'a' },
+      portType: { kind: 'bit' },
+    },
+  ],
+  implementation: { kind: 'composite' },
+} as unknown as Circuit;
+
+const library = {
+  resolveCircuit: (name: string) =>
+    name === 'HalfAdder' ? halfAdder : ({ implementation: { kind: 'primitive' } } as Circuit),
+  getAllPrimitiveNames: () => ['Xor', 'And'],
+};
+
+const metadata = {
+  components: { h1: { position: { x: 0, y: 0 } }, h2: { position: { x: 200, y: 0 } } },
+} as never;
+
+describe('a wire between two composites', () => {
+  it('is green when the flattened net behind it carries a 1', () => {
+    // Only the internal net exists — exactly what the simulator produces.
+    const portValues: FlatPortValueMap = new Map([['h1.a1.out', 1]]);
+
+    const { edges } = projectCircuitToReactFlow(top, metadata, library, portValues);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].style?.stroke).toBe(TRUE);
+  });
+
+  it('stays undefined when nothing behind it has a value', () => {
+    const { edges } = projectCircuitToReactFlow(top, metadata, library, new Map());
+    expect(edges[0].style?.stroke).toBe(UNDEFINED);
+  });
+
+  it('reaches through nested composites to the primitive underneath', () => {
+    // Top -> Mid -> Inner -> And. The simulator flattens this to `m1.i1.g.out`
+    // (verified against a real elaboration), so nothing along the way exists as
+    // a key and the resolver has to descend twice.
+    const port = (name: string) => ({ name, portType: { kind: 'bit' } });
+    const node = (id: string, componentRef: string, ins: string[], outs: string[]) => ({
+      id,
+      label: id,
+      componentRef,
+      arguments: {},
+      inputs: ins.map((n) => ({ id: `${id}_${n}`, ...port(n) })),
+      outputs: outs.map((n) => ({ id: `${id}_${n}`, ...port(n) })),
+    });
+    const wire = (id: string, s: [string, string], t: [string, string]) => ({
+      id,
+      source: { nodeId: s[0], portName: s[1] },
+      target: { nodeId: t[0], portName: t[1] },
+      portType: { kind: 'bit' },
+    });
+
+    const inner = {
+      name: 'Inner',
+      inputs: [port('a')],
+      outputs: [port('out')],
+      nodes: [node('g', 'And', ['a'], ['out'])],
+      connections: [wire('i1w', ['g', 'out'], ['', 'out'])],
+      implementation: { kind: 'composite' },
+    } as unknown as Circuit;
+
+    const mid = {
+      name: 'Mid',
+      inputs: [port('a')],
+      outputs: [port('out')],
+      nodes: [node('i1', 'Inner', ['a'], ['out'])],
+      connections: [wire('m1w', ['i1', 'out'], ['', 'out'])],
+      implementation: { kind: 'composite' },
+    } as unknown as Circuit;
+
+    const nestedTop = {
+      name: 'Top',
+      inputs: [],
+      outputs: [],
+      nodes: [node('m1', 'Mid', ['a'], ['out']), node('m2', 'Mid', ['a'], ['out'])],
+      connections: [wire('w', ['m1', 'out'], ['m2', 'a'])],
+      implementation: { kind: 'composite' },
+    } as unknown as Circuit;
+
+    const nestedLibrary = {
+      resolveCircuit: (name: string) =>
+        name === 'Mid'
+          ? mid
+          : name === 'Inner'
+            ? inner
+            : ({ implementation: { kind: 'primitive' } } as Circuit),
+      getAllPrimitiveNames: () => ['And'],
+    };
+
+    const { edges } = projectCircuitToReactFlow(
+      nestedTop,
+      metadata,
+      nestedLibrary,
+      new Map([['m1.i1.g.out', 1]]),
+    );
+    expect(edges[0].style?.stroke).toBe(TRUE);
+  });
+
+  it('does not hang on a circuit whose ports feed back on themselves', () => {
+    const looped = {
+      ...halfAdder,
+      connections: [
+        {
+          id: 'loop',
+          source: { nodeId: '', portName: 'carry' },
+          target: { nodeId: '', portName: 'carry' },
+          portType: { kind: 'bit' },
+        },
+      ],
+    } as unknown as Circuit;
+
+    const loopLibrary = { ...library, resolveCircuit: () => looped };
+    expect(() => projectCircuitToReactFlow(top, metadata, loopLibrary, new Map())).not.toThrow();
+  });
+});

--- a/packages/ui/src/canvas/projection.ts
+++ b/packages/ui/src/canvas/projection.ts
@@ -5,7 +5,13 @@
  */
 
 import type { Circuit, PortPath } from '@simten/core';
-import type { CircuitLibrary, FlatPortValueMap, FlatSequentialState } from '@simten/core/simulator';
+import type {
+  BitValue,
+  BusValue,
+  CircuitLibrary,
+  FlatPortValueMap,
+  FlatSequentialState,
+} from '@simten/core/simulator';
 import type { Edge, Node as ReactFlowNode } from '@xyflow/react';
 import type { NodeData } from '../nodes';
 import type { MetadataState } from './types';
@@ -306,18 +312,80 @@ function projectCircuitToNodes(
 }
 
 /**
+ * The value on a port, looking through composite boundaries.
+ *
+ * Edges are drawn from the *unelaborated* circuit, where a composite is one
+ * node with ports. `portValues` comes from the *flattened* netlist, where that
+ * boundary has been dissolved — a `HalfAdder` named `h1` contributes
+ * `h1.x1.out` and `h1.a1.out`, and no `h1.carry` at all.
+ *
+ * So a wire between two composites had neither endpoint in the map and rendered
+ * as undefined, even while the simulation was carrying a perfectly good 1 along
+ * it. Wires touching a primitive escaped the bug, because the primitive's side
+ * of the connection did resolve — which is why only *some* composite wires
+ * looked dead.
+ *
+ * This walks inward instead: for an output port, find the internal connection
+ * that drives it; for an input port, find one it feeds. Repeat until the path
+ * lands on something the flat map knows about. Depth is bounded by nesting, and
+ * `seen` stops a malformed circuit from looping forever.
+ */
+function resolvePortValue(
+  path: PortPath,
+  circuit: Circuit,
+  library: CircuitLibrary,
+  portValues: FlatPortValueMap,
+  prefix = '',
+  seen = new Set<string>(),
+): BitValue | BusValue | undefined {
+  const key = prefix ? `${prefix}.${portPathKey(path)}` : portPathKey(path);
+  const direct = portValues.get(key);
+  if (direct !== undefined) return direct;
+
+  if (seen.has(key)) return undefined;
+  seen.add(key);
+
+  const node = circuit.nodes.find((n) => n.id === path.nodeId);
+  if (!node) return undefined;
+
+  const inner = library.resolveCircuit(node.componentRef);
+  if (!inner || inner.implementation?.kind === 'primitive') return undefined;
+
+  const innerPrefix = prefix ? `${prefix}.${node.id}` : node.id;
+
+  // A circuit's own ports use `nodeId: ''` inside its definition. An output is
+  // driven by an internal source; an input drives internal targets.
+  for (const conn of inner.connections) {
+    if (conn.target.nodeId === '' && conn.target.portName === path.portName) {
+      const value = resolvePortValue(conn.source, inner, library, portValues, innerPrefix, seen);
+      if (value !== undefined) return value;
+    }
+    if (conn.source.nodeId === '' && conn.source.portName === path.portName) {
+      const value = resolvePortValue(conn.target, inner, library, portValues, innerPrefix, seen);
+      if (value !== undefined) return value;
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Project Circuit connections to ReactFlow edges.
  * Pure function — no hidden state.
  */
-function projectCircuitToEdges(circuit: Circuit, portValues?: FlatPortValueMap): Edge[] {
+function projectCircuitToEdges(
+  circuit: Circuit,
+  library: CircuitLibrary,
+  portValues?: FlatPortValueMap,
+): Edge[] {
   const edges: Edge[] = [];
 
   for (const connection of circuit.connections) {
     let edgeColor = WIRE_COLORS.UNDEFINED;
     if (portValues) {
       const value =
-        portValues.get(portPathKey(connection.source)) ??
-        portValues.get(portPathKey(connection.target));
+        resolvePortValue(connection.source, circuit, library, portValues) ??
+        resolvePortValue(connection.target, circuit, library, portValues);
       if (value !== undefined) {
         edgeColor = (typeof value === 'boolean' ? value : value !== 0)
           ? WIRE_COLORS.TRUE
@@ -356,6 +424,6 @@ export function projectCircuitToReactFlow(
 
   return {
     nodes: projectCircuitToNodes(circuit, metadata, library, portValues, seqState),
-    edges: projectCircuitToEdges(circuit, portValues),
+    edges: projectCircuitToEdges(circuit, library, portValues),
   };
 }


### PR DESCRIPTION
A wire running between two composite components rendered grey rather than green,
even while the simulation was carrying a 1 along it. Elaboration and simulation
were correct throughout — only the styling was wrong.

## Cause

Edges are projected from the **unelaborated** circuit, where a composite is one
node with ports. `portValues` comes from the **flattened** netlist, where that
boundary has been dissolved. For two `HalfAdder` nodes wired `h1.carry → h2.a`,
dumping the simulator gives:

```
draws:   h1.carry -> h2.a
has:     h1.a1.out = true      ← the value actually lives here
missing: h1.carry, h2.a
```

`projectCircuitToEdges` looked up the connection's source, then fell back to its
target. A wire touching a *primitive* still resolved on that side — `h1.carry →
o1.a` works because `o1.a` exists — so only wires with a composite at **both**
ends fell through to `UNDEFINED`. That is why the bug looked intermittent.

## Fix

`resolvePortValue` walks inward when a port is absent from the flat map: for an
output it follows the internal connection driving it, for an input one it feeds,
repeating until the path lands on something the map knows. The path prefix is
rebuilt as it descends — `m1` → `m1.i1` → `m1.i1.g` — which reconstructs exactly
the naming the simulator produces.

Termination is guarded three ways: it stops at primitives, a `seen` set blocks
revisiting a key, and depth is bounded by real nesting.

**Strictly additive.** The direct key is tried first, so every lookup that
already worked takes the identical path. Only previously-undefined lookups
behave differently.

## Verification

Four tests, and the first is a real regression test — reverting to the old
lookup fails it with `expected '#cbd5e1' to be '#22c55e'`, the exact
grey-for-green being reported.

Arbitrary nesting was checked against ground truth rather than assumed: a real
`Top → Mid → Inner → And` circuit put through the actual elaborator and
simulator produces `m1.i1.g.out` with no intermediate boundary keys, and the
resolver reaches it through both layers.

Also confirmed in the browser on the reported case — with `a=ON b=ON cin=OFF`,
the `h1.carry → h2.a` wire is now `rgb(34, 197, 94)` while `cin → h2.b` stays
grey, correctly.

`projectCircuitToNodes` reads `portValues` too, but only ever for a node's own
port (`Switch.out`, `Led.in`, `HexDisplay.in`), and primitives keep their ports
through flattening — so node rendering was never affected and needs no change.

`@simten/ui` 114 passing, typecheck clean, lint holds the 590 baseline.
