### PR TITLE
docs: rewrite the handoff for the ten-level campaign and the persistence plan

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,161 +2,265 @@
 
 ## Where things stand
 
-`apps/game` is a playable four-level campaign at `play.simten.dev` (dev: `localhost:3003`).
-All four levels have been solved end to end in a browser. The engine works.
+`apps/game` is a ten-level campaign at `play.simten.dev` (dev: `localhost:3003`).
+The map is the front door; there is no list page.
 
-**Branch `feat/game-level-complete` has uncommitted work** that must be committed and
-PR'd before anything else:
+Everything described here is **on `main`**:
 
-- `packages/ui/src/primitives/dialog.tsx` — new shadcn Dialog over Radix Dialog (the
-  same library `Sheet` already uses, so no new dependency). Exported as
-  `@simten/ui/primitives/dialog`, wired into `exports` **and** `publishConfig.exports`.
-- `apps/game/src/components/LevelComplete.tsx` — completion dialog.
-- Per-level `outro: { headline, body }` on the `Level` type, written for all four levels.
-- Level 2's stub now places `n1: Nand` and pre-wires `n1.out.to(out.in)`.
-- `SpecPanel` shows failures only; a pass belongs to the dialog.
+- **#293** — four Act 1 levels, the map as a running circuit, the drilldown,
+  array-valued `nodes` in `@simten/core`
+- **#294** — map as `/`, editor gated per level, arithmetic band, reference
+  solutions as typechecked files
+- **#295** — `@simten/ui` fix: a wire between two composites rendered grey while
+  carrying a 1. That bug affected `/circuit` and the RV32I demos too, not only
+  the game
 
-Needs a changeset for `@simten/ui` (minor — new export). Everything else is app-local.
+Branch fresh from `main` before starting.
 
-Merged already: #285 #286 #287 #289. PR #290 is an open Version Packages release.
+**The dev sandbox must be running.** `pnpm dev:sandbox` (port 3002). Without it
+the canvas is blank and Submit never grades — it looks like a bug and is not.
+The game server on 3003 is run by the user; do not start your own.
 
-## The task
+## The levels
 
-Add Act 1's four missing levels to `apps/game/src/game/levels.ts`:
+Ten, in four bands. `apps/game/src/game/levels.ts`.
+
+| # | id | target | allowed | par |
+|---|---|---|---|---|
+| 1 | `first-wire` | `Nand1` | Nand | 1 |
+| 2 | `not-from-nand` | `Not1` | Nand | 1 |
+| 3 | `and-from-nand` | `And2` | Nand | 2 |
+| 4 | `or-from-nand` | `Or1` | Nand | 3 |
+| 5 | `nor-from-nand` | `Nor1` | Nand | 4 |
+| 6 | `xor-from-nand` | `Xor1` | Nand | 4 |
+| 7 | `xnor-from-nand` | `Xnor1` | Nand | 5 |
+| 8 | `making-a-component` | `Xor2` | Nand | 4 |
+| 9 | `half-adder` | `HalfAdder` | `ARITHMETIC_GATES` | 2 |
+| 10 | `full-adder` | `FullAdder` | `ARITHMETIC_GATES` | 5 |
+
+Level 8's id **changed** from `half-adder` to `making-a-component` so the real
+half adder could take the name. That is a live URL change.
+
+`ARITHMETIC_GATES` is every gate the player built from NAND, handed back. It is
+the only place `allowed` grows, which is what makes the completion card's unlock
+line fire — once, after level 8: *"Not, And, Or, Nor, Xor, Xnor unlocked"*.
+
+## The persistence task
+
+This is the next thing to build. Four finished features are inert without it,
+and it is step one of composition rather than a separate feature.
+
+### Two stores, and the distinction matters
 
 ```
-1  First Wire          (And given)     exists
-2  NOT from NAND                       exists
-3  AND from NAND       ADD  ~2 gates, 4 wires
-4  OR from NAND        ADD  ~3 gates, 5 wires   ← De Morgan, the insight of the act
-5  NOR from NAND       ADD  ~4 gates, 6 wires
-6  XOR from NAND                       exists (renumber after 5)
-7  XNOR from NAND      ADD  ~5 gates, 7 wires
-8  Making a Component                  exists (currently id `half-adder`, keep the id —
-                                       it is public URL surface)
+simten:game:progress   per level: the source that last PASSED, + gate count
+simten:game:drafts     per level: what is currently in the editor
 ```
 
