### PR TITLE
feat(game): persist drafts and progress in localStorage

### DIFF
--- a/apps/game/src/components/LevelDrilldown.tsx
+++ b/apps/game/src/components/LevelDrilldown.tsx
@@ -11,11 +11,13 @@
  * double-click it, so by the time the dialog is asked for, the circuit is ready
  * and it opens instantly instead of flashing empty while the sandbox works.
  *
- * Today it draws the reference answer, because nothing stores the player's
- * (see `solutions.ts`). That makes the interaction judgeable now and is the
- * wrong content long term: the point of the feature is seeing *your* circuit,
- * at *your* gate count, which is also what stops it being a spoiler. When
- * drafts persist, only the `source` line below changes.
+ * It draws the player's own circuit, which is the point of the feature: your
+ * work, at your gate count, rather than a spoiler. The draft is the right
+ * source rather than a passing snapshot — the drilldown *shows* your circuit,
+ * it does not depend on it, so a solved level you have since edited should
+ * appear as you left it. Levels never opened fall back to the reference answer,
+ * because a map where most cards inspect to nothing is worse than one that
+ * shows what the shape of an answer looks like.
  */
 
 import type { Circuit } from '@simten/core';
@@ -27,13 +29,15 @@ import type { Level } from '../game/types';
 
 export interface LevelDrilldownProps {
   level: Level;
+  /** The player's source for this level, when they have opened it. */
+  draft?: string;
   /** Whether the inspector is open. False means this is only prefetching. */
   expanded?: boolean;
   onCloseExpanded?: () => void;
 }
 
