### PR TITLE
Changeset for the Monaco shadow-model fix

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@simten/ui': patch
+---
+
+Keep the Monaco model that shadows a planted lib in step with it. `addExtraLib` registers a virtual file, but the first hover or quick fix on a lib makes Monaco materialise it as a model at the same URI, which then shadows the lib for every later update. Consumers that vary the globals at runtime — handing out a different set of components per screen — got the set frozen at whichever one was open when the first hover happened, and any component added afterwards reported "Cannot find name". Writing through the model also revalidates open files, so a stale marker clears immediately rather than on the next keystroke.


### PR DESCRIPTION
#318 merged after the 0.11.0 release, so the shadow-model fix is on `main` but not in any published version — and without a changeset the next Version Packages PR would not pick it up.

`@simten/ui` patch → 0.11.1.