-Loosely follows Turing Complete's own order (NAND → NOT → {AND, NOR, OR} → XOR → XNOR).
-Each new level is a few minutes. This takes Act 1 from ten minutes to something with a
-shape, and fills the gap where the scaffolding currently drops sharply between levels 2
-and 3.
+A draft is written as you type. Progress is written **only on a pass** and is
+frozen until the next pass.
 
-## Design rules that were argued out — do not quietly reverse these
+Downstream levels must read **progress**, never drafts. Otherwise going back and
+mangling your half adder breaks a later level built on it, with an error
+pointing at code you are not looking at. Re-solve it and the better version
+propagates — which is the good version of that behaviour.
 
-**Levels are self-contained.** `Switch` nodes → your gates → `Led` nodes. **No `inputs`/
-`outputs` ports.** A circuit with ports gets wrapped by `autoHarness` and renders as one
-opaque `dut` box, which hides the gates the player just wrote — the entire feedback loop.
-`autoHarness` returns the circuit untouched when it declares no ports
-(`packages/core/src/circuit/auto-harness.ts:23`), so self-contained levels get the raw
-view for free. Level 8 is the deliberate exception: introducing ports *is* its lesson,
-and the black box is the point.
+The interface is safe by construction: a snapshot only exists because it passed,
+and passing means `grade.ts` already verified it exposes the signals the level
+named. You cannot rename your way into breaking a downstream level, because the
+rename would not have passed.
 
-**Composition is for ingredients, never for the dish.** What you build this level is
-always self-contained and fully visible. What you *reuse* from an earlier level is a box
-you can double-click into. Never let the thing under construction collapse.
+### What exists already
 
-**Watch the wire budget.** Act 1 levels are 4–7 `.to()` lines. That is fine. A 4-bit
-adder written as raw gates is ~90 lines and would be unplayable; built from the player's
-own `FullAdder` it is ~12. Composition is not a nice-to-have arriving late — it is what
-decides whether Act 2 exists. Nothing today lets a level import a previous solution;
-**that is the real design work after this task.**
+`apps/game/src/game/storage.ts` — `readStored(key, fallback)` and
+`writeStored(key, data)`. SSR-guarded, parse wrapped in try/catch, every record
+carries a `version` envelope so a format change is detectable rather than
+silently misread. The intro flag is its only caller today.
 
-**Skip TC's byte-widening grind.** Byte NAND / Byte NOT / Adding Bytes / Byte XOR exist
-in TC because wiring eight copies by hand is its difficulty. `bus(8)` makes eight bits
-one wire. Replace that whole band with a single parameterised-width level.
+### Wiring, file by file
 
-**Names are fixed and that is fine** (LeetCode does the same). What was wrong was the
-silence — solved in #287: the editor warns inline on the exact line, the preview falls
-back to the last circuit defined so the canvas never blanks, and the panel always shows
-"Must define". Do not reintroduce a silent failure here.
+1. **`storage.ts`** — add typed accessors over the generic pair. Something like
+   `readProgress(): Record<string, {source: string; gates: number}>` and
+   `readDrafts(): Record<string, string>` plus writers. Keep the envelope.
 
