### PR TITLE
Cut the last completion card back

### DIFF
--- a/apps/game/src/components/LevelComplete.tsx
+++ b/apps/game/src/components/LevelComplete.tsx
@@ -114,15 +114,15 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
             </Link>
           ) : (
             /* End of the campaign, and the highest-intent moment the game
-               gets: someone has just built an adder out of NANDs and knows
-               what it cost. Sending them back to a map of levels they have
-               already solved wastes it. The editor is where the same language
-               stops being a puzzle and starts being a tool. */
+               gets. Sending them back to a map of levels they have already
+               solved wastes it. `/circuit` opens on the example catalog —
+               Snake, a RISC-V computer, npm output baked into a ROM — so the
+               next thing they see is the range, and they pick. */
             <a
-              href="https://simten.dev/circuit?example=rv32i-computer"
+              href="https://simten.dev/circuit"
               className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground no-underline"
             >
-              See where this goes →
+              More demos →
             </a>
           )}
         </DialogFooter>

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -481,8 +481,8 @@ export default circuit('FullAdder', {
     ],
     par: 5,
     outro: {
-      headline: 'Built from what you built',
-      body: 'Two half adders and an OR, and you never touched a gate. That is the whole point of wrapping something in ports: every adder from here up is these chained together, the carry out of one bit becoming the carry in of the next. Chain enough of them and you have an ALU, then a CPU. Same language, same editor, and it runs on real hardware.',
+      headline: 'Full adder',
+      body: "That's the last level for now. More to come.",
     },
   },
 ];


### PR DESCRIPTION
The final card was doing too much. Someone who has just built a full adder does not need it explained back to them, and the body had drifted into a pitch.

**Headline** `Built from what you built` → `Full adder`. The old one was a chiasmus doing the work of nothing.

**Body** was four sentences recapping the solution and gesturing at ALUs and CPUs, including the claim "you never touched a gate" — which is wrong, since the level needs an OR. Now: *"That's the last level for now. More to come."* The one question a player actually has at that moment is whether that was the end.

**Button** `See where this goes →` → `More demos →`, and it now points at `/circuit` rather than the RV32I example. `/circuit` opens on the example catalog — Snake, a RISC-V computer, npm output baked into a ROM — so they see the range and pick, instead of being handed a CPU. The old label also read as though it led to more levels.

## Verification

`pnpm test` (1064 passing), `pnpm typecheck`, `pnpm biome ci`, `pnpm check-exports` clean.

Copy only, no behaviour change.