### PR TITLE
fix(sandbox): stop caching the shell so a deploy cannot strand a stale one

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,11 +17,14 @@ We aim to acknowledge new reports within a few days. Once a fix is ready, we pub
 Reports are in scope if they affect any of:
 
 - Published packages: `@simten/core`, `@simten/ui`, `@simten/embed`, `@simten/mcp`
-- The hosted app at [simten.dev](https://simten.dev)
-- The `apps/compiler` and `apps/verifier` Cloudflare Container services
+- The hosted apps at [simten.dev](https://simten.dev) and [play.simten.dev](https://play.simten.dev)
+- [sandbox.simten.dev](https://sandbox.simten.dev), the isolated origin that executes circuit code
+- The `apps/compiler`, `apps/verifier` and `apps/synth` Cloudflare Container services
 - Anything in this repository's CI/CD or release pipeline
 
-Examples of issues we care about: sandbox escape from user-supplied circuit code, XSS in the embed or editor, RCE in the compiler/verifier services, supply-chain risks in the release flow.
+Examples of issues we care about: sandbox escape from user-supplied circuit code, XSS in the embed or editor, RCE in the compiler/verifier/synth services, supply-chain risks in the release flow.
+
+The sandbox is the boundary worth attacking. It runs untrusted circuit code on its own origin under a restrictive CSP, and takes work only over `postMessage` from the page that embeds it. Anything that reaches out of that origin, executes on `simten.dev` or `play.simten.dev`, or persuades the sandbox to accept instructions from somewhere other than its embedding page, is in scope.
 
 ## Out of scope
 

--- a/apps/sandbox/public/_headers
+++ b/apps/sandbox/public/_headers
@@ -1,3 +1,25 @@
+# Only one block sets `Cache-Control` for any given path. Cloudflare's rules for
+# combining multiple matching blocks are easy to get wrong, and two blocks both
+# claiming a path's cache policy is the way to end up serving
+# `no-store, public, max-age=31536000` and trusting neither.
+
 /*
   Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-eval' blob: https://esm.sh; connect-src 'self' https://esm.sh; worker-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none';
   X-Robots-Tag: noindex, nofollow
+
+# The shell names its assets by content hash, so those names change on every
+# deploy. A cached shell points at files that no longer exist, which breaks the
+# sandbox for whoever is holding one — a browser, or Cloudflare's edge, which
+# was serving this as `public` with a cf-cache-status of HIT. The document is
+# tiny and only ever loaded inside an iframe, so caching it gains nothing and
+# costs a working sandbox after each deploy.
+/
+  Cache-Control: no-store
+
+/index.html
+  Cache-Control: no-store
+
+# Safe to cache forever precisely because the names are content-hashed: change
+# a file and it becomes a different URL, so nothing can go stale.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
The sandbox 403s after a redeploy — in a normal browser profile, never in incognito, and clearing site data fixes it until the next deploy.

The shell was being served `cache-control: public, max-age=0, must-revalidate` with `cf-cache-status: HIT`, so both browsers and Cloudflare's edge could hold it. It names its assets by content hash, and those names change on every deploy, so a held shell points at files that no longer exist. That matches the symptoms exactly: deploy-correlated, per-profile, cleared by wiping site data.

- **`/` and `/index.html` → `no-store`.** The document is tiny and only ever loaded inside an iframe, so caching gains nothing and costs a working sandbox after each deploy.
- **`/assets/*` → `immutable`, a year.** Safe precisely because the names are content-hashed: a changed file is a different URL.

Only one block sets `Cache-Control` for any path. Cloudflare's rules for combining matching blocks are easy to get wrong, and two blocks both claiming a path is how you end up serving `no-store, public, max-age=31536000`.

This may not be the whole story — if a WAF rule or Bot Fight Mode is involved, that lives in the dashboard and this won't touch it. But the stale-shell failure mode is real regardless, and it would hit players after every deploy, not just one laptop.