-**Stubs use `export default circuit('Name', …)`.** One occurrence of the name, no unused
-`const`. Verified this registers identically to the `const` form — `stripExports`
-rewrites it to a bare expression.
+2. **`routes/play.$levelId.tsx`**
+   - Seed the editor from the draft: `useState(level.stub)` becomes the draft if
+     one exists. The route already remounts per level via `key`, so the
+     initialiser runs per level — do not add an effect for this.
+   - Write the draft on change (debounce; every keystroke is wasteful).
+   - On `verdict.status === 'pass'`, write progress with the source and
+     `verdict.gates`.
+
+3. **`routes/index.tsx`** (the map) — read progress, derive a `Set` of solved
+   ids, pass it to `<LevelMap solved={…} />`. The prop already exists and is
+   already threaded into `buildMapGraph(solved)` and `simulateMap(solved)`.
+
+4. **`components/LevelMap.tsx`** — flip `ENFORCE_LOCKING` to `true`. Read its
+   docstring first; this is a design decision, not just a switch. Locking gives
+   the map stakes and makes the unlock line mean something, but levels are
+   reachable by URL regardless so it is a soft gate.
+
+5. **`components/LevelDrilldown.tsx`** — one line. `SOLUTIONS[level.id]` becomes
+   the player's passing source, falling back to the reference answer for levels
+   they have not solved. This also retires the spoiler: `solutions/` currently
+   ships every answer to the browser, which is documented as temporary in
+   `solutions/index.ts`.
+
+6. **Add a reset-level button.** Once drafts persist there is no way back to the
+   stub, and a player who mangles a given preamble is stuck.
+
+### Traps
+
+- **SSR.** Read storage in an effect, never during render, or you get a
+  hydration mismatch. `IntroDialog.tsx` does it correctly — copy that shape.
+- **Do not write the draft on mount.** The first render carries the stub; a
+  write-on-mount overwrites a real draft with the stub before it is read.
+- **The theme key is `theme`, not namespaced.** Written by an inline script in
+  `__root.tsx` that runs before paint. Do not route it through `storage.ts` —
+  they have to agree on the default (`dark`), and a mismatch there already caused
+  one bug where the page loaded dark and flipped to light.
+
+### Verify
+
+`pnpm --filter @simten/game test` (105 today), `tsc --noEmit`, `pnpm lint` (590
+warning baseline — do not raise it).
+
+Then **in the browser**, because every UI bug in this project has passed the test
+suite: solve a level, refresh, confirm the draft survives; go back and break a
+solved level, confirm a later level still works; confirm the map goes green and
+the drilldown shows your circuit.
+
+## After persistence
+
+**Cut NOR and XNOR.** They teach nothing new — both are "bolt a NOT onto the
+thing you just built". Agreed repeatedly, never done.
+
+**Add two problem levels.** Act 1 has no level whose title withholds the answer.
+Do *not* copy Turing Complete's list — its gate order is deliberately shared, but
+lifting its level names reads as a clone. Two that come from this campaign's own
+arc:
+
+- **Majority** — three switches, light when most are on. Secretly the carry-out
+  of a full adder, so it rehearses something needed two bands later.
+- **Exactly one** — three switches, light when precisely one is on. Sounds like
+  XOR and is not; XOR-of-three is true for one *or* three. That gap is the
+  puzzle.
+
+**Then the byte band.** `Invert a byte` — eight switches, eight lamps, one loop.
+Array-valued nodes shipped in `@simten/core`, and this was verified end to end
+through the game's own execution path. It is the level that shows why this is
+not nandgame.
+
+**Then composition.** `Adding Bytes` needs a half adder *and* a full adder
+available. The stub trick used in level 10 works for exactly one hop before the
+scenery compounds. Two things are proven and neither is built:
+
+- Library components can be real `.ts` files loaded with Vite's `?raw`
+  (verified: composed and graded at 5 gates)
+- Monaco resolves relative imports across models with full type flow (verified
+  live: `h1.bogus` errored with the real port type while `h1.sum` did not) — so
+  no hand-written type declarations are needed
+
+The remaining piece is teaching the sandbox to resolve `./half-adder`.
+`rewrite-imports.ts` already does that shape of work for npm via blob URLs.
+Cheapest version: prepend the library source and let the existing
+import-stripping remove the player's import line — that needs one condition in
+`rewriteSpecifier` treating relative specifiers like `@simten/*` (skip them).
+
+To use the player's *own* circuit as a component you also need a deharness
+transform: a passing self-contained solution exposes node ids, not ports, so
+`Switch`/`Led` must become `inputs`/`outputs`. The names are grader-guaranteed.
+`createDrillDownViewCircuit` does the same job in the other direction and is a
+working precedent.
 
 ## How the pieces work
 
