### PR TITLE
Stop a blocked sandbox from silently freezing the canvas, and fix stale level par

### DIFF
--- a/apps/game/src/game/__tests__/levels.test.ts
+++ b/apps/game/src/game/__tests__/levels.test.ts
@@ -72,11 +72,19 @@ describe.each(LEVELS.map((l) => [l.id, l] as const))('%s', (id, level) => {
     expect(result.status === 'pass' ? 'pass' : JSON.stringify(result)).toBe('pass');
   });
 
-  it('scores at or under par, counting only permitted primitives', async () => {
+  /**
+   * Equality, not `<=`. A par looser than the reference solution passes a `<=`
+   * check while quietly promising the player a target they beat by default,
+   * which is how four levels ended up carrying pars from before gates unlocked
+   * progressively — `xnor` advertised 5 when XOR plus a NOT does it in 2. If
+   * this fails, either the reference solution got cheaper and par should follow,
+   * or par moved and the reference solution has not caught up.
+   */
+  it('scores exactly par, counting only permitted primitives', async () => {
     const result = await grade(localRuntime(), level, SOLUTIONS[id]);
     if (result.status !== 'pass') throw new Error('reference solution did not pass');
     expect(result.gates).toBeGreaterThan(0);
-    if (level.par !== undefined) expect(result.gates).toBeLessThanOrEqual(level.par);
+    if (level.par !== undefined) expect(result.gates).toBe(level.par);
   });
 
   it.each([0, 1] as const)('is not vacuous — a constant %i answer fails', async (value) => {

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -253,7 +253,7 @@ export default circuit('Nor1', {
       { inputs: { a: 1, b: 0 }, expect: { result: 0 } },
       { inputs: { a: 1, b: 1 }, expect: { result: 0 } },
     ],
-    par: 4,
+    par: 2,
     outro: {
       headline: 'Four gates deep',
       body: 'Every gate you finish makes the next one cheaper, because you stop solving it from scratch and start bolting a NOT onto something that already works. XOR does not give you that. It needs a shape you have not built yet.',
@@ -291,10 +291,10 @@ export default circuit('Xor1', {
       { inputs: { a: 1, b: 0 }, expect: { result: 1 } },
       { inputs: { a: 1, b: 1 }, expect: { result: 0 } },
     ],
-    par: 4,
+    par: 3,
     outro: {
-      headline: 'Four NANDs, one XOR',
-      body: "That's the gate an adder is built from, so you'll be reaching for it again. One left in the set, and it is XOR with the answer flipped.",
+      headline: 'Three gates, one XOR',
+      body: "Three if you used what you have earned, four if you stuck to NAND alone. Either way it's the gate an adder is built from, so you'll be reaching for it again. One left in the set, and it is XOR with the answer flipped.",
     },
   },
 
@@ -330,10 +330,10 @@ export default circuit('Xnor1', {
       { inputs: { a: 1, b: 0 }, expect: { result: 0 } },
       { inputs: { a: 1, b: 1 }, expect: { result: 1 } },
     ],
-    par: 5,
+    par: 2,
     outro: {
       headline: 'Every gate, from one gate',
-      body: 'NOT, AND, OR, NOR, XOR, XNOR. Six gates out of the only one you were given. What you cannot do yet is use any of them again: each one is sealed inside the level that built it. That is what the last level fixes.',
+      body: 'NOT, AND, OR, NOR, XOR, XNOR. Six gates out of the only one you were given, and each one stayed with you as you went. What none of them can do yet is leave: a circuit made of switches and a lamp is something you look at, not something another circuit can use. That is what the next level fixes.',
     },
   },
 
@@ -341,12 +341,12 @@ export default circuit('Xnor1', {
     id: 'making-a-component',
     title: 'Making a Component',
     brief:
-      'The XOR from two levels back, but this time give the circuit `inputs` and `outputs` instead of switches and a lamp. Watch what happens to the diagram: it becomes one box. That is the trade — you can no longer see inside, and in exchange anything can now use it.',
+      'The XOR from two levels back, but this time give the circuit `inputs` and `outputs` instead of switches and a lamp. You have XOR now, so the inside is a single node: the lesson here is the edges, not the wiring. Watch what happens to the diagram. It becomes one box, and that is the trade: you can no longer see inside, and in exchange anything can now use it.',
     target: 'Xor2',
     inputs: ['a', 'b'],
     outputs: ['out'],
     allowed: ['Nand', 'Not', 'And', 'Or', 'Nor', 'Xor', 'Xnor'],
-    stub: `// Ports, not switches. Still NAND only.
+    stub: `// Ports, not switches. Every gate you have built is available.
 //
 // \`inputs\` and \`outputs\` are the circuit's edges — what it looks like from
 // the outside. Wire them with \`inputs.a.to(...)\` and \`....to(outputs.out)\`.
@@ -372,7 +372,7 @@ export default circuit('Xor2', {
       { inputs: { a: 1, b: 0 }, expect: { out: 1 } },
       { inputs: { a: 1, b: 1 }, expect: { out: 0 } },
     ],
-    par: 4,
+    par: 1,
     outro: {
       headline: "It's a component now",
       body: 'Ports instead of switches, and the diagram collapsed into one box. That is what lets circuits build on each other, which is where this goes next.',

--- a/apps/game/src/game/solutions/making-a-component.ts
+++ b/apps/game/src/game/solutions/making-a-component.ts
@@ -1,18 +1,15 @@
 /** Reference solution for `making-a-component`. Proven by `__tests__/levels.test.ts`. */
 
 import { bit, circuit } from '@simten/core/circuit';
-import { Nand } from '@simten/core/std';
+import { Xor } from '@simten/core/std';
 
 export const Xor2 = circuit('Xor2', {
   inputs: { a: bit, b: bit },
   outputs: { out: bit },
-  nodes: { n1: Nand, n2: Nand, n3: Nand, n4: Nand },
-  connect: ({ inputs, outputs, nodes: { n1, n2, n3, n4 } }) => [
-    inputs.a.to(n1.a, n2.a),
-    inputs.b.to(n1.b, n3.b),
-    n1.out.to(n2.b, n3.a),
-    n2.out.to(n4.a),
-    n3.out.to(n4.b),
-    n4.out.to(outputs.out),
+  nodes: { xor1: Xor },
+  connect: ({ inputs, outputs, nodes: { xor1 } }) => [
+    inputs.a.to(xor1.a),
+    inputs.b.to(xor1.b),
+    xor1.out.to(outputs.out),
   ],
 });

--- a/apps/game/src/game/solutions/nor.ts
+++ b/apps/game/src/game/solutions/nor.ts
@@ -1,16 +1,14 @@
 /** Reference solution for `nor`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
-import { Led, Nand, Switch } from '@simten/core/std';
+import { Led, Not, Or, Switch } from '@simten/core/std';
 
 export const Nor1 = circuit('Nor1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, result: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, n4, result } }) => [
-    a.out.to(n1.a, n1.b),
-    b.out.to(n2.a, n2.b),
-    n1.out.to(n3.a),
-    n2.out.to(n3.b),
-    n3.out.to(n4.a, n4.b),
-    n4.out.to(result.in),
+  nodes: { a: Switch, b: Switch, or1: Or, not1: Not, result: Led },
+  connect: ({ nodes: { a, b, or1, not1, result } }) => [
+    a.out.to(or1.a),
+    b.out.to(or1.b),
+    or1.out.to(not1.in),
+    not1.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/xnor.ts
+++ b/apps/game/src/game/solutions/xnor.ts
@@ -1,17 +1,14 @@
 /** Reference solution for `xnor`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
-import { Led, Nand, Switch } from '@simten/core/std';
+import { Led, Not, Switch, Xor } from '@simten/core/std';
 
 export const Xnor1 = circuit('Xnor1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, n5: Nand, result: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, n4, n5, result } }) => [
-    a.out.to(n1.a, n2.a),
-    b.out.to(n1.b, n3.b),
-    n1.out.to(n2.b, n3.a),
-    n2.out.to(n4.a),
-    n3.out.to(n4.b),
-    n4.out.to(n5.a, n5.b),
-    n5.out.to(result.in),
+  nodes: { a: Switch, b: Switch, xor1: Xor, not1: Not, result: Led },
+  connect: ({ nodes: { a, b, xor1, not1, result } }) => [
+    a.out.to(xor1.a),
+    b.out.to(xor1.b),
+    xor1.out.to(not1.in),
+    not1.out.to(result.in),
   ],
 });

--- a/apps/game/src/game/solutions/xor.ts
+++ b/apps/game/src/game/solutions/xor.ts
@@ -1,16 +1,15 @@
 /** Reference solution for `xor`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
-import { Led, Nand, Switch } from '@simten/core/std';
+import { And, Led, Nand, Or, Switch } from '@simten/core/std';
 
 export const Xor1 = circuit('Xor1', {
-  nodes: { a: Switch, b: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, result: Led },
-  connect: ({ nodes: { a, b, n1, n2, n3, n4, result } }) => [
-    a.out.to(n1.a, n2.a),
-    b.out.to(n1.b, n3.b),
-    n1.out.to(n2.b, n3.a),
-    n2.out.to(n4.a),
-    n3.out.to(n4.b),
-    n4.out.to(result.in),
+  nodes: { a: Switch, b: Switch, or1: Or, nand1: Nand, and1: And, result: Led },
+  connect: ({ nodes: { a, b, or1, nand1, and1, result } }) => [
+    a.out.to(or1.a, nand1.a),
+    b.out.to(or1.b, nand1.b),
+    or1.out.to(and1.a),
+    nand1.out.to(and1.b),
+    and1.out.to(result.in),
   ],
 });

--- a/apps/web/src/features/splash/ClaudeDemoSection.tsx
+++ b/apps/web/src/features/splash/ClaudeDemoSection.tsx
@@ -154,7 +154,8 @@ const PROMPT_OPTIONS: PromptOption[] = [
   {
     label: 'Build a full adder',
     circuit: GateFullAdder,
-    displayCode: `const FullAdder = circuit('FullAdder', {
+    displayCode: `// Adds two bits plus a carry in, so adders chain.
+const FullAdder = circuit('FullAdder', {
   inputs: { a: bit, b: bit, cin: bit },
   outputs: { sum: bit, cout: bit },
   nodes: {
@@ -233,7 +234,8 @@ const PROMPT_OPTIONS: PromptOption[] = [
   {
     label: 'Make a 2-bit binary counter',
     circuit: Counter2Bit,
-    displayCode: `const Counter2Bit = circuit('Counter2Bit', {
+    displayCode: `// Counts 0 to 3, one step per clock tick.
+const Counter2Bit = circuit('Counter2Bit', {
   outputs: { bit0: bit, bit1: bit },
   nodes: {
     dff0: DFlipFlop(),
@@ -301,7 +303,8 @@ const PROMPT_OPTIONS: PromptOption[] = [
   {
     label: 'Make a toggle flip-flop',
     circuit: Toggle,
-    displayCode: `const Toggle = circuit('Toggle', {
+    displayCode: `// Flips between 0 and 1 every clock tick.
+const Toggle = circuit('Toggle', {
   outputs: { q: bit, q_bar: bit },
   nodes: { dff: DFlipFlop(), inv: Not },
   connect: ({
@@ -362,7 +365,8 @@ const PROMPT_OPTIONS: PromptOption[] = [
   {
     label: 'Build a 2-to-1 multiplexer',
     circuit: Mux2to1,
-    displayCode: `const Mux2to1 = circuit('Mux2to1', {
+    displayCode: `// Passes a or b through, whichever sel picks.
+const Mux2to1 = circuit('Mux2to1', {
   inputs: { a: bit, b: bit, sel: bit },
   outputs: { out: bit },
   nodes: {
@@ -790,7 +794,8 @@ interface HeroDemo {
   displayCode: string;
 }
 
-const HALF_ADDER_DISPLAY = `const HalfAdder = circuit('HalfAdder', {
+const HALF_ADDER_DISPLAY = `// Adds two bits, giving sum and carry.
+const HalfAdder = circuit('HalfAdder', {
   inputs: { a: bit, b: bit },
   outputs: { sum: bit, carry: bit },
   nodes: { xor1: Xor, and1: And },

--- a/apps/web/src/features/splash/Hero.tsx
+++ b/apps/web/src/features/splash/Hero.tsx
@@ -89,7 +89,8 @@ export const FigletDemo = circuit('FigletDemo', {
 // below, exported so ClaudeDemoSection can render it without duplicating the
 // figlet ROM-generation logic. Kept as a free const rather than read out of
 // DEMOS at runtime to avoid a circular-feeling self-reference.
-export const FIGLET_DEMO_CODE = `import figlet from 'figlet';
+export const FIGLET_DEMO_CODE = `// Bakes an npm package's output into a ROM.
+import figlet from 'figlet';
 import smallFont from 'figlet/fonts/Small.js';
 figlet.parseFont('Small', smallFont);
 

--- a/packages/embed/src/hooks/useCircuitSimulator.ts
+++ b/packages/embed/src/hooks/useCircuitSimulator.ts
@@ -27,7 +27,7 @@ import type {
   SimulatorEngine,
 } from '@simten/core/simulator';
 import { HexDisplay, Input, Led, Output, Switch } from '@simten/core/std';
-import { type EvalSource, useSandboxContext } from '@simten/ui/sandbox';
+import { type EvalSource, SANDBOX_UNAVAILABLE_ERROR, useSandboxContext } from '@simten/ui/sandbox';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const TOP_LEVEL_NODE = '__top__';
@@ -730,7 +730,10 @@ export function useCircuitSimulator(
     inputs,
     cycleCount: cycle,
     ready,
-    error: null,
+    // A sandbox that never loaded is the one failure the simulator cannot report
+    // through a result, because no call ever completes. Surfacing it here means
+    // the viewer shows a message instead of an empty canvas.
+    error: sandbox.status === 'unavailable' ? SANDBOX_UNAVAILABLE_ERROR : null,
     isSequential,
     circuit: harnessedCircuit,
     portValues: portValues.size > 0 ? portValues : null,

--- a/packages/ui/src/monaco/SimtenCodeEditor.tsx
+++ b/packages/ui/src/monaco/SimtenCodeEditor.tsx
@@ -58,7 +58,12 @@ export interface SimtenCodeEditorHandle {
 
 export interface SimtenCodeEditorProps
   extends Omit<EditorProps, 'beforeMount' | 'language' | 'defaultLanguage'> {
-  /** Tune or disable Simten's IntelliSense. `false` leaves Monaco untouched. */
+  /**
+   * Tune or disable Simten's IntelliSense. `false` leaves Monaco untouched.
+   *
+   * Re-applied whenever this value changes identity, so give it a stable one
+   * (`useMemo`) unless you want Monaco reconfigured on every render.
+   */
   intellisense?: IntellisenseOptions | false;
   /** Tune or disable network type acquisition for third-party imports. */
   typeAcquisition?: TypeAcquisitionOptions;
@@ -148,6 +153,16 @@ export function SimtenCodeEditor({
     },
     [intellisense, beforeMount],
   );
+
+  // `beforeMount` fires once, so a later change to `intellisense` would never
+  // reach Monaco: the game hands the editor a different set of globals per
+  // level, and navigating between levels left the previous level's set in
+  // place until a full page load. Re-applying is cheap and `addExtraLib`
+  // overwrites by path, so this converges rather than accumulating.
+  useEffect(() => {
+    if (!monaco || intellisense === false) return;
+    setupSimtenIntellisense(monaco, intellisense ?? {});
+  }, [monaco, intellisense]);
 
   const handleMount = useCallback<OnMount>(
     (e, m) => {

--- a/packages/ui/src/sandbox/SandboxProvider.tsx
+++ b/packages/ui/src/sandbox/SandboxProvider.tsx
@@ -30,6 +30,7 @@ const NULL_HANDLE: SandboxHandle = {
   pruneSnapshots: async () => ({ type: 'error', error: 'Sandbox not ready' }),
   dispose: async () => {},
   isReady: () => false,
+  status: 'loading',
 };
 
 export function useSandboxContext(): SandboxHandle {

--- a/packages/ui/src/sandbox/index.ts
+++ b/packages/ui/src/sandbox/index.ts
@@ -6,9 +6,10 @@ export type {
   ResetResult,
   SandboxError,
   SandboxHandle,
+  SandboxStatus,
   SetNodeResult,
   SimSlot,
   SimulateResult,
   TickResult,
 } from './useSandbox.js';
-export { useSandbox } from './useSandbox.js';
+export { SANDBOX_UNAVAILABLE_ERROR, useSandbox } from './useSandbox.js';

--- a/packages/ui/src/sandbox/useSandbox.ts
+++ b/packages/ui/src/sandbox/useSandbox.ts
@@ -28,7 +28,7 @@
 
 import type { Circuit } from '@simten/core';
 import type { RLEValue } from '@simten/core/api';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 // ============================================================================
 // Config
@@ -41,6 +41,18 @@ import { useCallback, useEffect, useRef } from 'react';
 const env = typeof import.meta !== 'undefined' ? (import.meta as any).env : undefined;
 const SANDBOX_ORIGIN: string =
   env?.VITE_SANDBOX_ORIGIN || (env?.PROD ? 'https://sandbox.simten.dev' : 'http://localhost:3002');
+
+// How long to wait for the iframe's `ready` handshake before giving up on it.
+// Nothing else catches a sandbox that never comes up: `iframe.onerror` does not
+// fire for HTTP error statuses (a 403 still loads a document — the error page),
+// so a blocked, blocked-by-extension, or unreachable sandbox used to leave every
+// request queued on `readyQueue` forever, with no rejection and no UI change.
+// Generous enough to cover a cold load on a slow connection.
+const READY_TIMEOUT_MS = 10000;
+
+/** Message given to callers, and shown by the UI, when the sandbox never loads. */
+export const SANDBOX_UNAVAILABLE_ERROR =
+  'Sandbox failed to load. It may be blocked by a browser extension, or unreachable.';
 
 // ============================================================================
 // Types
@@ -56,6 +68,9 @@ const SANDBOX_ORIGIN: string =
  * a node — the sim analog of memory-mapped I/O.
  */
 export type PeripheralState = Record<string, unknown>;
+
+/** Whether the sandbox iframe has completed its handshake, or given up. */
+export type SandboxStatus = 'loading' | 'ready' | 'unavailable';
 
 export interface CompileResult {
   circuits: Circuit[];
@@ -136,6 +151,9 @@ type PendingResolve = (result: SandboxResult) => void;
 interface SandboxState {
   iframe: HTMLIFrameElement | null;
   ready: boolean;
+  /** Set once the ready handshake has timed out. Requests fail fast instead of queueing. */
+  unavailable: boolean;
+  readyTimer: ReturnType<typeof setTimeout> | null;
   pending: Map<string, PendingResolve>;
   readyQueue: Array<() => void>;
   idCounter: number;
@@ -146,6 +164,7 @@ function createIframe(
   container: HTMLElement,
   handleMessage: (event: MessageEvent) => void,
   onCrash: () => void,
+  onReadyTimeout: () => void,
 ): HTMLIFrameElement {
   // Remove old iframe if any
   if (state.iframe) {
@@ -170,6 +189,10 @@ function createIframe(
   container.appendChild(iframe);
   state.iframe = iframe;
   state.ready = false;
+  state.unavailable = false;
+
+  if (state.readyTimer) clearTimeout(state.readyTimer);
+  state.readyTimer = setTimeout(onReadyTimeout, READY_TIMEOUT_MS);
 
   window.addEventListener('message', handleMessage);
 
@@ -285,21 +308,52 @@ export interface SandboxHandle {
   /** Free a slot's simulator + library when no longer needed (e.g. embed unmount). */
   dispose(slot: SimSlot): Promise<void>;
   isReady(): boolean;
+  /**
+   * Reactive load state, for UI that needs to tell the user the sandbox is gone.
+   * `unavailable` is terminal for this iframe: every call resolves to an error
+   * until something recreates it.
+   */
+  status: SandboxStatus;
 }
 
 export function useSandbox(): SandboxHandle {
   const stateRef = useRef<SandboxState>({
     iframe: null,
     ready: false,
+    unavailable: false,
+    readyTimer: null,
     pending: new Map(),
     readyQueue: [],
     idCounter: 0,
   });
 
+  // Mirrors state.ready/state.unavailable into React so consumers can render a
+  // message. The ref stays the source of truth for the message handlers, which
+  // run outside React's lifecycle.
+  const [status, setStatus] = useState<SandboxStatus>('loading');
+
   // Container div injected into document body (avoids React tree)
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const handleMessageRef = useRef<(event: MessageEvent) => void>(() => {});
+
+  // The iframe never sent `ready`. Fail everything waiting on it — queued sends
+  // are already registered in `pending`, so resolving that map covers both — and
+  // leave `unavailable` set so later calls fail immediately rather than piling
+  // up behind a handshake that is not coming.
+  const markUnavailable = useCallback(() => {
+    const state = stateRef.current;
+    state.readyTimer = null;
+    if (state.ready) return;
+
+    state.unavailable = true;
+    for (const [, resolve] of state.pending) {
+      resolve({ type: 'error', error: SANDBOX_UNAVAILABLE_ERROR });
+    }
+    state.pending.clear();
+    state.readyQueue = [];
+    setStatus('unavailable');
+  }, []);
 
   const recreateIframe = useCallback(() => {
     const state = stateRef.current;
@@ -312,10 +366,17 @@ export function useSandbox(): SandboxHandle {
     }
     state.pending.clear();
     state.readyQueue = [];
+    setStatus('loading');
 
     window.removeEventListener('message', handleMessageRef.current);
-    createIframe(state, container, handleMessageRef.current, recreateIframeRef.current);
-  }, []);
+    createIframe(
+      state,
+      container,
+      handleMessageRef.current,
+      recreateIframeRef.current,
+      markUnavailable,
+    );
+  }, [markUnavailable]);
 
   const handleMessage = useCallback((event: MessageEvent) => {
     if (event.origin !== SANDBOX_ORIGIN) return;
@@ -330,6 +391,12 @@ export function useSandbox(): SandboxHandle {
 
     if (data.type === 'ready') {
       state.ready = true;
+      state.unavailable = false;
+      if (state.readyTimer) {
+        clearTimeout(state.readyTimer);
+        state.readyTimer = null;
+      }
+      setStatus('ready');
       // Flush queued sends
       for (const fn of state.readyQueue) fn();
       state.readyQueue = [];
@@ -357,22 +424,33 @@ export function useSandbox(): SandboxHandle {
     containerRef.current = container;
 
     const state = stateRef.current;
-    createIframe(state, container, handleMessage, recreateIframe);
+    createIframe(state, container, handleMessage, recreateIframe, markUnavailable);
 
     return () => {
       window.removeEventListener('message', handleMessage);
+      if (state.readyTimer) {
+        clearTimeout(state.readyTimer);
+        state.readyTimer = null;
+      }
       container.remove();
       containerRef.current = null;
     };
-  }, [handleMessage]);
+  }, [handleMessage, recreateIframe, markUnavailable]);
 
-  // No timeout here — the sandbox's own 5s worker timeout always sends back an
-  // error response if user code hangs. recreateIframe() is only called by the
-  // iframe's onerror handler (catastrophic crash, failed load, OOM).
+  // No per-request timeout here — the sandbox's own 5s worker timeout always
+  // sends back an error response if user code hangs. The one case that produces
+  // no response at all is an iframe that never loads, and that is covered by the
+  // ready-handshake timeout rather than by timing out each request.
   const send = useCallback(
     <T extends SandboxResult>(message: object): Promise<T | SandboxError> => {
       return new Promise((resolve) => {
         const state = stateRef.current;
+
+        if (state.unavailable) {
+          resolve({ type: 'error', error: SANDBOX_UNAVAILABLE_ERROR } as SandboxError);
+          return;
+        }
+
         const id = nextId(state);
         const msgWithId = { ...message, id };
 
@@ -622,6 +700,7 @@ export function useSandbox(): SandboxHandle {
   const isReady = useCallback(() => stateRef.current.ready, []);
 
   return {
+    status,
     compile,
     compileIR,
     tick,


### PR DESCRIPTION
## Why

Chasing intermittent 403s from `sandbox.simten.dev` turned up a bug that isn't specific to Cloudflare: if the sandbox iframe never loads, **every request hangs forever**, with no error anywhere. Root cause of the 403 is still unidentified, but this makes any sandbox-origin failure visible instead of silent.

Two unrelated fixes came out of the same session.

## Changes

**`fix(sandbox)`** — `useSandbox` queued requests behind a `ready` handshake that never arrived, so promises never settled. `iframe.onerror` doesn't cover it: an HTTP 403 still loads a document, so the existing crash-recovery path never fired. Adds a 10s handshake timeout that fails everything waiting with a real error and exposes a reactive `status`. `useCircuitSimulator` now reports it through `SimulatorState.error`, which was declared but hardcoded `null` — `CircuitViewer` already had an error UI for it that had never fired.

**`fix(ui)`** — `setupSimtenIntellisense` only ran in `beforeMount`, which fires once. Navigating between game levels left the previous level's globals in Monaco, so a newly unlocked gate wasn't in the types until a full page reload, despite showing correctly on the canvas.

**`fix(game)`** — par on four levels predated progressive gate unlocks: `nor` 4→2, `xor` 4→3, `xnor` 5→2, `making-a-component` 4→1. Reference solutions rewritten to use the gates each level grants, and copy quoting the old counts updated. `levels.test.ts` asserted `gates <= par`, which a loose par passes silently; now asserts equality.

**`docs(web)`** — one-line comment at the top of each splash demo so it's clear what each one is.

## Verification

`pnpm test` (1064 passing), `pnpm typecheck`, `pnpm biome ci` all clean.

The Monaco fix needs the running app to confirm — it can't be covered by the existing tests.