-export function LevelDrilldown({ level, expanded, onCloseExpanded }: LevelDrilldownProps) {
-  const source = SOLUTIONS[level.id];
+export function LevelDrilldown({ level, draft, expanded, onCloseExpanded }: LevelDrilldownProps) {
+  const source = draft ?? SOLUTIONS[level.id];
 
   // `select` is a picker over the compiled circuits, not a name — the default
   // takes the last circuit defined. Same shape the level page uses.
@@ -82,9 +86,10 @@ export function LevelDrilldown({ level, expanded, onCloseExpanded }: LevelDrilld
     onCloseExpanded?.();
   }, [onCloseExpanded]);
 
-  // These are our own reference solutions and the suite proves they compile, so
-  // this should be unreachable — but a drilldown that opens to nothing at all
-  // would be indistinguishable from a broken double-click.
+  // Reachable now that this draws drafts: a level left mid-thought does not
+  // compile, and inspecting it is a perfectly reasonable thing to do. Says so
+  // rather than opening to nothing, which is indistinguishable from a broken
+  // double-click.
   if (expanded && preview.compileError) {
     return (
       <div className="fixed inset-x-0 bottom-6 mx-auto w-fit rounded-lg border border-border bg-card px-4 py-2 text-sm text-muted-foreground">

--- a/apps/game/src/components/LevelMap.tsx
+++ b/apps/game/src/components/LevelMap.tsx
@@ -50,13 +50,17 @@ type LevelNode = Node<LevelNodeView, 'level'>;
 /**
  * Whether the circuit's verdict is allowed to actually lock a level.
  *
- * The map really does compute unlock state — see `map-circuit.ts` — but nothing
- * persists progress yet, so no level can ever become solved and enforcing the
- * result would leave every level after the first permanently shut. The gate is
- * built and wired; this just lets it pass through until there is a save system
- * for it to read. Flip to `true` the day progress is stored.
+ * On, now that progress persists — the map computes unlock state by running
+ * itself as a circuit (see `map-circuit.ts`), and a campaign where every level
+ * is open from the start has no shape and no reason to care about the unlock
+ * line the arithmetic band earns.
+ *
+ * It stays a constant rather than disappearing because it is a soft gate and
+ * worth being able to lift: every level is still reachable by URL, so this
+ * shapes the front door rather than enforcing anything. Off is also how you
+ * look at a late level without solving nine first.
  */
-const ENFORCE_LOCKING = false;
+const ENFORCE_LOCKING = true;
 
 /**
  * Wire and port styling, matched to the circuit canvas rather than invented.
@@ -175,7 +179,7 @@ type MapFlowNode = LevelNode | SectionFlowNode;
 const NODE_TYPES: NodeTypes = { level: LevelMapNode, section: SectionBand };
 
 export interface LevelMapProps {
-  /** Completed level ids. Empty until progress is persisted. */
+  /** Completed level ids. Empty for the first frame, before storage is read. */
   solved?: ReadonlySet<string>;
   /** Called when a level is hovered, so the page can preview its drilldown. */
   onHoverLevel?: (levelId: string) => void;

--- a/apps/game/src/game/__tests__/storage.test.ts
+++ b/apps/game/src/game/__tests__/storage.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The storage layer, driven through a fake `window`.
+ *
+ * The suite runs in the node environment — see `vitest.config.ts` — so there is
+ * no `localStorage` and, more usefully, no `window` at all. That is exactly the
+ * condition the module's SSR guard exists for, so the absent case is tested by
+ * simply not installing the stub.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearDraft,
+  DRAFTS_KEY,
+  PROGRESS_KEY,
+  readDrafts,
+  readProgress,
+  readStored,
+  writeDraft,
+  writeProgress,
+  writeStored,
+} from '../storage';
+
+function installStorage(seed: Record<string, string> = {}) {
+  const store = new Map(Object.entries(seed));
+  (globalThis as { window?: unknown }).window = {
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  };
+  return store;
+}
+
+afterEach(() => {
+  (globalThis as { window?: unknown }).window = undefined;
+});
+
+describe('readStored / writeStored', () => {
+  it('returns the fallback with no window at all', () => {
+    expect(readDrafts()).toEqual({});
+    expect(readProgress()).toEqual({});
+  });
+
+  it('writing without a window is a no-op rather than a throw', () => {
+    expect(() => writeDraft('first-wire', 'x')).not.toThrow();
+  });
+
+  it('round-trips through the envelope', () => {
+    const store = installStorage();
+    writeStored('k', { a: 1 });
+    expect(JSON.parse(store.get('k') as string)).toEqual({ version: 1, data: { a: 1 } });
+    expect(readStored('k', null)).toEqual({ a: 1 });
+  });
+
+  it('reads unparseable, unenveloped and stale records as absent', () => {
+    installStorage({
+      broken: '{{{',
+      bare: '{"gates":2}',
+      stale: JSON.stringify({ version: 99, data: { gates: 2 } }),
+    });
+    expect(readStored('broken', 'fallback')).toBe('fallback');
+    expect(readStored('bare', 'fallback')).toBe('fallback');
+    expect(readStored('stale', 'fallback')).toBe('fallback');
+  });
+});
+
+describe('drafts', () => {
+  it('stores per level and leaves the others alone', () => {
+    installStorage();
+    writeDraft('first-wire', 'one');
+    writeDraft('not-from-nand', 'two');
+    expect(readDrafts()).toEqual({ 'first-wire': 'one', 'not-from-nand': 'two' });
+
+    writeDraft('first-wire', 'edited');
+    expect(readDrafts()).toEqual({ 'first-wire': 'edited', 'not-from-nand': 'two' });
+  });
+
+  it('clears one level without disturbing the rest', () => {
+    installStorage();
+    writeDraft('first-wire', 'one');
+    writeDraft('not-from-nand', 'two');
+    clearDraft('first-wire');
+    expect(readDrafts()).toEqual({ 'not-from-nand': 'two' });
+  });
+
+  it('clearing a level that was never drafted is harmless', () => {
+    installStorage();
+    clearDraft('first-wire');
+    expect(readDrafts()).toEqual({});
+  });
+
+  it('uses the documented key', () => {
+    const store = installStorage();
+    writeDraft('first-wire', 'one');
+    expect(store.has(DRAFTS_KEY)).toBe(true);
+    expect(DRAFTS_KEY).toBe('simten:game:drafts');
+  });
+});
+
+describe('progress', () => {
+  it('records a gate count per level, latest pass winning', () => {
+    installStorage();
+    writeProgress('first-wire', { gates: 1 });
+    writeProgress('and-from-nand', { gates: 3 });
+    expect(readProgress()).toEqual({ 'first-wire': { gates: 1 }, 'and-from-nand': { gates: 3 } });
+
+    writeProgress('and-from-nand', { gates: 2 });
+    expect(readProgress()['and-from-nand']).toEqual({ gates: 2 });
+  });
+
+  it('is a separate record from drafts', () => {
+    const store = installStorage();
+    writeDraft('first-wire', 'source');
+    writeProgress('first-wire', { gates: 1 });
+    expect(store.get(PROGRESS_KEY)).not.toContain('source');
+    expect(PROGRESS_KEY).toBe('simten:game:progress');
+  });
+
+  it('carries no source — the map needs a flag and a score, nothing more', () => {
+    installStorage();
+    writeProgress('first-wire', { gates: 1 });
+    expect(Object.keys(readProgress()['first-wire'])).toEqual(['gates']);
+  });
+
+  // What the map page does with it.
+  it('yields the solved set the map reads', () => {
+    installStorage();
+    writeProgress('first-wire', { gates: 1 });
+    writeProgress('not-from-nand', { gates: 1 });
+    expect(new Set(Object.keys(readProgress()))).toEqual(new Set(['first-wire', 'not-from-nand']));
+  });
+});

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -129,10 +129,10 @@ const SECTION_PAD_BOTTOM = 30;
  * upward: the first row gets the largest Y so it sits at the bottom. Edges run
  * from a row to the one above it, which is the direction of progress.
  *
- * `solved` is the set of completed level ids. There is no persistence yet, so
- * today it is always empty and every level renders as available — which is
- * honest, since any level is reachable by URL regardless. Locking becomes
- * meaningful the moment progress is stored, and only this function changes.
+ * `solved` is the set of completed level ids, read from stored progress by the
+ * map page. It is empty for the first frame after mount, because storage can
+ * only be read on the client — so this must be safe to call with nothing
+ * solved, which it is: every level renders as available.
  */
 export function buildMapGraph(solved: ReadonlySet<string> = new Set()): {
   nodes: MapNode[];

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -22,10 +22,10 @@
  * at these.
  *
  * ⚠️ These are the answers, and this module ships to the browser. Anyone can
- * read them out of the bundle. That is deliberate and temporary: the map's
- * drilldown needs *some* circuit to draw before progress is persisted. Once
- * `simten:game:drafts` exists the drilldown should read the player's own source
- * and this becomes test-only again.
+ * read them out of the bundle. The drilldown now draws the player's own draft
+ * where there is one, so this is only the fallback for levels never opened —
+ * the spoiler is smaller than it was, but it is still there. Making it
+ * test-only means finding something else for an unopened level to inspect to.
  */
 
 import andFromNand from './and-from-nand.ts?raw';

--- a/apps/game/src/game/storage.ts
+++ b/apps/game/src/game/storage.ts
@@ -61,3 +61,65 @@ export function writeStored<T>(key: string, data: T): void {
 
 /** Whether the player has already been shown what this is. */
 export const INTRO_SEEN_KEY = 'simten:game:intro-seen';
+
+/** Every level's editor contents, whether or not it has ever passed. */
+export const DRAFTS_KEY = 'simten:game:drafts';
+
+/** Every level that has passed, and what it cost. */
+export const PROGRESS_KEY = 'simten:game:progress';
+
+/** What a solved level records. */
+export interface LevelProgress {
+  gates: number;
+}
+
+export type Drafts = Record<string, string>;
+export type Progress = Record<string, LevelProgress>;
+
+/**
+ * Two records, not one, because they are different kinds of data.
+ *
+ * A draft is whatever is in the editor — mid-thought, broken, or finished. It
+ * exists so a refresh does not cost you your work. Progress is a flag and a
+ * score: it is what the map's green nodes, the lit wires, `ENFORCE_LOCKING`
+ * and the completion card read, and none of them need a line of source.
+ *
+ * Progress deliberately holds no source yet. Nothing would read it — no level
+ * imports another level's circuit today, since the full adder's half adder
+ * lives in its own stub. When composition lands, `LevelProgress` gains the
+ * source that last *passed*, and downstream levels read that rather than the
+ * draft: otherwise going back and mangling a solved circuit breaks a later
+ * level, with an error pointing at code you are not looking at.
+ *
+ * Both are stored as one record per key rather than a key per level. The whole
+ * map is read on every page anyway, and a single envelope means one version
+ * number to migrate rather than one per level.
+ */
+export function readDrafts(): Drafts {
+  return readStored<Drafts>(DRAFTS_KEY, {});
+}
+
+/** Store one level's editor contents, leaving every other level alone. */
+export function writeDraft(levelId: string, source: string): void {
+  writeStored<Drafts>(DRAFTS_KEY, { ...readDrafts(), [levelId]: source });
+}
+
+/** Forget one level's draft, so it opens from its stub again. */
+export function clearDraft(levelId: string): void {
+  const drafts = readDrafts();
+  delete drafts[levelId];
+  writeStored<Drafts>(DRAFTS_KEY, drafts);
+}
+
+export function readProgress(): Progress {
+  return readStored<Progress>(PROGRESS_KEY, {});
+}
+
+/**
+ * Record a pass. The latest one wins rather than the cheapest — the score
+ * describes the circuit you have, and a player who refactors to something
+ * slower should see that rather than a number they can no longer reproduce.
+ */
+export function writeProgress(levelId: string, entry: LevelProgress): void {
+  writeStored<Progress>(PROGRESS_KEY, { ...readProgress(), [levelId]: entry });
+}

--- a/apps/game/src/routes/index.tsx
+++ b/apps/game/src/routes/index.tsx
@@ -12,22 +12,49 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { IntroDialog } from '../components/IntroDialog';
 import { LevelDrilldown } from '../components/LevelDrilldown';
 import { LevelMap } from '../components/LevelMap';
 import { Logo } from '../components/Logo';
 import ThemeToggle from '../components/ThemeToggle';
 import { LEVELS_BY_ID } from '../game/levels';
+import { type Drafts, readDrafts, readProgress } from '../game/storage';
 
 export const Route = createFileRoute('/')({
   component: MapPage,
   staticData: { skipDefaultChrome: true },
 });
 
+/** Stable identity, so the first render does not invalidate the map's memos. */
+const NOTHING_SOLVED: ReadonlySet<string> = new Set();
+const NO_DRAFTS: Drafts = {};
+
 function MapPage() {
   const [hovered, setHovered] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
+
+  /**
+   * Saved state, read after mount rather than during render.
+   *
+   * This page server-renders, and unlike the editor its storage-derived state
+   * is visible DOM — a solved level is a green card and a live wire. Reading in
+   * an initialiser would render one thing on the server and another on the
+   * client and lose the hydration argument. The map is honest for one frame
+   * instead: nothing solved, everything available.
+   *
+   * Both records are read here so the drilldown gets its source without going
+   * to storage itself. It mounts on hover, long after this, so the draft is
+   * already in hand and it compiles the right circuit the first time rather
+   * than compiling the reference answer and then replacing it.
+   */
+  const [solved, setSolved] = useState(NOTHING_SOLVED);
+  const [drafts, setDrafts] = useState(NO_DRAFTS);
+
+  useEffect(() => {
+    setSolved(new Set(Object.keys(readProgress())));
+    setDrafts(readDrafts());
+  }, []);
 
   const onHoverLevel = useCallback((levelId: string) => setHovered(levelId), []);
   const onExpandLevel = useCallback((levelId: string) => setExpanded(levelId), []);
@@ -59,7 +86,7 @@ function MapPage() {
       </header>
 
       <main className="min-h-0 flex-1">
-        <LevelMap onHoverLevel={onHoverLevel} onExpandLevel={onExpandLevel} />
+        <LevelMap solved={solved} onHoverLevel={onHoverLevel} onExpandLevel={onExpandLevel} />
       </main>
 
       {level && (
@@ -68,6 +95,7 @@ function MapPage() {
         <LevelDrilldown
           key={level.id}
           level={level}
+          draft={drafts[level.id]}
           expanded={expanded === level.id}
           onCloseExpanded={onCloseExpanded}
         />

--- a/apps/game/src/routes/play.$levelId.tsx
+++ b/apps/game/src/routes/play.$levelId.tsx
@@ -26,8 +26,8 @@ import {
 import { Sheet, SheetContent, SheetTitle } from '@simten/ui/primitives/sheet';
 import { useSandboxContext } from '@simten/ui/sandbox';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
-import { Network } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { Network, RotateCcw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LevelComplete } from '../components/LevelComplete';
 import { Logo } from '../components/Logo';
 import { SpecPanel } from '../components/SpecPanel';
@@ -35,8 +35,20 @@ import { grade, STRUCTURAL } from '../game/grade';
 import { nameDiagnostics } from '../game/level-name';
 import { LEVELS_BY_ID, nextLevel } from '../game/levels';
 import { sandboxRuntime } from '../game/runtime';
+import { clearDraft, readDrafts, writeDraft, writeProgress } from '../game/storage';
 import type { GradeResult, Level } from '../game/types';
 import { useVictoryRun } from '../game/useVictoryRun';
+
+/**
+ * How long typing pauses before the draft is stored.
+ *
+ * Writing on every keystroke means a JSON parse, a spread and a serialise per
+ * character, for a record that only matters when the tab goes away. Long enough
+ * to coalesce a burst of typing, short enough that no realistic pause loses
+ * work — and the pending write is flushed on unmount regardless, so leaving the
+ * page mid-keystroke is safe.
+ */
+const DRAFT_DEBOUNCE_MS = 400;
 
 export const Route = createFileRoute('/play/$levelId')({
   staticData: { skipDefaultChrome: true },
@@ -86,13 +98,61 @@ function PlayLevelRoute() {
 function PlayLevel({ level }: { level: Level }) {
   const sandbox = useSandboxContext();
 
-  const [source, setSource] = useState(level.stub);
+  /**
+   * Open on the player's own work, falling back to the stub.
+   *
+   * Read in the initialiser rather than an effect, which is normally the wrong
+   * shape in a server-rendered app. It is safe here for a specific reason:
+   * Monaco renders a placeholder on the server and never puts `source` in the
+   * markup, so the server and client agree on the DOM whatever this returns.
+   * Seeding after mount would instead hand the editor the stub first and swap
+   * it, which flashes and — worse — makes the first change event carry the stub.
+   *
+   * The route remounts per level via `key`, so this runs again on every
+   * navigation rather than sticking on the level it first mounted with.
+   */
+  const [source, setSource] = useState(() => readDrafts()[level.id] ?? level.stub);
   const [result, setResult] = useState<GradeResult | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [specOpen, setSpecOpen] = useState(true);
   // Closing the completion dialog must not immediately reopen it, but a fresh
   // submit should bring it back.
   const [completeDismissed, setCompleteDismissed] = useState(false);
+
+  /**
+   * Store the draft, a beat after typing stops.
+   *
+   * Driven from the editor's change event rather than an effect watching
+   * `source`: an effect also fires on mount, which would write the stub over a
+   * real draft in the moment between seeding and reading it. Only an edit is a
+   * reason to save.
+   */
+  const pendingDraft = useRef<string | null>(null);
+  const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveDraft = useCallback(
+    (next: string) => {
+      pendingDraft.current = next;
+      if (draftTimer.current) clearTimeout(draftTimer.current);
+      draftTimer.current = setTimeout(() => {
+        draftTimer.current = null;
+        pendingDraft.current = null;
+        writeDraft(level.id, next);
+      }, DRAFT_DEBOUNCE_MS);
+    },
+    [level.id],
+  );
+
+  // Leaving the page mid-debounce must not cost the last few keystrokes, and
+  // clicking "Map" straight after typing is the obvious way to hit that.
+  useEffect(
+    () => () => {
+      if (!draftTimer.current) return;
+      clearTimeout(draftTimer.current);
+      if (pendingDraft.current !== null) writeDraft(level.id, pendingDraft.current);
+    },
+    [level.id],
+  );
 
   // Preview the circuit the source describes. Pinned to the level's target by
   // name — the default picks the last circuit defined, which would follow a
@@ -138,12 +198,29 @@ function PlayLevel({ level }: { level: Level }) {
       // Submit is a request for a verdict, so show it — hidden, the spec sheet
       // swallowed both the failure message and the whole victory run.
       setSpecOpen(true);
-      if (verdict.status === 'pass') victory.start();
-      else victory.reset();
+      if (verdict.status === 'pass') {
+        // The score, not the source. Nothing reads a passing snapshot yet, and
+        // the map only needs to know this level is done and what it cost.
+        writeProgress(level.id, { gates: verdict.gates });
+        victory.start();
+      } else victory.reset();
     } finally {
       setSubmitting(false);
     }
   }, [sandbox, level, source, victory]);
+
+  /** Back to the level as it was handed over. The draft goes with it. */
+  const onReset = useCallback(() => {
+    if (draftTimer.current) {
+      clearTimeout(draftTimer.current);
+      draftTimer.current = null;
+    }
+    pendingDraft.current = null;
+    clearDraft(level.id);
+    setSource(level.stub);
+    setResult(null);
+    victory.reset();
+  }, [level.id, level.stub, victory]);
 
   // Surfaced as a Monaco squiggle rather than a panel note: the problem is on
   // a specific line, and that is where someone is looking.
@@ -213,6 +290,19 @@ function PlayLevel({ level }: { level: Level }) {
             <Network className="h-3.5 w-3.5 -rotate-90" />
             Map
           </Link>
+          {/* Drafts persist, so the stub is otherwise gone for good — and a
+              player who deletes half of a given preamble has no way back to a
+              level that compiles. Monaco keeps its undo stack across this, so
+              a misclick is one ⌘Z rather than a lost solution. */}
+          <button
+            type="button"
+            onClick={onReset}
+            title="Restore this level's starting code"
+            className="flex items-center gap-1.5 whitespace-nowrap rounded-md border border-border px-3 py-1.5 text-xs font-medium"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            Reset
+          </button>
           <button
             type="button"
             onClick={() => setSpecOpen((v) => !v)}
@@ -238,7 +328,9 @@ function PlayLevel({ level }: { level: Level }) {
               <SimtenCodeEditor
                 value={source}
                 onChange={(v) => {
-                  setSource(v ?? '');
+                  const next = v ?? '';
+                  setSource(next);
+                  saveDraft(next);
                   // A verdict describes the source that produced it, so an
                   // edit retires both the verdict and any victory run still
                   // sweeping.


### PR DESCRIPTION
Two localStorage records, and the four features that were waiting on them.

```
simten:game:drafts     levelId -> the source in the editor
simten:game:progress   levelId -> { gates: number }
```

Progress deliberately carries no source. Nothing would read it — no level imports another level's circuit today, since the full adder's half adder lives in its own stub. When composition lands, `LevelProgress` gains the source that last *passed*, and downstream levels read that snapshot rather than the draft.

### What this switches on

- The map's green nodes and lit wires — `solved` was already threaded into `buildMapGraph` and `simulateMap`, and was never passed
- `ENFORCE_LOCKING` → `true`. Still a soft gate: every level is reachable by URL
- The drilldown draws **your** circuit, falling back to the reference answer for levels never opened. Shrinks the `solutions/` spoiler without removing the fallback
- A **Reset** button, because drafts persisting means the stub is otherwise gone for good

### SSR

The two routes needed opposite treatments, so this is the part worth reviewing.

`play.$levelId` seeds the editor in the `useState` initialiser. That route does server-render, but the editor value never reaches the markup — Monaco renders a placeholder, and the served HTML contains no source text — so there is nothing to mismatch. Seeding in an effect would instead flash the stub and make the first change event carry it.

`routes/index` is the opposite: solved state is visible DOM, so it reads storage after mount and is honest for one frame. Drafts are read there too, so the drilldown compiles the right circuit the first time instead of compiling the reference and replacing it.

Drafts are written from the editor's change event, debounced 400ms, never from an effect watching `source` — an effect also fires on mount and would write the stub over a real draft. The pending write is flushed on unmount, so clicking Map straight after typing does not cost the last keystrokes.

### Checks

117 tests (105 + 12 new for the storage layer, driven through a fake `window`), `tsc --noEmit` clean, lint at the 590-warning baseline. No changeset: `apps/game` only.

Verified in the browser, since every UI bug here has passed the suite. Solved level 1 → `{"version":1,"data":{"first-wire":{"gates":1}}}`; refresh restores the draft with no hydration error; the map goes green with a live wire into level 2 and locks 3+; adding a stray gate to a solved level left progress intact and the drilldown drew the stray gate, while an unopened level still fell back to the reference; Reset emptied the record and left the level solved; typing then immediately leaving still saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUgzxXEKwMKSXmRW2apzQV