### PR TITLE
Title the first level NAND

### DIFF
--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -52,7 +52,7 @@ const ARITHMETIC_GATES = ['Nand', 'Not', 'And', 'Or', 'Nor', 'Xor', 'Xnor'];
 export const LEVELS: Level[] = [
   {
     id: 'first-wire',
-    title: 'First Wire',
+    title: 'NAND',
     brief:
       'This circuit is finished apart from one connection: nothing carries the gate’s result to the lamp. Add that line, then flip the switches.',
     target: 'Nand1',


### PR DESCRIPTION
Every other level is named after the gate it is about — NOT, AND, OR, NOR, XOR, XNOR. "First Wire" was the one exception, describing the mechanic rather than the gate, which makes the first row of the map read as though it belongs to a different campaign.

Title only. The `id` stays `first-wire`: it is the URL segment, and the type marks it as public surface not to be renamed. Solutions, the map row and the tests all key off the id, so nothing else moves.