### PR TITLE
chore: deploy the game as part of the full deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:synth": "pnpm --filter @simten/synth dev",
     "dev:verifier": "pnpm --filter @simten/verifier dev",
     "dev:compiler": "pnpm --filter @simten/compiler dev",
-    "deploy": "pnpm run deploy:sandbox && pnpm run deploy:web",
+    "deploy": "pnpm run deploy:sandbox && pnpm run deploy:web && pnpm run deploy:game",
     "deploy:sandbox": "dotenv -- pnpm --filter @simten/sandbox run deploy",
     "deploy:web": "dotenv -- pnpm --filter @simten/web run deploy",
     "deploy:game": "dotenv -- pnpm --filter @simten/game run deploy",


### PR DESCRIPTION
`deploy:game` already existed. `deploy` did not run it, so a full deploy shipped the sandbox and `simten.dev` and left `play.simten.dev` on whatever was last pushed by hand.

```
deploy = deploy:sandbox && deploy:web && deploy:game
```

Sandbox stays first: the canvas loads circuit code from `sandbox.simten.dev`, so shipping an app against a stale sandbox is the failure mode worth avoiding.

Worth knowing while looking at this: there is no CI deploy for these three. `deploy-container.yml` is `workflow_dispatch` only and offers `synth`, `verifier` and `compiler`. Web, sandbox and game all ship from a laptop via these scripts. `CONTRIBUTING.md` says "the CI deploy workflow will ship to production", which is not true today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUgzxXEKwMKSXmRW2apzQV