### PR TITLE
feat: link the game from the site nav, tighten intro copy, gate the drilldown

### DIFF
--- a/apps/game/src/components/IntroDialog.tsx
+++ b/apps/game/src/components/IntroDialog.tsx
@@ -44,7 +44,11 @@ export function IntroDialog() {
         </DialogHeader>
 
         <div className="space-y-3 text-sm text-muted-foreground">
-          <p>Build a computer out of logic gates, one layer of abstraction at a time.</p>
+          <p>Build a computer from logic gates, one layer of abstraction at a time.</p>
+          <p>
+            You do this by writing TypeScript rather than dragging wires. The circuit draws itself
+            as you type.
+          </p>
           <p>
             Take it as far as you like:{' '}
             <a
@@ -73,11 +77,7 @@ export function IntroDialog() {
             >
               games
             </a>
-            , exporting to Verilog and flashing your designs to real silicon on FPGAs.
-          </p>
-          <p>
-            You do it by writing TypeScript rather than dragging wires. The circuit draws itself as
-            you type.
+            . Then export to Verilog and flash your designs to real silicon on FPGAs.
           </p>
           <p>Good luck.</p>
         </div>

--- a/apps/game/src/components/LevelMap.tsx
+++ b/apps/game/src/components/LevelMap.tsx
@@ -134,18 +134,26 @@ function LevelMapNode({ data }: NodeProps<LevelNode>) {
               to guess. It sits outside the Link deliberately: clicking the card
               still opens the level, and inspecting is its own target.
 
+              Solved levels only. On an unsolved one there is nothing of the
+              player's to show, so the drilldown falls back to the reference
+              answer — which hands over the solution to a level they have not
+              attempted. The badge is the affordance, so removing it is what
+              removes the spoiler.
+
               `contents` keeps the button boxless, so the badge's own absolute
               positioning still resolves against the card rather than nesting a
               second offset inside a wrapper.
             */}
-            <button
-              type="button"
-              className="contents"
-              aria-label={`Look inside ${data.title}`}
-              onDoubleClick={() => data.onExpand?.(data.levelId)}
-            >
-              <CompositeBadge />
-            </button>
+            {data.state === 'solved' && (
+              <button
+                type="button"
+                className="contents"
+                aria-label={`Look inside ${data.title}`}
+                onDoubleClick={() => data.onExpand?.(data.levelId)}
+              >
+                <CompositeBadge />
+              </button>
+            )}
           </>
         )}
       </div>

--- a/apps/game/src/routes/index.tsx
+++ b/apps/game/src/routes/index.tsx
@@ -63,8 +63,14 @@ function MapPage() {
   // While the inspector is open it wins, so sweeping the pointer across other
   // levels behind the modal cannot swap what is being inspected. Otherwise the
   // hovered level is mounted to warm its compile before it is asked for.
+  // Solved levels only. The drilldown falls back to the reference answer when
+  // the player has no draft, so mounting it for an unattempted level would
+  // compile the solution and hand it over on a double-click. LevelMap hides the
+  // badge for the same reason; this makes it structural rather than cosmetic,
+  // and stops a hover compiling an answer nobody asked for.
   const activeId = expanded ?? hovered;
-  const level = activeId ? LEVELS_BY_ID.get(activeId) : undefined;
+  const candidate = activeId ? LEVELS_BY_ID.get(activeId) : undefined;
+  const level = candidate && solved.has(candidate.id) ? candidate : undefined;
 
   return (
     <div className="flex h-screen flex-col">

--- a/apps/web/src/components/SiteNavLinks.tsx
+++ b/apps/web/src/components/SiteNavLinks.tsx
@@ -51,6 +51,11 @@ export function SiteNavLinks() {
           ThemeToggle, matching the gap-6 rhythm between the links themselves
           (so the GitHub icon doesn't look stuck to the toggle). */}
       <nav className="hidden items-center gap-6 text-[15px] text-foreground/70 sm:mr-3 sm:flex">
+        {/* Own subdomain, so a plain anchor rather than a router Link. Same tab:
+            it is the same product, not somewhere you send people away to. */}
+        <a href="https://play.simten.dev" className="transition-colors hover:text-foreground">
+          Play
+        </a>
         <Link to="/blog" className="transition-colors hover:text-foreground">
           Blog
         </Link>
@@ -97,6 +102,9 @@ export function SiteNavLinks() {
               className="fixed inset-x-0 bottom-0 top-14 z-40 bg-background/60 backdrop-blur-sm"
             />
             <nav className="fixed inset-x-0 top-14 z-50 flex flex-col gap-1 border-b border-border bg-background px-4 pb-4 pt-2">
+              <a href="https://play.simten.dev" onClick={close} className={mobileItem}>
+                Play
+              </a>
               <Link to="/blog" onClick={close} className={mobileItem}>
                 Blog
               </Link>


### PR DESCRIPTION
**Nav link.** `simten.dev` had no link to `play.simten.dev` anywhere — not the homepage, not the source. That's a discovery problem for Google, which finds pages through links, and for anyone landing on the main site. Added as the first nav item, desktop and mobile. Plain anchor (different origin) and same tab (same product).

**Intro dialog.** Reordered so the mechanic comes before the ambition, and the FPGA claim is its own sentence at the end:

> Build a computer from logic gates, one layer of abstraction at a time.
>
> You do this by writing TypeScript rather than dragging wires. The circuit draws itself as you type.
>
> Take it as far as you like: CPUs that run C, accelerators, games. Then export to Verilog and flash your designs to real silicon on FPGAs.
>
> Good luck.

**Drilldown spoiler.** The inspect badge was on every unlocked level, and for a level with no draft the drilldown falls back to `SOLUTIONS[level.id]` — so double-clicking level 1 showed the answer before you'd written anything. Now solved levels only, gated twice: `LevelMap` hides the badge, and `routes/index.tsx` won't mount the drilldown for an unsolved level, which also stops a hover compiling a reference solution in the background.

Verified in the browser with only `first-wire` solved: it's the only node with a badge, the other nine have none. 117 tests, both apps typecheck, lint at 590.