### PR TITLE
feat: rewrite the intro dialog, publish the arch-test result, use pipes in titles

### DIFF
--- a/apps/game/src/components/IntroDialog.tsx
+++ b/apps/game/src/components/IntroDialog.tsx
@@ -39,22 +39,58 @@ export function IntroDialog() {
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <img src="/favicon.svg" alt="" width={40} height={40} className="mb-3" />
-          <DialogTitle className="text-2xl">Build a computer from one gate</DialogTitle>
+          <DialogTitle className="text-2xl">TypeScript meets hardware</DialogTitle>
           <DialogDescription className="sr-only">What this is, and how it works.</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3 text-sm text-muted-foreground">
+          <p>Build a computer out of logic gates, one layer of abstraction at a time.</p>
           <p>
-            You get one gate: NAND. Every other gate gets built out of it, and everything after that
-            gets built out of those.
+            Take it as far as you like:{' '}
+            <a
+              href="https://simten.dev/blog/rv32i-cpu"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              CPUs that run C
+            </a>
+            ,{' '}
+            <a
+              href="https://simten.dev/blog/how-tpus-work"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              accelerators
+            </a>
+            ,{' '}
+            <a
+              href="https://simten.dev/blog/snake-in-hardware"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              games
+            </a>
+            , exporting to Verilog and flashing your designs to real silicon on FPGAs.
           </p>
           <p>
-            You build by writing TypeScript rather than dragging wires, and the diagram draws itself
-            as you type. The same code runs on a real FPGA.
+            You do it by writing TypeScript rather than dragging wires. The circuit draws itself as
+            you type.
           </p>
+          <p>Good luck.</p>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="sm:items-end sm:justify-between">
+          <a
+            href="https://simten.dev"
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            Built on Simten, a TypeScript HDL ↗
+          </a>
           <button
             type="button"
             onClick={dismiss}

--- a/apps/game/src/routes/__root.tsx
+++ b/apps/game/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import appCss from '../styles.css?url';
 
 const THEME_INIT_SCRIPT = `(function(){try{var stored=window.localStorage.getItem('theme');var mode=(stored==='light'||stored==='dark'||stored==='auto')?stored:'dark';var prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=mode==='auto'?(prefersDark?'dark':'light'):mode;var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);if(mode==='auto'){root.removeAttribute('data-theme')}else{root.setAttribute('data-theme',mode)}root.style.colorScheme=resolved;}catch(e){}})();`;
 
-const TITLE = 'Simten — build hardware. Bit by bit.';
+const TITLE = 'Simten | Design hardware. Bit by bit.';
 const DESCRIPTION =
   'A puzzle campaign built on Simten, a TypeScript HDL that simulates in the browser and synthesizes to Verilog.';
 const SITE_URL = 'https://play.simten.dev';

--- a/apps/web/src/features/blog/rv32i-cpu/sections/ConformanceSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/ConformanceSection.tsx
@@ -1,0 +1,64 @@
+export function ConformanceSection() {
+  return (
+    <section className="py-12">
+      <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+        Does it actually implement RISC-V?
+      </h2>
+      <div className="prose-invert space-y-6">
+        <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+          &ldquo;It runs my C program&rdquo; is a weak claim. A CPU can run a lot of code correctly
+          and still get an edge case wrong &mdash; a shift by 32, a signed comparison at the
+          boundary, a branch offset that wraps. The industry answer to that is a conformance suite,
+          so we ran one.
+        </p>
+        <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+          The core passes all 38 of the official{' '}
+          <a
+            href="https://github.com/riscv/riscv-arch-test"
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
+          >
+            riscv-arch-test
+          </a>{' '}
+          RV32I-I tests, with its signature compared byte-for-byte against{' '}
+          <a
+            href="https://github.com/riscv-software-src/riscv-isa-sim"
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
+          >
+            Spike
+          </a>
+          , the reference RISC-V simulator. What gets tested is the elaborated gate-level netlist
+          &mdash; the same circuit shown above, flattened to primitives &mdash; not a behavioural
+          model written alongside it. The core needed no changes to pass.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-100 dark:bg-gray-900 p-4 text-sm text-gray-800 dark:text-gray-200">
+          <code>38/38 attempted pass vs Spike · 38/38 trap-free (pure RV32I) · 0 skipped</code>
+        </pre>
+        <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+          A green test run only means something if it can go red. The harness includes a fault check
+          that patches an <code>add</code> into a <code>sub</code> in the instruction stream and
+          confirms the signature then diverges from Spike, so passing is evidence rather than a
+          formality.
+        </p>
+        <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+          Two honest limits: this is simulation, not silicon &mdash; the suite has not been run on
+          the FPGA &mdash; and passing arch-test is not the same as being certified.
+        </p>
+      </div>
+
+      <div className="mt-6 text-center">
+        <a
+          href="https://github.com/simtenHQ/simten/tree/main/hardware/ulx3s/projects/cpu/archtest"
+          target="_blank"
+          rel="noreferrer"
+          className="text-sm text-blue-400 hover:text-blue-300 underline underline-offset-2"
+        >
+          The conformance harness on GitHub &rarr;
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,7 +24,7 @@ const shareCircuitFn = (source: string) => shareCircuit({ data: { source } });
 
 const SITE_URL = 'https://simten.dev';
 const SITE_NAME = 'Simten';
-const DEFAULT_TITLE = 'Simten — Hardware design in TypeScript';
+const DEFAULT_TITLE = 'Simten | Hardware design in TypeScript';
 const DEFAULT_DESCRIPTION =
   'Design and simulate digital hardware in TypeScript. From single gates to RISC-V CPUs, synthesizable to Verilog, running live in your browser.';
 const DEFAULT_OG_IMAGE = `${SITE_URL}/og-default.png`;

--- a/apps/web/src/routes/blog/rv32i-cpu.tsx
+++ b/apps/web/src/routes/blog/rv32i-cpu.tsx
@@ -31,6 +31,11 @@ const RunningCodeSection = lazy(() =>
     default: m.RunningCodeSection,
   })),
 );
