### PR TITLE
refactor(game): name single-output led nodes result instead of out

### DIFF
--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -57,7 +57,7 @@ export const LEVELS: Level[] = [
       'This circuit is finished apart from one connection: nothing carries the gate’s result to the lamp. Add that line, then flip the switches.',
     target: 'Nand1',
     inputs: ['a', 'b'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// A circuit is a set of nodes and the wires between them.
 // \`x.to(y)\` sends the value at x into y.
@@ -71,20 +71,20 @@ export default circuit('Nand1', {
     a: Switch,
     b: Switch,
     n1: Nand,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, b, n1, out } }) => [
+  connect: ({ nodes: { a, b, n1, result } }) => [
     a.out.to(n1.a),
     b.out.to(n1.b),
-    // One more line. Send n1.out to out.in
+    // One more line. Send n1.out to result.in
   ],
 });
 `,
     vectors: [
-      { inputs: { a: 0, b: 0 }, expect: { out: 1 } },
-      { inputs: { a: 0, b: 1 }, expect: { out: 1 } },
-      { inputs: { a: 1, b: 0 }, expect: { out: 1 } },
-      { inputs: { a: 1, b: 1 }, expect: { out: 0 } },
+      { inputs: { a: 0, b: 0 }, expect: { result: 1 } },
+      { inputs: { a: 0, b: 1 }, expect: { result: 1 } },
+      { inputs: { a: 1, b: 0 }, expect: { result: 1 } },
+      { inputs: { a: 1, b: 1 }, expect: { result: 0 } },
     ],
     par: 1,
     outro: {
@@ -100,7 +100,7 @@ export default circuit('Nand1', {
       'You have seen what NAND does: it outputs 0 only when both its inputs are 1. It is the only gate you get, so every other gate gets built from it. Start with the simplest — turn a 1 into a 0.',
     target: 'Not1',
     inputs: ['a'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// The same gate as last level, and the only one there is.
 // NAND outputs 0 only when both inputs are 1.
@@ -115,16 +115,16 @@ export default circuit('Not1', {
   nodes: {
     a: Switch,
     n1: Nand,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, n1, out } }) => [
-    n1.out.to(out.in),
+  connect: ({ nodes: { a, n1, result } }) => [
+    n1.out.to(result.in),
   ],
 });
 `,
     vectors: [
-      { inputs: { a: 0 }, expect: { out: 1 } },
-      { inputs: { a: 1 }, expect: { out: 0 } },
+      { inputs: { a: 0 }, expect: { result: 1 } },
+      { inputs: { a: 1 }, expect: { result: 0 } },
     ],
     par: 1,
     outro: {
@@ -140,7 +140,7 @@ export default circuit('Not1', {
       'A NAND is an AND gate with its answer flipped. You spent the last level learning to flip an answer. Light the lamp only when both switches are on.',
     target: 'And2',
     inputs: ['a', 'b'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// The NAND already sees both switches. Its answer
 // is the one you want, upside down.
@@ -156,9 +156,9 @@ export default circuit('And2', {
     a: Switch,
     b: Switch,
     n1: Nand,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, b, n1, out } }) => [
+  connect: ({ nodes: { a, b, n1, result } }) => [
     a.out.to(n1.a),
     b.out.to(n1.b),
     //
@@ -166,10 +166,10 @@ export default circuit('And2', {
 });
 `,
     vectors: [
-      { inputs: { a: 0, b: 0 }, expect: { out: 0 } },
-      { inputs: { a: 0, b: 1 }, expect: { out: 0 } },
-      { inputs: { a: 1, b: 0 }, expect: { out: 0 } },
-      { inputs: { a: 1, b: 1 }, expect: { out: 1 } },
+      { inputs: { a: 0, b: 0 }, expect: { result: 0 } },
+      { inputs: { a: 0, b: 1 }, expect: { result: 0 } },
+      { inputs: { a: 1, b: 0 }, expect: { result: 0 } },
+      { inputs: { a: 1, b: 1 }, expect: { result: 1 } },
     ],
     par: 2,
     outro: {
@@ -185,7 +185,7 @@ export default circuit('And2', {
       'Light the lamp when either switch is on. There is no way to get there by flipping a NAND, so come at it from the other end: work out when the lamp should stay off.',
     target: 'Or1',
     inputs: ['a', 'b'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// The lamp is off in exactly one case: both switches down.
 //
@@ -200,18 +200,18 @@ export default circuit('Or1', {
   nodes: {
     a: Switch,
     b: Switch,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, b, out } }) => [
+  connect: ({ nodes: { a, b, result } }) => [
     //
   ],
 });
 `,
     vectors: [
-      { inputs: { a: 0, b: 0 }, expect: { out: 0 } },
-      { inputs: { a: 0, b: 1 }, expect: { out: 1 } },
-      { inputs: { a: 1, b: 0 }, expect: { out: 1 } },
-      { inputs: { a: 1, b: 1 }, expect: { out: 1 } },
+      { inputs: { a: 0, b: 0 }, expect: { result: 0 } },
+      { inputs: { a: 0, b: 1 }, expect: { result: 1 } },
+      { inputs: { a: 1, b: 0 }, expect: { result: 1 } },
+      { inputs: { a: 1, b: 1 }, expect: { result: 1 } },
     ],
     par: 3,
     outro: {
@@ -227,10 +227,10 @@ export default circuit('Or1', {
       'NOR is OR with the answer flipped: the lamp is on only when both switches are off. You built OR a minute ago, so most of this is already done.',
     target: 'Nor1',
     inputs: ['a', 'b'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// Nothing new here. Build the OR you already
-// worked out, then flip what comes out of it.
+// worked result, then flip what comes out of it.
 //
 // Four NANDs is the target.
 
@@ -238,18 +238,18 @@ export default circuit('Nor1', {
   nodes: {
     a: Switch,
     b: Switch,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, b, out } }) => [
+  connect: ({ nodes: { a, b, result } }) => [
     //
   ],
 });
 `,
     vectors: [
-      { inputs: { a: 0, b: 0 }, expect: { out: 1 } },
-      { inputs: { a: 0, b: 1 }, expect: { out: 0 } },
-      { inputs: { a: 1, b: 0 }, expect: { out: 0 } },
-      { inputs: { a: 1, b: 1 }, expect: { out: 0 } },
+      { inputs: { a: 0, b: 0 }, expect: { result: 1 } },
+      { inputs: { a: 0, b: 1 }, expect: { result: 0 } },
+      { inputs: { a: 1, b: 0 }, expect: { result: 0 } },
+      { inputs: { a: 1, b: 1 }, expect: { result: 0 } },
     ],
     par: 4,
     outro: {
@@ -265,7 +265,7 @@ export default circuit('Nor1', {
       'Light the lamp when the two switches disagree. This is the one that takes a minute — and it is the gate an adder is built from, so it pays off twice.',
     target: 'Xor1',
     inputs: ['a', 'b'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// Work out how many NANDs this needs. Fewer is better.
 //
@@ -276,18 +276,18 @@ export default circuit('Xor1', {
   nodes: {
     a: Switch,
     b: Switch,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, b, out } }) => [
+  connect: ({ nodes: { a, b, result } }) => [
     //
   ],
 });
 `,
     vectors: [
-      { inputs: { a: 0, b: 0 }, expect: { out: 0 } },
-      { inputs: { a: 0, b: 1 }, expect: { out: 1 } },
-      { inputs: { a: 1, b: 0 }, expect: { out: 1 } },
-      { inputs: { a: 1, b: 1 }, expect: { out: 0 } },
+      { inputs: { a: 0, b: 0 }, expect: { result: 0 } },
+      { inputs: { a: 0, b: 1 }, expect: { result: 1 } },
+      { inputs: { a: 1, b: 0 }, expect: { result: 1 } },
+      { inputs: { a: 1, b: 1 }, expect: { result: 0 } },
     ],
     par: 4,
     outro: {
@@ -303,7 +303,7 @@ export default circuit('Xor1', {
       'The last gate in the set, and the opposite of the one you just built: light the lamp when the two switches agree. You already know the move.',
     target: 'Xnor1',
     inputs: ['a', 'b'],
-    outputs: ['out'],
+    outputs: ['result'],
     allowed: ['Nand'],
     stub: `// Your XOR, with the answer flipped.
 //
@@ -315,18 +315,18 @@ export default circuit('Xnor1', {
   nodes: {
     a: Switch,
     b: Switch,
-    out: Led,
+    result: Led,
   },
-  connect: ({ nodes: { a, b, out } }) => [
+  connect: ({ nodes: { a, b, result } }) => [
     //
   ],
 });
 `,
     vectors: [
-      { inputs: { a: 0, b: 0 }, expect: { out: 1 } },
-      { inputs: { a: 0, b: 1 }, expect: { out: 0 } },
-      { inputs: { a: 1, b: 0 }, expect: { out: 0 } },
-      { inputs: { a: 1, b: 1 }, expect: { out: 1 } },
+      { inputs: { a: 0, b: 0 }, expect: { result: 1 } },
+      { inputs: { a: 0, b: 1 }, expect: { result: 0 } },
+      { inputs: { a: 1, b: 0 }, expect: { result: 0 } },
+      { inputs: { a: 1, b: 1 }, expect: { result: 1 } },
     ],
     par: 5,
     outro: {

--- a/apps/game/src/game/solutions/and-from-nand.ts
+++ b/apps/game/src/game/solutions/and-from-nand.ts
@@ -4,11 +4,11 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const And2 = circuit('And2', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, out: Led },
-  connect: ({ nodes: { a, b, n1, n2, out } }) => [
+  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, result: Led },
+  connect: ({ nodes: { a, b, n1, n2, result } }) => [
     a.out.to(n1.a),
     b.out.to(n1.b),
     n1.out.to(n2.a, n2.b),
-    n2.out.to(out.in),
+    n2.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/first-wire.ts
+++ b/apps/game/src/game/solutions/first-wire.ts
@@ -4,6 +4,10 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const Nand1 = circuit('Nand1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, out: Led },
-  connect: ({ nodes: { a, b, n1, out } }) => [a.out.to(n1.a), b.out.to(n1.b), n1.out.to(out.in)],
+  nodes: { a: Switch, b: Switch, n1: Nand, result: Led },
+  connect: ({ nodes: { a, b, n1, result } }) => [
+    a.out.to(n1.a),
+    b.out.to(n1.b),
+    n1.out.to(result.in),
+  ],
 });

--- a/apps/game/src/game/solutions/nor-from-nand.ts
+++ b/apps/game/src/game/solutions/nor-from-nand.ts
@@ -4,13 +4,13 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const Nor1 = circuit('Nor1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, out: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, n4, out } }) => [
+  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, result: Led },
+  connect: ({ nodes: { a, b, n1, n2, n3, n4, result } }) => [
     a.out.to(n1.a, n1.b),
     b.out.to(n2.a, n2.b),
     n1.out.to(n3.a),
     n2.out.to(n3.b),
     n3.out.to(n4.a, n4.b),
-    n4.out.to(out.in),
+    n4.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/not-from-nand.ts
+++ b/apps/game/src/game/solutions/not-from-nand.ts
@@ -4,6 +4,6 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const Not1 = circuit('Not1', {
-  nodes: { a: Switch, n1: Nand, out: Led },
-  connect: ({ nodes: { a, n1, out } }) => [a.out.to(n1.a, n1.b), n1.out.to(out.in)],
+  nodes: { a: Switch, n1: Nand, result: Led },
+  connect: ({ nodes: { a, n1, result } }) => [a.out.to(n1.a, n1.b), n1.out.to(result.in)],
 });

--- a/apps/game/src/game/solutions/or-from-nand.ts
+++ b/apps/game/src/game/solutions/or-from-nand.ts
@@ -4,12 +4,12 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const Or1 = circuit('Or1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, out: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, out } }) => [
+  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, result: Led },
+  connect: ({ nodes: { a, b, n1, n2, n3, result } }) => [
     a.out.to(n1.a, n1.b),
     b.out.to(n2.a, n2.b),
     n1.out.to(n3.a),
     n2.out.to(n3.b),
-    n3.out.to(out.in),
+    n3.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/xnor-from-nand.ts
+++ b/apps/game/src/game/solutions/xnor-from-nand.ts
@@ -4,14 +4,14 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const Xnor1 = circuit('Xnor1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, n5: Nand, out: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, n4, n5, out } }) => [
+  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, n5: Nand, result: Led },
+  connect: ({ nodes: { a, b, n1, n2, n3, n4, n5, result } }) => [
     a.out.to(n1.a, n2.a),
     b.out.to(n1.b, n3.b),
     n1.out.to(n2.b, n3.a),
     n2.out.to(n4.a),
     n3.out.to(n4.b),
     n4.out.to(n5.a, n5.b),
-    n5.out.to(out.in),
+    n5.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/xor-from-nand.ts
+++ b/apps/game/src/game/solutions/xor-from-nand.ts
@@ -4,13 +4,13 @@ import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
 export const Xor1 = circuit('Xor1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, out: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, n4, out } }) => [
+  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, result: Led },
+  connect: ({ nodes: { a, b, n1, n2, n3, n4, result } }) => [
     a.out.to(n1.a, n2.a),
     b.out.to(n1.b, n3.b),
     n1.out.to(n2.b, n3.a),
     n2.out.to(n4.a),
     n3.out.to(n4.b),
-    n4.out.to(out.in),
+    n4.out.to(result.in),
   ],
 });


### PR DESCRIPTION
`n1.out.to(out.in)` collided: `out` was the Led node's id *and* the port name on every component. Level 1's own hint read "Send n1.out to out.in", which is the worst version of it.

Renamed to `result`, which follows the convention levels 9 and 10 already use — Led nodes named for the signal they carry (`sum`, `carry`, `cout`), not for the component.

Scope is levels 1–7 and their seven reference solutions. Deliberately untouched:

- **Ports.** `a.out.to(n1.a)` still says `out`, because that is the gate's output port.
- **Level 8's `outputs: { out: bit }`** — a signal name on a component, the correct convention, and no clash there.
- **Level 10's `sum`/`cout`** — already right.
- **The prose.** Briefs still say "light the lamp", because the thing on screen is still a lamp. Only the identifier changed.

`levels.test.ts` runs every reference solution against its level, so a rename that missed a spot would fail rather than ship. 117 tests, tsc clean, lint at 590. Verified in the browser: truth table row and canvas node both read `result`.

**Existing drafts break.** A saved draft still says `out: Led` while the level now wants a signal called `result`, so it fails the interface check — and those failures are currently silent, so Submit will look like it does nothing. Reset restores the stub. Only affects anyone who played before this ships, which is a handful of people given the game went public today.