### PR TITLE
feat(game): unlock gates as you build them, and name levels after their gate

### DIFF
--- a/apps/game/src/components/LevelMap.tsx
+++ b/apps/game/src/components/LevelMap.tsx
@@ -83,12 +83,7 @@ function LevelMapNode({ data }: NodeProps<LevelNode>) {
   const locked = data.state === 'locked';
 
   const body = (
-    <span className="flex items-baseline gap-3">
-      <span className="font-mono text-xs text-muted-foreground">
-        {String(data.position).padStart(2, '0')}
-      </span>
-      <span className="font-medium leading-tight">{data.title}</span>
-    </span>
+    <span className="block w-full text-center font-medium leading-tight">{data.title}</span>
   );
 
   return (

--- a/apps/game/src/game/__tests__/levels.test.ts
+++ b/apps/game/src/game/__tests__/levels.test.ts
@@ -107,10 +107,10 @@ describe('the graded circuit is chosen by name', () => {
    * signal names and the wrong logic follows it, and the level still passes.
    */
   it('ignores a later circuit with the same signals', async () => {
-    const level = LEVELS_BY_ID.get('not-from-nand');
+    const level = LEVELS_BY_ID.get('not');
     if (!level) throw new Error('level missing');
 
-    const withDecoyLast = `${SOLUTIONS['not-from-nand']}
+    const withDecoyLast = `${SOLUTIONS['not']}
 
 export const Decoy = circuit('Decoy', {
   nodes: { a: Switch, b: Buffer, out: Led },

--- a/apps/game/src/game/__tests__/preamble.test.ts
+++ b/apps/game/src/game/__tests__/preamble.test.ts
@@ -20,7 +20,7 @@ describe('given-preamble detection', () => {
 
   it('leaves instruction comments visible', () => {
     // Every other stub opens with the hint; scrolling past it would hide it.
-    const orLevel = LEVELS.find((l) => l.id === 'or-from-nand');
+    const orLevel = LEVELS.find((l) => l.id === 'or');
     if (!orLevel) throw new Error('missing level');
     expect(givenPreambleEnd(orLevel.stub.split('\n'))).toBeNull();
   });

--- a/apps/game/src/game/__tests__/storage.test.ts
+++ b/apps/game/src/game/__tests__/storage.test.ts
@@ -69,19 +69,19 @@ describe('drafts', () => {
   it('stores per level and leaves the others alone', () => {
     installStorage();
     writeDraft('first-wire', 'one');
-    writeDraft('not-from-nand', 'two');
-    expect(readDrafts()).toEqual({ 'first-wire': 'one', 'not-from-nand': 'two' });
+    writeDraft('not', 'two');
+    expect(readDrafts()).toEqual({ 'first-wire': 'one', 'not': 'two' });
 
     writeDraft('first-wire', 'edited');
-    expect(readDrafts()).toEqual({ 'first-wire': 'edited', 'not-from-nand': 'two' });
+    expect(readDrafts()).toEqual({ 'first-wire': 'edited', 'not': 'two' });
   });
 
   it('clears one level without disturbing the rest', () => {
     installStorage();
     writeDraft('first-wire', 'one');
-    writeDraft('not-from-nand', 'two');
+    writeDraft('not', 'two');
     clearDraft('first-wire');
-    expect(readDrafts()).toEqual({ 'not-from-nand': 'two' });
+    expect(readDrafts()).toEqual({ 'not': 'two' });
   });
 
   it('clearing a level that was never drafted is harmless', () => {
@@ -102,11 +102,11 @@ describe('progress', () => {
   it('records a gate count per level, latest pass winning', () => {
     installStorage();
     writeProgress('first-wire', { gates: 1 });
-    writeProgress('and-from-nand', { gates: 3 });
-    expect(readProgress()).toEqual({ 'first-wire': { gates: 1 }, 'and-from-nand': { gates: 3 } });
+    writeProgress('and', { gates: 3 });
+    expect(readProgress()).toEqual({ 'first-wire': { gates: 1 }, 'and': { gates: 3 } });
 
-    writeProgress('and-from-nand', { gates: 2 });
-    expect(readProgress()['and-from-nand']).toEqual({ gates: 2 });
+    writeProgress('and', { gates: 2 });
+    expect(readProgress()['and']).toEqual({ gates: 2 });
   });
 
   it('is a separate record from drafts', () => {
@@ -127,7 +127,7 @@ describe('progress', () => {
   it('yields the solved set the map reads', () => {
     installStorage();
     writeProgress('first-wire', { gates: 1 });
-    writeProgress('not-from-nand', { gates: 1 });
-    expect(new Set(Object.keys(readProgress()))).toEqual(new Set(['first-wire', 'not-from-nand']));
+    writeProgress('not', { gates: 1 });
+    expect(new Set(Object.keys(readProgress()))).toEqual(new Set(['first-wire', 'not']));
   });
 });

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -94,8 +94,8 @@ export default circuit('Nand1', {
   },
 
   {
-    id: 'not-from-nand',
-    title: 'NOT from NAND',
+    id: 'not',
+    title: 'NOT',
     brief:
       'You have seen what NAND does: it outputs 0 only when both its inputs are 1. It is the only gate you get, so every other gate gets built from it. Start with the simplest — turn a 1 into a 0.',
     target: 'Not1',
@@ -134,19 +134,20 @@ export default circuit('Not1', {
   },
 
   {
-    id: 'and-from-nand',
-    title: 'AND from NAND',
+    id: 'and',
+    title: 'AND',
     brief:
       'A NAND is an AND gate with its answer flipped. You spent the last level learning to flip an answer. Light the lamp only when both switches are on.',
     target: 'And2',
     inputs: ['a', 'b'],
     outputs: ['result'],
-    allowed: ['Nand'],
+    allowed: ['Nand', 'Not'],
     stub: `// The NAND already sees both switches. Its answer
 // is the one you want, upside down.
 //
-// You need a second gate, so add one to the list:
-//   n2: Nand,
+// You built NOT last level, so it is yours to use now.
+// Add it to the list:
+//   n: Not,
 //
 // Anything you add to \`nodes\` has to be named in the
 // \`connect\` line below before you can wire it.
@@ -179,14 +180,14 @@ export default circuit('And2', {
   },
 
   {
-    id: 'or-from-nand',
-    title: 'OR from NAND',
+    id: 'or',
+    title: 'OR',
     brief:
       'Light the lamp when either switch is on. There is no way to get there by flipping a NAND, so come at it from the other end: work out when the lamp should stay off.',
     target: 'Or1',
     inputs: ['a', 'b'],
     outputs: ['result'],
-    allowed: ['Nand'],
+    allowed: ['Nand', 'Not', 'And'],
     stub: `// The lamp is off in exactly one case: both switches down.
 //
 // A NAND says "not both". Stop feeding it the switches
@@ -221,18 +222,19 @@ export default circuit('Or1', {
   },
 
   {
-    id: 'nor-from-nand',
-    title: 'NOR from NAND',
+    id: 'nor',
+    title: 'NOR',
     brief:
       'NOR is OR with the answer flipped: the lamp is on only when both switches are off. You built OR a minute ago, so most of this is already done.',
     target: 'Nor1',
     inputs: ['a', 'b'],
     outputs: ['result'],
-    allowed: ['Nand'],
-    stub: `// Nothing new here. Build the OR you already
-// worked result, then flip what comes out of it.
+    allowed: ['Nand', 'Not', 'And', 'Or'],
+    stub: `// Nothing new here. Take the OR you built and flip
+// what comes out of it.
 //
-// Four NANDs is the target.
+// You have both of those now, so this is two gates.
+// Four NANDs if you would rather do it the long way.
 
 export default circuit('Nor1', {
   nodes: {
@@ -259,14 +261,14 @@ export default circuit('Nor1', {
   },
 
   {
-    id: 'xor-from-nand',
-    title: 'XOR from NAND',
+    id: 'xor',
+    title: 'XOR',
     brief:
       'Light the lamp when the two switches disagree. This is the one that takes a minute — and it is the gate an adder is built from, so it pays off twice.',
     target: 'Xor1',
     inputs: ['a', 'b'],
     outputs: ['result'],
-    allowed: ['Nand'],
+    allowed: ['Nand', 'Not', 'And', 'Or', 'Nor'],
     stub: `// Work out how many NANDs this needs. Fewer is better.
 //
 // A signal can drive more than one port:
@@ -297,19 +299,19 @@ export default circuit('Xor1', {
   },
 
   {
-    id: 'xnor-from-nand',
-    title: 'XNOR from NAND',
+    id: 'xnor',
+    title: 'XNOR',
     brief:
       'The last gate in the set, and the opposite of the one you just built: light the lamp when the two switches agree. You already know the move.',
     target: 'Xnor1',
     inputs: ['a', 'b'],
     outputs: ['result'],
-    allowed: ['Nand'],
+    allowed: ['Nand', 'Not', 'And', 'Or', 'Nor', 'Xor'],
     stub: `// Your XOR, with the answer flipped.
 //
-// Five NANDs. Nothing here is new — this level is
-// the one where you find out how much of the last
-// six you actually kept.
+// Two gates, now that XOR is yours. The long way
+// round is five NANDs, if you want to prove you
+// still can.
 
 export default circuit('Xnor1', {
   nodes: {
@@ -343,7 +345,7 @@ export default circuit('Xnor1', {
     target: 'Xor2',
     inputs: ['a', 'b'],
     outputs: ['out'],
-    allowed: ['Nand'],
+    allowed: ['Nand', 'Not', 'And', 'Or', 'Nor', 'Xor', 'Xnor'],
     stub: `// Ports, not switches. Still NAND only.
 //
 // \`inputs\` and \`outputs\` are the circuit's edges — what it looks like from

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -21,12 +21,12 @@ import { LEVELS_BY_ID, levelIndex } from './levels';
 /** Bottom to top. Each inner array is one row of siblings. */
 export const MAP_ROWS: string[][] = [
   ['first-wire'],
-  ['not-from-nand'],
-  ['and-from-nand'],
-  ['or-from-nand'],
-  ['nor-from-nand'],
-  ['xor-from-nand'],
-  ['xnor-from-nand'],
+  ['not'],
+  ['and'],
+  ['or'],
+  ['nor'],
+  ['xor'],
+  ['xnor'],
   ['making-a-component'],
   ['half-adder'],
   ['full-adder'],

--- a/apps/game/src/game/solutions/and.ts
+++ b/apps/game/src/game/solutions/and.ts
@@ -1,4 +1,4 @@
-/** Reference solution for `and-from-nand`. Proven by `__tests__/levels.test.ts`. */
+/** Reference solution for `and`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -28,25 +28,25 @@
  * test-only means finding something else for an unopened level to inspect to.
  */
 
-import andFromNand from './and-from-nand.ts?raw';
+import andGate from './and.ts?raw';
 import firstWire from './first-wire.ts?raw';
 import fullAdder from './full-adder.ts?raw';
 import halfAdder from './half-adder.ts?raw';
 import makingAComponent from './making-a-component.ts?raw';
-import norFromNand from './nor-from-nand.ts?raw';
-import notFromNand from './not-from-nand.ts?raw';
-import orFromNand from './or-from-nand.ts?raw';
-import xnorFromNand from './xnor-from-nand.ts?raw';
-import xorFromNand from './xor-from-nand.ts?raw';
+import norGate from './nor.ts?raw';
+import notGate from './not.ts?raw';
+import orGate from './or.ts?raw';
+import xnorGate from './xnor.ts?raw';
+import xorGate from './xor.ts?raw';
 
 export const SOLUTIONS: Record<string, string> = {
   'first-wire': firstWire,
-  'not-from-nand': notFromNand,
-  'and-from-nand': andFromNand,
-  'or-from-nand': orFromNand,
-  'nor-from-nand': norFromNand,
-  'xor-from-nand': xorFromNand,
-  'xnor-from-nand': xnorFromNand,
+  not: notGate,
+  and: andGate,
+  or: orGate,
+  nor: norGate,
+  xor: xorGate,
+  xnor: xnorGate,
   'making-a-component': makingAComponent,
   'half-adder': halfAdder,
   'full-adder': fullAdder,

--- a/apps/game/src/game/solutions/nor.ts
+++ b/apps/game/src/game/solutions/nor.ts
@@ -1,16 +1,16 @@
-/** Reference solution for `xor-from-nand`. Proven by `__tests__/levels.test.ts`. */
+/** Reference solution for `nor`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
-export const Xor1 = circuit('Xor1', {
+export const Nor1 = circuit('Nor1', {
   nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, result: Led },
   connect: ({ nodes: { a, b, n1, n2, n3, n4, result } }) => [
-    a.out.to(n1.a, n2.a),
-    b.out.to(n1.b, n3.b),
-    n1.out.to(n2.b, n3.a),
-    n2.out.to(n4.a),
-    n3.out.to(n4.b),
+    a.out.to(n1.a, n1.b),
+    b.out.to(n2.a, n2.b),
+    n1.out.to(n3.a),
+    n2.out.to(n3.b),
+    n3.out.to(n4.a, n4.b),
     n4.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/not.ts
+++ b/apps/game/src/game/solutions/not.ts
@@ -1,4 +1,4 @@
-/** Reference solution for `not-from-nand`. Proven by `__tests__/levels.test.ts`. */
+/** Reference solution for `not`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';

--- a/apps/game/src/game/solutions/or.ts
+++ b/apps/game/src/game/solutions/or.ts
@@ -1,4 +1,4 @@
-/** Reference solution for `or-from-nand`. Proven by `__tests__/levels.test.ts`. */
+/** Reference solution for `or`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';

--- a/apps/game/src/game/solutions/xnor.ts
+++ b/apps/game/src/game/solutions/xnor.ts
@@ -1,4 +1,4 @@
-/** Reference solution for `xnor-from-nand`. Proven by `__tests__/levels.test.ts`. */
+/** Reference solution for `xnor`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';

--- a/apps/game/src/game/solutions/xor.ts
+++ b/apps/game/src/game/solutions/xor.ts
@@ -1,16 +1,16 @@
-/** Reference solution for `nor-from-nand`. Proven by `__tests__/levels.test.ts`. */
+/** Reference solution for `xor`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
 import { Led, Nand, Switch } from '@simten/core/std';
 
-export const Nor1 = circuit('Nor1', {
+export const Xor1 = circuit('Xor1', {
   nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, result: Led },
   connect: ({ nodes: { a, b, n1, n2, n3, n4, result } }) => [
-    a.out.to(n1.a, n1.b),
-    b.out.to(n2.a, n2.b),
-    n1.out.to(n3.a),
-    n2.out.to(n3.b),
-    n3.out.to(n4.a, n4.b),
+    a.out.to(n1.a, n2.a),
+    b.out.to(n1.b, n3.b),
+    n1.out.to(n2.b, n3.a),
+    n2.out.to(n4.a),
+    n3.out.to(n4.b),
     n4.out.to(result.in),
   ],
 });


### PR DESCRIPTION
Split out of #311, which merged before these two commits were pushed.

### Each level permits the gates you already built

`allowed` widens per level: AND may use NOT, OR may use NOT and AND, and so on, ending where `ARITHMETIC_GATES` already begins. Same stand-in level 9 already makes, applied earlier — so from here a netlist can contain a stdlib primitive rather than bottoming out at NAND.

Par is unchanged and still correct, since a `Not` costs one gate exactly as a `Nand` does, and the NAND-only reference solutions still score at or under it. The completion card now announces the right unlock at every level rather than one lump after level 8 — that fell out of the existing diff logic with no code change.

NOR and XNOR become two-gate levels as a result, so their stubs say so and keep the NAND count as an optional flex.

### Levels renamed to their gates

`AND from NAND` was inaccurate once NOT was permitted, and it named the answer. Now:

`/not` `/and` `/or` `/nor` `/xor` `/xnor`

with solution files renamed to match. Old URLs 404. Nothing links to them and the game is not indexed, so this was the moment — but it is the last free one.

Also drops the number from map nodes and centres the title, and fixes a comment the earlier `out` → `result` rename mangled ("worked out" had become "worked result"), which is live in production.

122 tests, tsc clean, lint at 590. Verified against a production build: `/and`, `/or`, `/not` serve, `/xor-from-nand` 404s.