### PR TITLE
fix(web): update the rv32i post's stale CTA copy

### DIFF
--- a/apps/web/src/features/blog/rv32i-cpu/sections/CTASection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/CTASection.tsx
@@ -8,9 +8,10 @@ export function CTASection() {
           Now build your own
         </h2>
         <p className="text-gray-600 dark:text-gray-400 max-w-xl mx-auto leading-relaxed">
-          Every circuit on this page was designed in Simten &mdash; a visual circuit simulator with
-          an AI tutor. Start from simple components or jump straight to CPU design. The AI helps you
-          wire things up, debug issues, and understand what&rsquo;s happening at every level.
+          Every circuit on this page was designed in Simten, a TypeScript HDL. Circuits are typed
+          code that simulates in the browser and exports to Verilog, so the same design runs on an
+          FPGA. Start from a single gate, or point your own AI assistant at it over MCP and build
+          alongside it.
         </p>
         <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
           <Link


### PR DESCRIPTION
The CTA called Simten "a visual circuit simulator with an AI tutor". Both halves are out of date: the category is a TypeScript HDL, and the visual-simulator framing is the Logisim slot the rest of the site's copy deliberately avoids. There is also no in-app AI tutor — the AI story is `@simten/mcp`, which you point your own assistant at.

Now:

> Every circuit on this page was designed in Simten, a TypeScript HDL. Circuits are typed code that simulates in the browser and exports to Verilog, so the same design runs on an FPGA. Start from a single gate, or point your own AI assistant at it over MCP and build alongside it.

Confined to this one file — every other post uses the shared `BlogFooter`, which doesn't describe Simten at all. Heading and buttons unchanged. tsc and lint clean.