-**Level format** — `apps/game/src/game/types.ts`. A level is pure data: `id`, `title`,
-`brief`, `target` (circuit name), `inputs`/`outputs` (**bare signal-name arrays**, not
-port maps), `allowed` (primitive names), `stub`, `vectors`, `par?`, `outro`.
-Nothing executes, so levels can move to R2 later as plain JSON.
+**Level format** — `game/types.ts`. Pure data: `id`, `title`, `brief`, `target`,
+`inputs`/`outputs` (bare signal-name arrays), `allowed`, `stub`, `vectors`,
+`par?`, `outro`.
 
-**Grading** — `apps/game/src/game/grade.ts`, four ordered checks: circuit exists →
-exposes the named signals → built only from permitted primitives → truth table.
-The score is **positive**: `gates = nodes whose type ∈ allowed`. Counting everything and
-subtracting an exclusion list means a forgotten primitive silently inflates par; this way
-`Switch`/`Led` never count because they are not in `allowed`.
+**`allowed` does three jobs**, and they are starting to conflict:
 
-**Runtime** — `apps/game/src/game/runtime.ts`. `GradeRuntime` is a narrow interface so
-the grader runs host-side in tests. Two traps already paid for:
+1. which primitives may appear in the flattened netlist (`forbiddenPrimitives`)
+2. the scoring list — `countGates` counts nodes whose type is in it
+3. what the editor puts in scope
 
-- `sandbox.compile` builds its simulator on the **last** circuit in the source, so
-  `select()` pins the target by name via `compileIR`. Without it a helper defined below
-  the answer gets graded instead.
-- Output keys differ between runtimes — the sandbox namespaces top-level ports under
-  `__top__.`, `@simten/core/sim` returns them bare. `resolveOutput` reads
-  `__top__.<name>` else `<name>.in`. A missing signal is an **error**, never a default
-  of 0; a `?? 0` fallback silently passed every row expecting 0, which is most of them.
+A composite never survives flattening, so it cannot go in `allowed` to be made
+available — that would serve (3) while breaking (1) and (2). Splitting scope out
+is the change library components will force.
 
-**The validation gate** — `apps/game/src/game/__tests__/levels.test.ts`. Every level
-ships a reference solution that must pass, **and** constant-0/constant-1 answers that
-must fail. The second direction catches a tautological grader and is invisible if you
-only test that solutions pass. **Add a reference solution for every new level** — the
-suite asserts the set matches `LEVELS` exactly.
+**Editor gating** — `buildGlobalsFor(names)` in `@simten/ui/monaco` filters the
+generated ambient globals to a subset, JSDoc intact. The level page composes it
+from `allowed ∪ STRUCTURAL ∪ helpers`. On a NAND level `Xor` does not
+autocomplete and does not compile. `STRUCTURAL` is exported from `grade.ts` so
+the editor and grader cannot disagree.
 
-## Verification
+**Reference solutions** — `game/solutions/*.ts`, real files loaded via `?raw`.
+They typecheck: a wrong port name fails `tsc` rather than surviving to a grader
+failure. ⚠️ `?raw` is **Vite-only** — vitest resolves it, a bare `tsx` script
+does not. Use vitest when poking at these.
 
-```
-pnpm --filter @simten/game test       # 47 currently; add ~4 per new level
-pnpm --filter @simten/game exec tsc --noEmit
-pnpm test                             # check-exports + all packages
-pnpm lint                             # 590-warning baseline, do not raise it
-```
+**The map is a real circuit** — `game/map-circuit.ts` builds an actual
+`circuit()`: a `Switch` per level, a `Constant` feeding row 0, `And` gates where
+a row has several prerequisites, and an `Led` per level whose value *is* its
+unlock state. `simulateMap` runs it on the same engine as player circuits. Wire
+colour comes from the canvas's `WIRE_COLORS`, so a live wire is the same green a
+`1` is everywhere else.
 
