### PR TITLE
Reopen the intro from "What is this?"

### DIFF
--- a/apps/game/src/components/IntroDialog.tsx
+++ b/apps/game/src/components/IntroDialog.tsx
@@ -1,14 +1,13 @@
 /**
- * First-visit introduction.
+ * The introduction: what this is, in two sentences.
  *
- * Someone arriving cold sees a list of level titles and no reason to care. This
- * says what the thing is in two sentences and gets out of the way.
+ * Opens itself on a first visit, and the map's "What is this?" reopens it after
+ * that. Controlled from the outside for exactly that reason — the answer to
+ * "what is this" is already written here, so the header link pointing at
+ * simten.dev sent people off the site to read a worse version of it.
  *
- * Shown once, then never again — the flag is written on dismissal rather than
- * on open, so closing the tab mid-read brings it back.
- *
- * It renders closed on the server and opens after mount. Reading storage during
- * render would either mismatch hydration or flash the dialog on every visit.
+ * The seen flag is written on dismissal rather than on open, so closing the tab
+ * mid-read brings it back.
  */
 
 import {
@@ -19,19 +18,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@simten/ui/primitives/dialog';
-import { useEffect, useState } from 'react';
-import { INTRO_SEEN_KEY, readStored, writeStored } from '../game/storage';
+import { INTRO_SEEN_KEY, writeStored } from '../game/storage';
 
-export function IntroDialog() {
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    if (!readStored(INTRO_SEEN_KEY, false)) setOpen(true);
-  }, []);
-
+export function IntroDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
   const dismiss = () => {
     writeStored(INTRO_SEEN_KEY, true);
-    setOpen(false);
+    onOpenChange(false);
   };
 
   return (

--- a/apps/game/src/routes/index.tsx
+++ b/apps/game/src/routes/index.tsx
@@ -19,7 +19,7 @@ import { LevelMap } from '../components/LevelMap';
 import { Logo } from '../components/Logo';
 import ThemeToggle from '../components/ThemeToggle';
 import { LEVELS_BY_ID } from '../game/levels';
-import { type Drafts, readDrafts, readProgress } from '../game/storage';
+import { type Drafts, INTRO_SEEN_KEY, readDrafts, readProgress, readStored } from '../game/storage';
 
 export const Route = createFileRoute('/')({
   component: MapPage,
@@ -51,9 +51,18 @@ function MapPage() {
   const [solved, setSolved] = useState(NOTHING_SOLVED);
   const [drafts, setDrafts] = useState(NO_DRAFTS);
 
+  /**
+   * Owned here rather than inside the dialog, so the header can reopen it.
+   * Starts closed and opens after mount for the same reason as the rest of this
+   * state: reading storage during render would either mismatch hydration or
+   * flash the dialog at someone who has already dismissed it.
+   */
+  const [introOpen, setIntroOpen] = useState(false);
+
   useEffect(() => {
     setSolved(new Set(Object.keys(readProgress())));
     setDrafts(readDrafts());
+    if (!readStored(INTRO_SEEN_KEY, false)) setIntroOpen(true);
   }, []);
 
   const onHoverLevel = useCallback((levelId: string) => setHovered(levelId), []);
@@ -81,12 +90,13 @@ function MapPage() {
         </span>
         <span className="text-sm text-muted-foreground">Build a computer</span>
         <div className="ml-auto flex items-center gap-3">
-          <a
-            href="https://simten.dev"
+          <button
+            type="button"
+            onClick={() => setIntroOpen(true)}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             What is this?
-          </a>
+          </button>
           <ThemeToggle />
         </div>
       </header>
@@ -107,7 +117,7 @@ function MapPage() {
         />
       )}
 
-      <IntroDialog />
+      <IntroDialog open={introOpen} onOpenChange={setIntroOpen} />
     </div>
   );
 }


### PR DESCRIPTION
"What is this?" in the map header was an `<a>` to simten.dev, which sent people off the site to read a worse version of an answer the game already has. The intro dialog says exactly this, and after the first visit there was no way back to it.

It now reopens that dialog. Nothing is lost by not linking out: the dialog's own footer links to simten.dev, and its body links to the CPU, TPU and Snake posts.

`IntroDialog` becomes controlled, with the open state owned by the map route so the header can reach it. The first-visit read stays in an effect for the reason the route already documents for its other storage-derived state: reading during render would either mismatch hydration or flash the dialog at someone who has already dismissed it. The seen flag is still written on dismissal, not on open.

## Verification

Checked in a browser, both paths:

| | result |
|---|---|
| load with the flag set | stays closed |
| click "What is this?" | opens |
| dismiss with "Start building" | closes |
| clear the flag and reload | opens by itself |

`pnpm test` (122 game tests), `pnpm typecheck`, `pnpm biome ci` clean.