### PR TITLE
Add changesets for the sandbox and intellisense fixes

### DIFF
--- a/.changeset/lucky-mangos-smile.md
+++ b/.changeset/lucky-mangos-smile.md
@@ -1,0 +1,5 @@
+---
+'@simten/ui': patch
+---
+
+Re-apply Monaco IntelliSense when `SimtenCodeEditor`'s `intellisense` prop changes. It was only applied in `beforeMount`, which fires once, so a consumer that varies the available globals at runtime kept the set from first mount until a full page reload.

--- a/.changeset/soft-cats-shave.md
+++ b/.changeset/soft-cats-shave.md
@@ -1,0 +1,6 @@
+---
+'@simten/ui': minor
+'@simten/embed': patch
+---
+
+Report a sandbox that never loads instead of hanging forever. Requests made before the iframe's ready handshake used to queue indefinitely if the handshake never arrived, so a blocked or unreachable sandbox left every promise unsettled and the canvas frozen with no error. `useSandbox` now gives up after 10s, fails everything waiting with a real error, and exposes a `status` of `loading | ready | unavailable`. `useCircuitSimulator` surfaces that through `SimulatorState.error`, so `CircuitViewer` shows a message rather than an empty canvas.


### PR DESCRIPTION
Changesets for the package changes in #315, which I should have included there.

- `@simten/ui` **minor** — new public exports (`SandboxStatus`, `SANDBOX_UNAVAILABLE_ERROR`) and a new `status` field on `SandboxHandle`, alongside the two behaviour fixes
- `@simten/embed` **patch** — `SimulatorState.error` now reports sandbox failure

Merging this opens the usual Version Packages PR.