### PR TITLE
Show port names on the game's circuit diagram

### DIFF
--- a/.changeset/olive-pugs-smile.md
+++ b/.changeset/olive-pugs-smile.md
@@ -1,0 +1,5 @@
+---
+'@simten/ui': patch
+---
+
+Make port labels legible. `showPortLabels` rendered them at 9px, which is small enough that the name a beginner is hunting for does not register as text. Now 11px, which stays inside the padding the labels already reserve.

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -437,6 +437,14 @@ function PlayLevel({ level }: { level: Level }) {
               portValues={preview.portValues}
               theme="dark"
               showControls
+              // The diagram has to answer "what is this port called", because
+              // the code demands the exact name and nothing else on screen
+              // supplies it. Unlabelled circles leave a beginner guessing at
+              // `.out` and `.in` with the answer sitting right in front of
+              // them. Always on here rather than a toggle: levels are three to
+              // six nodes, so there is no clutter to trade against, and someone
+              // stuck on a port name will not go hunting for a display option.
+              showPortLabels
               // Re-lay out on every change. The default only re-runs the
               // layout when nodes appear or disappear, so adding the last
               // wire — which changes no nodes — left the lamp where it had

--- a/packages/ui/src/nodes/BaseNode.tsx
+++ b/packages/ui/src/nodes/BaseNode.tsx
@@ -87,7 +87,7 @@ export function BaseNode({
             />
             {showPortLabels && (
               <div
-                className="absolute text-[9px] font-mono text-[var(--embed-text-secondary)] pointer-events-none select-none"
+                className="absolute text-[11px] font-mono text-[var(--embed-text-secondary)] pointer-events-none select-none"
                 style={{ top: topPct, left: '10px', transform: 'translateY(-50%)' }}
               >
                 {port.name}
@@ -153,7 +153,7 @@ export function BaseNode({
             />
             {showPortLabels && (
               <div
-                className="absolute text-[9px] font-mono text-[var(--embed-text-secondary)] pointer-events-none select-none"
+                className="absolute text-[11px] font-mono text-[var(--embed-text-secondary)] pointer-events-none select-none"
                 style={{
                   top: topPct,
                   right: '10px',


### PR DESCRIPTION
The diagram never said what a port was called, while the code demands the exact name. A player writing `a.out.to(or1.a)` had to know a `Switch` has `.out` and a `Nand` has `.a`, with the answer sitting in front of them as unlabelled circles.

Turns out this was already built and simply never switched on. `CircuitCanvas` has always accepted `showPortLabels`, `BaseNode` renders the labels and widens node padding to fit them, and all eighteen node components forward it. No consumer passed it.

**`feat(game)`** — pass the prop on the level canvas. Always on rather than a toggle: levels are three to six nodes so there is no clutter to trade against, and someone stuck on a port name will not go looking for a display option.

**`fix(ui)`** — the labels rendered at 9px, small enough that the name a beginner is hunting for does not register as text. Now 11px, which fits the padding already reserved. Nothing else passes `showPortLabels`, so this is game-only in practice today.

Left alone deliberately: `/circuit` still gets no labels. On a RISC-V core they would be noise, and the right rule there is zoom-gated visibility rather than an always-on flag.

## Verification

`pnpm test` (1064 passing), `pnpm typecheck`, `pnpm biome ci`, `pnpm check-exports` clean.

Checked in a browser on the NOR level: `out` on each switch, `a`/`b`/`out` on the OR, `in`/`out` on the NOT, `in` on the lamp. No collisions with the gate symbols.