+const ConformanceSection = lazy(() =>
+  import('@/features/blog/rv32i-cpu/sections/ConformanceSection').then((m) => ({
+    default: m.ConformanceSection,
+  })),
+);
 const TryItSection = lazy(() =>
   import('@/features/blog/rv32i-cpu/sections/TryItSection').then((m) => ({
     default: m.TryItSection,
@@ -99,6 +104,14 @@ function RV32ICPUPage() {
         <ErrorBoundary>
           <Suspense fallback={<SectionSkeleton />}>
             <RunningCodeSection />
+          </Suspense>
+        </ErrorBoundary>
+
+        <hr className="border-gray-200 dark:border-gray-800" />
+
+        <ErrorBoundary>
+          <Suspense fallback={<SectionSkeleton />}>
+            <ConformanceSection />
           </Suspense>
         </ErrorBoundary>
 

--- a/apps/web/src/routes/circuit_.$encoded.tsx
+++ b/apps/web/src/routes/circuit_.$encoded.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/circuit_/$encoded')({
   head: ({ loaderData }) => {
     const name = loaderData?.circuitName;
     return pageHead({
-      title: name ? `${name} — Shared circuit` : 'Shared circuit',
+      title: name ? `${name} | Shared circuit` : 'Shared circuit',
       description: name
         ? `Open and modify the ${name} circuit in the Simten editor.`
         : 'Open and modify a shared Simten circuit.',

--- a/apps/web/src/routes/circuit_.s.$hash.tsx
+++ b/apps/web/src/routes/circuit_.s.$hash.tsx
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/circuit_/s/$hash')({
   head: ({ loaderData }) => {
     const name = loaderData?.circuitName;
     return pageHead({
-      title: name ? `${name} — Shared circuit` : 'Shared circuit',
+      title: name ? `${name} | Shared circuit` : 'Shared circuit',
       description: name
         ? `Open and modify the ${name} circuit in the Simten editor.`
         : 'Open and modify a shared Simten circuit.',

--- a/apps/web/src/routes/cpu/rv32i.tsx
+++ b/apps/web/src/routes/cpu/rv32i.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute('/cpu/rv32i')({
   staticData: { skipDefaultChrome: true },
   head: () => ({
     ...pageHead({
-      title: 'RV32I CPU Debugger — RISC-V in the browser',
+      title: 'RV32I CPU Debugger | RISC-V in the browser',
       description:
         'A working 5-stage pipelined RV32I RISC-V processor, built from logic gates. Write C, C++, or Rust, compile it with the GCC RISC-V toolchain, and step through execution cycle by cycle.',
       path: '/cpu/rv32i',

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -66,7 +66,7 @@ import { pageHead, softwareApplicationLd } from '@/lib/seo';
 export const Route = createFileRoute('/')({
   head: () => ({
     ...pageHead({
-      title: 'Simten — Hardware design in TypeScript',
+      title: 'Simten | Hardware design in TypeScript',
       titleExact: true,
       description:
         'A TypeScript HDL where npm is your testbench — from logic gates to a RISC-V CPU. Test circuits against real firmware, then synthesize to Verilog.',

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/privacy')({
   component: PrivacyPage,
   head: () => ({
     meta: [
-      { title: 'Privacy Policy — Simten' },
+      { title: 'Privacy Policy | Simten' },
       {
         name: 'description',
         content:

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/terms')({
   component: TermsPage,
   head: () => ({
     meta: [
-      { title: 'Terms of Service — Simten' },
+      { title: 'Terms of Service | Simten' },
       {
         name: 'description',
         content: 'Acceptance, acceptable use, warranty disclaimer, and liability terms for Simten.',


### PR DESCRIPTION
**Intro dialog.** It explained the game and never said what Simten was. Now it names the platform and links three things that show the ceiling: the RISC-V CPU post, the TPU post, and Snake. "Take it as far as you like" frames those as what the tool permits, not what the campaign contains.

**Tab titles.** `|` instead of an em-dash, eight titles across both apps. Consistency rather than preference: `lib/seo.ts:22` already builds every non-exact title as `${title} | ${SITE_NAME}`. The game's is now `Simten | Design hardware. Bit by bit.`

**Arch-test result.** The RISC-V post claimed "implements all of RV32I" while a full conformance run sat unseen in `hardware/ulx3s/projects/cpu/archtest`:

```
38/38 attempted pass vs Spike · 38/38 trap-free (pure RV32I) · 0 skipped
```

New section links riscv-arch-test, Spike and the harness (all three verified to resolve), keeps the README's caveats — simulation not silicon, not certification — and names the fault check, since a green run that can't go red proves nothing.

Both apps typecheck, 117 tests, lint at 590.

Noticed, not fixed: that post's CTA still calls Simten "a visual circuit simulator with an AI tutor". The other eleven posts probably share it.