-Browser is not optional. Every UI bug this session — blank canvas, stale layout, broken
-truth table, state surviving navigation — passed the test suite. Dev server is on
-**:3003**, run by the user; do not start your own. Drive it with the Playwright MCP:
-`window.monaco.editor.getModels()[0].setValue(...)` edits the editor,
-`document.querySelector('button.bg-primary').click()` submits.
+**Map bands** — `MAP_SECTIONS` in `game/map.ts`, declared by the row each opens
+on. `SECTION_PAD_TOP`/`BOTTOM` are budgeted out of `ROW_GAP - NODE_HEIGHT`;
+overrun it and adjacent bands overlap instead of separating.
 
-## Conventions
-
-Conventional Commits, **one line, no `Co-Authored-By`**. Biome runs first in CI, so
-`pnpm lint` before pushing. **Pull `main` and branch fresh before starting** — a stale
-branch cost a conflict this session. Every change to a published package
-(`@simten/core`, `@simten/ui`, `@simten/embed`, `@simten/mcp`) needs a changeset;
-apps are in the changesets ignore list.
+**Grading** — `game/grade.ts`, four ordered checks: circuit exists → exposes the
+named signals → built only from permitted primitives → truth table. Score is
+positive: nodes whose type is in `allowed`.
 
 ## Known, deliberately unfixed
 
+- **`GradeReport` was deleted.** `vector` failures are covered by the truth
+  table's red column, but `interface` failures ("no output signal `out`") are now
+  **silent**. `forbidden` matters less since the editor filter prevents it.
+- **`BaseNode` handle styling in `@simten/ui` is inert.** It sets
+  `h-3 w-3 bg-blue-500` for connected ports, but `@xyflow/react/dist/style.css`
+  defines `.react-flow__handle` at the same specificity and is imported after the
+  utilities, so every port on every canvas renders as React Flow's 6px default.
+  Measured, not inferred.
+- **monaco version skew in `apps/game`.** It declares `^0.52.2` but a direct
+  `import from 'monaco-editor'` resolves **0.55.1**, while the editor prop's type
+  comes from `@simten/ui`'s 0.52.2 — two incompatible `IStandaloneCodeEditor`
+  types. Let types infer from the prop rather than importing monaco types.
+- **`check_circuit` (MCP) fails on `Switch`/`Led`** with "Cannot read properties
+  of undefined", so every self-contained circuit — which is levels 1–7 — is
+  uncheckable through the MCP. They export correctly from `@simten/core/std` in
+  both source and dist, so it is the MCP's own resolution.
+- **`Adding Bytes` has a display problem.** Sixteen inputs and nine outputs is 25
+  signal rows in the truth table. Needs a different presentation for wide levels.
 - Level briefs render as plain text, so backticks show literally.
-- No hint affordance. Levels 2–3 are where someone will stall; this is the highest-value
-  UX addition after the levels themselves.
-- No persistence — refresh loses everything. localStorage was designed but not built:
-  `simten:game:progress` (solved + gates) and `simten:game:drafts` (source per level),
-  behind a narrow module so D1 can replace it later. Guard SSR, wrap the parse, include a
-  `version` field. Do this before any playtest, or lost progress will read as "broken".
-- No level map. The intent is that it *is* a circuit — solved levels as `Switch` nodes,
-  prerequisites as real `And` gates, unlock state as the simulator's actual output. TC's
-  map only looks like circuitry; ours would run. Edges should mean genuine dependency
-  ("this level imports the XOR you built"), not just suggested order.
-- Embed utility classes are unprefixed, so a host page also running Tailwind gets two
-  definitions of `.flex`. Deliberate: needs a divergent Tailwind config before anything
-  breaks, and scoping the sheet risks the `.dark` trigger that intentionally matches the
-  host's element.
-- `pnpm --filter @simten/web build` fails at prerendering on a Cloudflare API auth error,
-  after both Vite bundles build fine. Pre-existing and unrelated; matches the note about
-  wrangler defaulting to the wrong account.
+- No hint affordance. The cheapest real one is a circuit diff: run the player's
+  circuit and the reference over the vectors, find the first divergent row, then
+  walk their netlist for the earliest node whose value is wrong. That teaches
+  debugging rather than giving the answer, and needs no authored content.
 
-## Honest assessment, so the next agent does not oversell it
+## Conventions
 
-It is satisfying, not yet fun. The victory sweep — the lamp following the truth table,
-driven by the player's own circuit — is the best thing in it and should be protected.
-But two of four levels have no puzzle (level 1 hands you the answer, level 8 is level 6
-retyped), there is no reason to solve anything twice, and there is no viral loop at all:
-no share, no score comparison, no persistence, no map.
+Conventional Commits, **one line, no `Co-Authored-By`**. Biome runs first in CI,
+so `pnpm lint` before pushing. Pull `main` and branch fresh. Every change to a
+published package (`@simten/core`, `@simten/ui`, `@simten/embed`, `@simten/mcp`)
+needs a changeset; apps are in the ignore list.
 
-The gap to "game" is mostly **content**, which is human-authored and cannot be shortcut.
-Before paying that cost, the cheapest useful thing is to put the existing levels in front
-of five people and watch — specifically whether the typing feels like thinking or like
-typing, which is the bet the whole code-only decision rests on.
+## Honest assessment
+
+It is more of a game than it was — the arithmetic ladder gives it a spine, and
+the editor gating means rules are visible rather than discovered by breaking
+them. It still is not *fun* in the way Zachtronics is. Two of ten levels are real
+puzzles; the rest are recipes where the title names the answer.
+
+The code-only bet is still unexploited, because the game is too short to need it.
+At eight gates dragging would be fine. Typing only wins at scale, and the byte
+band is the first place that shows.
+
+And the gap to "game" is content, which is human-authored and cannot be
+shortcut. The project notes say the goal is visibility and to bias toward launch
+and outreach over feature-building. Several sessions have now been
+feature-building. The cheapest useful thing remains putting what exists in front
+of five people and watching whether the typing feels like thinking.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -47,28 +47,35 @@ line fire — once, after level 8: *"Not, And, Or, Nor, Xor, Xnor unlocked"*.
 
 ## The persistence task
 
-This is the next thing to build. Four finished features are inert without it,
-and it is step one of composition rather than a separate feature.
+This is the next thing to build: four finished features are inert without it.
+Composition later builds on top of it — a passing snapshot is a field added to
+`progress` — but that is not part of this task.
 
-### Two stores, and the distinction matters
+### Two records, one copy of the source
 
 ```
-simten:game:progress   per level: the source that last PASSED, + gate count
-simten:game:drafts     per level: what is currently in the editor
+simten:game:drafts     per level: the source currently in the editor
+simten:game:progress   per level: { gates: number }
 ```
 
-A draft is written as you type. Progress is written **only on a pass** and is
-frozen until the next pass.
+These are different *kinds* of data, not two copies of the same thing. The draft
+restores your work on refresh. Progress is a flag and a score — it is what the
+map's green nodes, the lit wires, `ENFORCE_LOCKING` and the header chip read,
+and it needs no source at all.
 
-Downstream levels must read **progress**, never drafts. Otherwise going back and
+Do not store the passing source yet. Nothing reads it: no level imports another
+level's circuit today, since the full adder's half adder lives in its own stub
+rather than being pulled from level 9. Building a snapshot store with no
+consumer is work with nothing to verify it against.
+
+**When composition lands**, `progress` gains a `source` field holding the
+solution that last *passed*, and the split earns its keep. Downstream levels must
+then read that snapshot rather than the draft — otherwise going back and
 mangling your half adder breaks a later level built on it, with an error
 pointing at code you are not looking at. Re-solve it and the better version
-propagates — which is the good version of that behaviour.
-
-The interface is safe by construction: a snapshot only exists because it passed,
-and passing means `grade.ts` already verified it exposes the signals the level
-named. You cannot rename your way into breaking a downstream level, because the
-rename would not have passed.
+propagates, which is the good version of that behaviour. The interface is safe
+by construction there: a snapshot only exists because it passed, and passing
+means `grade.ts` already verified it exposes the signals the level named.
 
 ### What exists already
 
