### PR TITLE
chore(sandbox): explain the origin to direct visitors and keep it out of search

### DIFF
--- a/apps/sandbox/index.html
+++ b/apps/sandbox/index.html
@@ -1,7 +1,42 @@
 <!DOCTYPE html>
-<html>
-<head><meta charset="utf-8" /></head>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Simten sandbox</title>
+<meta name="robots" content="noindex, nofollow" />
+</head>
 <body>
+<!--
+  Visible only when someone opens this origin directly. In its real job this
+  page is an invisible iframe and the body is never seen.
+
+  Deliberately unstyled: the CSP is `default-src 'none'` with no `style-src`,
+  so stylesheets and inline styles are blocked, and loosening the policy of the
+  one origin that executes untrusted code to make a paragraph prettier is a bad
+  trade. Plain text renders fine.
+
+  Deliberately static. The moment this echoes anything from the URL — a query
+  parameter, a referrer — it stops being inert and becomes an XSS surface.
+-->
+<main>
+  <h1>Simten sandbox</h1>
+  <p>
+    This origin runs circuit code in isolation for
+    <a href="https://simten.dev">simten.dev</a>,
+    <a href="https://play.simten.dev">play.simten.dev</a>, and anything embedding
+    Simten circuits. It exists as a separate origin so that the code it runs
+    cannot reach the pages that host it.
+  </p>
+  <p>
+    On its own it does nothing. It executes only what a parent page sends it
+    over <code>postMessage</code>, so opening this address directly runs no
+    code at all.
+  </p>
+  <p>
+    Source: <a href="https://github.com/simtenHQ/simten">github.com/simtenHQ/simten</a>.
+    Security policy: <a href="https://github.com/simtenHQ/simten/blob/main/SECURITY.md">SECURITY.md</a>.
+  </p>
+</main>
 <script type="module" src="./src/main.ts"></script>
 </body>
 </html>

--- a/apps/sandbox/public/_headers
+++ b/apps/sandbox/public/_headers
@@ -1,2 +1,3 @@
 /*
   Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-eval' blob: https://esm.sh; connect-src 'self' https://esm.sh; worker-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none';
+  X-Robots-Tag: noindex, nofollow

--- a/apps/sandbox/public/robots.txt
+++ b/apps/sandbox/public/robots.txt
@@ -1,0 +1,4 @@
+# The sandbox is an execution origin, not content. Nothing here should be
+# indexed; every path returns the same shell.
+User-agent: *
+Disallow: /


### PR DESCRIPTION
`sandbox.simten.dev` served an empty white page, and nothing stopped it being indexed. A blank page on the one origin that executes untrusted code is worse than an explanation — anyone who spots the domain in a network tab has no way to tell what it is.

- **A plain-text explainer**: what the origin is for, that it only runs what a parent sends over `postMessage`, and links to the repo and `SECURITY.md`.
- **`X-Robots-Tag: noindex, nofollow`** plus a `robots.txt` disallowing everything. Every path returns the same shell, so without this an execution origin can end up in search results.

Two deliberate constraints, both noted in the file:

**Unstyled.** The CSP is `default-src 'none'` with no `style-src`, so stylesheets and inline styles are blocked. Loosening the policy of the origin that runs untrusted code to make a paragraph prettier is a bad trade.

**Static.** If it ever echoes anything from the URL it stops being inert and becomes an XSS surface.

This changes no execution path: code only arrives by `postMessage`, and the sandbox pins the parent origin on the first message and rejects other origins after. A direct visit runs nothing. No `frame-ancestors` was added — third-party `@simten/embed` consumers need to iframe this, as `vite.config.ts` documents.

Built and verified: the module script survives the build, the text renders on a direct visit, `robots.txt` ships.

Worth confirming after deploy that a level's canvas still draws, since the sandbox's real job is being an invisible iframe and I could only test it standalone here.