### PR TITLE
Leave one action on the completion card

### DIFF
--- a/apps/game/src/components/LevelComplete.tsx
+++ b/apps/game/src/components/LevelComplete.tsx
@@ -6,9 +6,10 @@
  * receipt. Opening a dialog over a circuit still demonstrating itself would
  * step on the better of the two.
  *
- * Dismissible on purpose. `par` only means something if you can close this,
- * go back, and try to beat it — a completion screen whose only exit is "next"
- * quietly says optimising was never the point.
+ * Dismissible on purpose. `par` only means something if you can close this, go
+ * back, and try to beat it, so the X, Escape and a click outside all return to
+ * the circuit. That exit is not a button, though: it competes with the next
+ * level for attention, and the next level is what almost everyone wants.
  */
 
 import {
@@ -94,16 +95,11 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
           </ul>
         </div>
 
+        {/* One action. Going back to the circuit to beat par is still there —
+            the dialog closes on its X, on Escape and on a click outside — but
+            it does not need a button competing with the only thing most people
+            want at this point, which is the next level. */}
         <DialogFooter className="mt-6 gap-2">
-          {/* Closing is a real choice, not a dismissal: it is how you go back
-              and try to beat par. */}
-          <button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            className="rounded-md border border-border px-4 py-2 text-sm font-medium"
-          >
-            Back to the circuit
-          </button>
           {next ? (
             <Link
               to="/$levelId"


### PR DESCRIPTION
Recovered from #322, which squash-merged a stale head and dropped this commit.

The card had "Back to the circuit" sitting next to "Next: AND →". Going back to beat par is still possible — the dialog closes on its X, on Escape and on a click outside — but it does not need a button competing with the thing almost everyone wants next.

The file's header comment claimed the exit mattered *because* it was a button; that reasoning is updated rather than deleted, since the exit itself is still the point.

## Verification

Checked in a browser: the card now shows one action plus the X, and Escape still closes it (verified with a real key press, not a synthetic event).

`pnpm test` (122 game tests), `pnpm typecheck`, `pnpm biome ci` clean.