@@ -79,17 +86,18 @@ silently misread. The intro flag is its only caller today.
 
 ### Wiring, file by file
 
-1. **`storage.ts`** — add typed accessors over the generic pair. Something like
-   `readProgress(): Record<string, {source: string; gates: number}>` and
-   `readDrafts(): Record<string, string>` plus writers. Keep the envelope.
+1. **`storage.ts`** — add typed accessors over the generic pair:
+   `readDrafts(): Record<string, string>` and
+   `readProgress(): Record<string, { gates: number }>`, plus writers. Keep the
+   envelope.
 
 2. **`routes/play.$levelId.tsx`**
    - Seed the editor from the draft: `useState(level.stub)` becomes the draft if
      one exists. The route already remounts per level via `key`, so the
      initialiser runs per level — do not add an effect for this.
    - Write the draft on change (debounce; every keystroke is wasteful).
-   - On `verdict.status === 'pass'`, write progress with the source and
-     `verdict.gates`.
+   - On `verdict.status === 'pass'`, write `{ gates: verdict.gates }` to
+     progress. No source — see above.
 
 3. **`routes/index.tsx`** (the map) — read progress, derive a `Set` of solved
    ids, pass it to `<LevelMap solved={…} />`. The prop already exists and is
@@ -101,10 +109,15 @@ silently misread. The intro flag is its only caller today.
    reachable by URL regardless so it is a soft gate.
 
 5. **`components/LevelDrilldown.tsx`** — one line. `SOLUTIONS[level.id]` becomes
-   the player's passing source, falling back to the reference answer for levels
-   they have not solved. This also retires the spoiler: `solutions/` currently
-   ships every answer to the browser, which is documented as temporary in
-   `solutions/index.ts`.
+   the **draft** for that level, falling back to the reference answer for levels
+   never opened. Not a passing snapshot, which will not exist — and the draft is
+   the better source anyway, because the drilldown *shows* you your work rather
+   than depending on it. If you edited a solved level, seeing the edited version
+   is correct.
+
+   This also shrinks the spoiler: `solutions/` currently ships every answer to
+   the browser, documented as temporary in `solutions/index.ts`. It stays as the
+   fallback for unopened levels rather than disappearing.
 
 6. **Add a reset-level button.** Once drafts persist there is no way back to the
    stub, and a player who mangles a given preamble is stuck.


### PR DESCRIPTION
The handoff still described a four-level campaign, work sitting uncommitted on a
branch that has since merged, and a task that was finished two PRs ago.

Rewritten for where things actually are, and aimed at the next agent being able
to start without rediscovering things the hard way:

- The ten levels, with ids, targets, `allowed` and par. Level 8's id changed from
  `half-adder` to `making-a-component` so the real half adder could take it —
  that is a live URL change and it is called out.
- **The persistence plan, file by file.** Two stores (`progress` = the source
  that last passed, `drafts` = what is in the editor) and why the distinction
  matters: downstream levels read the passing snapshot, so going back and
  breaking a solved level cannot break something built on it.
- The traps that would otherwise cost an afternoon each: read storage in an
  effect not during render, do not write the draft on mount, and leave the theme
  key alone because an inline pre-paint script owns it.
- What is proven versus what is built for composition — library files via `?raw`
  and cross-model Monaco type resolution are both verified, the sandbox
  resolving `./half-adder` is not.
- Known-unfixed, with evidence: `GradeReport`'s removal made `interface`
  failures silent, `BaseNode`'s handle styling is inert because React Flow's
  stylesheet wins on source order, monaco version skew in `apps/game`, and
  `check_circuit` failing on `Switch`/`Led`.

Also notes not to fill level gaps from Turing Complete's list — the gate order is
deliberately shared, but lifting its level names reads as a clone — and suggests
two problems drawn from this campaign's own arc instead.

Docs only.