### PR TITLE
feat(game): explain failures, unlock gates as you build them, rename levels

### DIFF
--- a/apps/game/src/components/SpecPanel.tsx
+++ b/apps/game/src/components/SpecPanel.tsx
@@ -33,6 +33,40 @@ function Heading({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * What went wrong, in a sentence — for the failures a truth table cannot say.
+ *
+ * A red column expresses "your circuit computes the wrong thing" better than
+ * prose does, so `vector` returns null and the table keeps that job. The other
+ * four have nothing to redden: the circuit is missing, misnamed, uses a gate
+ * the level forbids, or never ran. Those used to submit in silence, which read
+ * as a broken button.
+ *
+ * Everything here comes off the failure itself — `GradeFailure` was written to
+ * carry what the player needs to fix it, and then nothing displayed it.
+ */
+function explain(result: GradeResult | null): string | null {
+  if (!result) return null;
+  if (result.status === 'error') return result.message;
+  if (result.status !== 'fail') return null;
+
+  const f = result.failure;
+  switch (f.kind) {
+    case 'vector':
+      return null;
+    case 'missing-circuit':
+      return f.found.length > 0
+        ? `No circuit called \`${f.expected}\`. This file defines: ${f.found.join(', ')}.`
+        : `No circuit called \`${f.expected}\`. Nothing is exported yet.`;
+    case 'interface':
+      return `This circuit has ${f.problems.join(', and ')}.`;
+    case 'forbidden': {
+      const plural = f.used.length > 1;
+      return `${f.used.join(', ')} ${plural ? 'are' : 'is'} not allowed on this level. You have: ${f.allowed.join(', ')}.`;
+    }
+  }
+}
+
 export function SpecPanel({ level, result, activeRow, provenRows }: SpecPanelProps) {
   // Which column the grader stopped on. The failure carries the vector it was
   // given rather than its position, and matching on the inputs rather than on
@@ -44,6 +78,7 @@ export function SpecPanel({ level, result, activeRow, provenRows }: SpecPanelPro
       ? -1
       : level.vectors.findIndex((v) => JSON.stringify(v.inputs) === failedKey);
   const failedIndex = failedAt >= 0 ? failedAt : null;
+  const reason = explain(result);
 
   return (
     <div className="flex h-full items-start gap-8 overflow-x-auto overflow-y-auto px-4 py-3">
@@ -61,6 +96,13 @@ export function SpecPanel({ level, result, activeRow, provenRows }: SpecPanelPro
         <Heading>The problem</Heading>
         <p className="text-sm leading-relaxed text-muted-foreground">{level.brief}</p>
       </div>
+
+      {reason && (
+        <div className="min-w-[220px] max-w-md shrink-0">
+          <Heading>Not yet</Heading>
+          <p className="text-sm leading-relaxed text-amber-600 dark:text-amber-400">{reason}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/game/src/game/__tests__/permitted.test.ts
+++ b/apps/game/src/game/__tests__/permitted.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The editor, the canvas and the grader must permit exactly the same set.
+ *
+ * They used to compose `allowed ∪ STRUCTURAL` separately — the editor built its
+ * ambient globals from one copy, the grader checked the netlist against another.
+ * Two copies of a rule is how you get a level that autocompletes a gate and then
+ * rejects it on Submit. `permittedFor` is now the only definition; this pins it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { forbiddenPrimitives, permittedFor, STRUCTURAL } from '../grade';
+import { LEVELS } from '../levels';
+
+describe('permittedFor', () => {
+  it('is the level gates plus the structural pieces, for every level', () => {
+    for (const level of LEVELS) {
+      expect(new Set(permittedFor(level.allowed))).toEqual(
+        new Set([...level.allowed, ...STRUCTURAL]),
+      );
+    }
+  });
+
+  it('never omits a gate the level names', () => {
+    for (const level of LEVELS) {
+      for (const gate of level.allowed) expect(permittedFor(level.allowed)).toContain(gate);
+    }
+  });
+
+  /**
+   * The property that matters: anything the editor puts in scope must survive
+   * the grader. If these drift, a player writes something the editor offered
+   * and Submit refuses it — with no way to tell which is right.
+   */
+  it('accepts every primitive the editor puts in scope', () => {
+    for (const level of LEVELS) {
+      const flat = {
+        nodes: permittedFor(level.allowed).map((primitiveType, i) => ({
+          id: `n${i}`,
+          primitiveType,
+        })),
+      };
+      expect(forbiddenPrimitives(flat as never, level.allowed)).toEqual([]);
+    }
+  });
+
+  it('rejects a primitive no level named', () => {
+    const level = LEVELS[0];
+    const flat = { nodes: [{ id: 'n0', primitiveType: 'Not' }] };
+    expect(forbiddenPrimitives(flat as never, level.allowed)).toEqual(['Not']);
+  });
+
+  it('exempts structural nodes without naming them in allowed', () => {
+    const flat = {
+      nodes: [...STRUCTURAL].map((primitiveType, i) => ({ id: `n${i}`, primitiveType })),
+    };
+    expect(forbiddenPrimitives(flat as never, [])).toEqual([]);
+  });
+});

--- a/apps/game/src/game/grade.ts
+++ b/apps/game/src/game/grade.ts
@@ -57,13 +57,25 @@ function interfaceProblems(circuit: Circuit, level: Level): string[] {
   return problems;
 }
 
-function forbiddenPrimitives(flat: FlatCircuit, allowed: string[]): string[] {
-  const permitted = new Set(allowed);
+/**
+ * Everything a level lets you place: its own gates, plus the structural pieces
+ * that carry no logic.
+ *
+ * One definition, three consumers — the editor's ambient globals, the canvas
+ * preview, and this grader. They were each composing `allowed ∪ STRUCTURAL`
+ * separately, which is how an editor that autocompletes a gate the grader then
+ * rejects comes about. `__tests__/permitted.test.ts` pins that they agree.
+ */
+export function permittedFor(allowed: string[]): string[] {
+  return [...allowed, ...STRUCTURAL];
+}
+
+/** Primitives in the elaborated netlist that the level does not permit. */
+export function forbiddenPrimitives(flat: FlatCircuit, allowed: string[]): string[] {
+  const permitted = new Set(permittedFor(allowed));
   const used = new Set<string>();
   for (const node of flat.nodes) {
-    if (!permitted.has(node.primitiveType) && !STRUCTURAL.has(node.primitiveType)) {
-      used.add(node.primitiveType);
-    }
+    if (!permitted.has(node.primitiveType)) used.add(node.primitiveType);
   }
   return [...used].sort();
 }

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -10,6 +10,7 @@
  * netlist and watch it become hardware you can click.
  */
 
+import { elaborate } from '@simten/core';
 import { ErrorDisplay, useCompiledCircuit } from '@simten/embed';
 import { CircuitCanvas } from '@simten/ui/canvas';
 import {
@@ -31,7 +32,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LevelComplete } from '../components/LevelComplete';
 import { Logo } from '../components/Logo';
 import { SpecPanel } from '../components/SpecPanel';
-import { grade, STRUCTURAL } from '../game/grade';
+import { forbiddenPrimitives, grade, permittedFor } from '../game/grade';
 import { nameDiagnostics } from '../game/level-name';
 import { LEVELS_BY_ID, nextLevel } from '../game/levels';
 import { sandboxRuntime } from '../game/runtime';
@@ -189,6 +190,62 @@ function PlayLevel({ level }: { level: Level }) {
   // switches flip and the LED lights. The proof is the machine running.
   const victory = useVictoryRun(level.vectors, preview.setNodeValue);
 
+  /**
+   * Gates in the preview that this level forbids.
+   *
+   * The editor filter only removes the type declarations, so a disallowed gate
+   * is a red squiggle and nothing more — the sandbox still executes it, and the
+   * canvas happily drew a component the level bans. That left the diagram
+   * looking like the authority while Submit disagreed.
+   *
+   * Checked here rather than in the sandbox, which has no business knowing a
+   * level's rules: this is the grader's own function run against the preview,
+   * so the canvas and the verdict cannot give different answers.
+   */
+  /**
+   * The last circuit that used only permitted gates.
+   *
+   * While a forbidden gate is present the canvas shows this instead of the
+   * current netlist, so a banned gate simply never appears — no banner, no
+   * fanfare. The editor already squiggles it; the diagram just declines to
+   * pretend it is real, and stops updating until the gate is gone.
+   *
+   * A ref rather than state — it is a cache of a render output, and setting
+   * state from render to track it would just loop.
+   */
+  const lastPermitted = useRef<{
+    circuit: typeof preview.circuit;
+    library: typeof preview.componentLibrary;
+  } | null>(null);
+
+  const forbidden = useMemo(() => {
+    if (!preview.circuit || !preview.componentLibrary) return [];
+    try {
+      return forbiddenPrimitives(
+        elaborate(preview.circuit, preview.componentLibrary),
+        level.allowed,
+      );
+    } catch {
+      // Mid-keystroke the netlist is often unelaboratable. That is the compile
+      // error's story to tell, not this one's.
+      return [];
+    }
+  }, [preview.circuit, preview.componentLibrary, level.allowed]);
+
+  if (forbidden.length === 0 && preview.circuit) {
+    lastPermitted.current = { circuit: preview.circuit, library: preview.componentLibrary };
+  }
+  // Forbidden with a good circuit behind it → keep showing that one. Forbidden
+  // with nothing behind it (a draft that arrived already broken) → show
+  // nothing, because the only alternative is drawing the banned gate.
+  const shown = forbidden.length > 0 ? lastPermitted.current : null;
+  const canvasCircuit = shown ? shown.circuit : forbidden.length > 0 ? null : preview.circuit;
+  const canvasLibrary = shown
+    ? shown.library
+    : forbidden.length > 0
+      ? null
+      : preview.componentLibrary;
+
   const onSubmit = useCallback(async () => {
     setSubmitting(true);
     try {
@@ -231,7 +288,7 @@ function PlayLevel({ level }: { level: Level }) {
    * earned yet does not autocomplete and does not compile. The rule stops being
    * something you discover by breaking it.
    *
-   * `STRUCTURAL` comes from the grader rather than a second list here: those are
+   * `permittedFor` comes from the grader rather than a second list here: those are
    * the pieces that carry no logic and never count toward par, which is exactly
    * why they are absent from `allowed`. Filtering on `allowed` alone would leave
    * every level unable to declare a `Switch`.
@@ -240,7 +297,7 @@ function PlayLevel({ level }: { level: Level }) {
     () => ({
       globals: false,
       extraLibs: {
-        'file:///simten-globals.d.ts': buildGlobalsFor([...level.allowed, ...STRUCTURAL]),
+        'file:///simten-globals.d.ts': buildGlobalsFor(permittedFor(level.allowed)),
       },
     }),
     [level.allowed],
@@ -358,7 +415,10 @@ function PlayLevel({ level }: { level: Level }) {
               />
             </div>
             {/* Diagnostics live under the editor, never over the canvas — a
-              parse error mid-keystroke must not blank the diagram. */}
+              parse error mid-keystroke must not blank the diagram. A forbidden
+              gate is the same class of message, so it lands here too: the
+              canvas keeps showing the last circuit that compiled, which is
+              what you want while you are still typing. */}
             {preview.compileError && <ErrorDisplay error={preview.compileError} />}
           </ResizablePanel>
 
@@ -366,8 +426,8 @@ function PlayLevel({ level }: { level: Level }) {
 
           <ResizablePanel defaultSize={55} minSize={20} className="overflow-hidden">
             <CircuitCanvas
-              circuit={preview.circuit}
-              componentLibrary={preview.componentLibrary ?? undefined}
+              circuit={canvasCircuit}
+              componentLibrary={canvasLibrary ?? undefined}
               portValues={preview.portValues}
               theme="dark"
               showControls


### PR DESCRIPTION
Four things, from a session of playing it.

### Submit was silent for four of five verdicts

`SpecPanel` used the failure only to redden a truth-table column, so a forbidden gate, a wrong signal name, a wrong circuit name and a runtime error all produced a button that appeared to do nothing. The grader already returns what the player needs — `{ kind: 'forbidden', used: ['Not'], allowed: ['Nand'] }` — and nothing displayed it. A "Not yet" column now carries it; the red column keeps the wrong-answer case.

### The canvas drew gates the level forbids

Editor gating only filters type declarations, so a banned gate was a squiggle while the sandbox still ran it and the canvas drew it. The canvas now runs `forbiddenPrimitives` — the grader's own function — against the preview and keeps showing the last permitted circuit. No banner: the squiggle is the signal, and deleting it brings the diagram back. Checked in the game rather than the sandbox, which has no business knowing a level's rules.

`permittedFor()` is now the single definition of what a level allows, used by the editor, the canvas and the grader, with five tests pinning that they agree.

### Each level now permits the gates you already built

`allowed` widens per level: AND may use NOT, OR may use NOT and AND, and so on, ending where `ARITHMETIC_GATES` already begins. Same stand-in that level 9 makes today, applied earlier.

Par is unchanged and still correct — a `Not` costs one gate exactly as a `Nand` does — and the completion card now announces the right unlock at every level instead of one lump after level 8. NOR and XNOR become two-gate levels, so their stubs name that and keep the NAND count as an optional flex.

### Levels renamed to their gates

`AND from NAND` was inaccurate once NOT was permitted, and it named the answer. Now `/and`, `/or`, `/nor`, `/xor`, `/xnor`, `/not`, with solution files to match. Old URLs 404 — nothing links to them and the game is not indexed, so this was the moment.

Also drops the number from map nodes and centres the title, and fixes a comment my earlier rename mangled ("worked out" had become "worked result"), which is live in production now.

122 tests, tsc clean, lint at 590. Verified against a production build: `/and`, `/or`, `/not` serve, `/xor-from-nand` 404s.