### PR TITLE
Per-level metadata, robots.txt and sitemap for the game

### DIFF
--- a/apps/game/public/robots.txt
+++ b/apps/game/public/robots.txt
@@ -1,0 +1,5 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+
+Sitemap: https://play.simten.dev/sitemap.xml

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -41,6 +41,7 @@ import { sandboxRuntime } from '../game/runtime';
 import { clearDraft, readDrafts, writeDraft, writeProgress } from '../game/storage';
 import type { GradeResult, Level } from '../game/types';
 import { useVictoryRun } from '../game/useVictoryRun';
+import { SITE_URL } from './__root';
 
 /**
  * How long typing pauses before the draft is stored.
@@ -59,6 +60,35 @@ export const Route = createFileRoute('/$levelId')({
     const level = LEVELS_BY_ID.get(params.levelId);
     if (!level) throw notFound();
     return { level };
+  },
+  /**
+   * Per-level metadata, overriding the root's site-wide set.
+   *
+   * Every page used to ship the root's title, description and `og:url`, so the
+   * eleven URLs were eleven duplicates as far as a crawler is concerned, and
+   * sending someone a level produced a card naming the site and linking to its
+   * front page rather than the level. The tagline is already a one-line
+   * description written for a human, which is exactly what this needs.
+   */
+  head: ({ loaderData }) => {
+    const level = loaderData?.level;
+    if (!level) return {};
+    const title = `${level.title} | Simten`;
+    const url = `${SITE_URL}/${level.id}`;
+    return {
+      meta: [
+        { title },
+        { name: 'description', content: level.tagline },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: level.tagline },
+        { property: 'og:url', content: url },
+        { name: 'twitter:title', content: title },
+        { name: 'twitter:description', content: level.tagline },
+      ],
+      // Levels are reachable whether or not you have unlocked them, so each one
+      // is a real page and should say which page it is.
+      links: [{ rel: 'canonical', href: url }],
+    };
   },
   component: PlayLevelRoute,
 });

--- a/apps/game/src/routes/__root.tsx
+++ b/apps/game/src/routes/__root.tsx
@@ -11,7 +11,7 @@ const THEME_INIT_SCRIPT = `(function(){try{var stored=window.localStorage.getIte
 const TITLE = 'Simten | Design hardware. Bit by bit.';
 const DESCRIPTION =
   'A puzzle campaign built on Simten, a TypeScript HDL that simulates in the browser and synthesizes to Verilog.';
-const SITE_URL = 'https://play.simten.dev';
+export const SITE_URL = 'https://play.simten.dev';
 const OG_IMAGE = `${SITE_URL}/og-default.png`;
 
 export const Route = createRootRoute({

--- a/apps/game/vite.config.ts
+++ b/apps/game/vite.config.ts
@@ -5,6 +5,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { LEVELS } from './src/game/levels';
 
 // `resolve.tsconfigPaths` is a Vite 8 feature. This workspace is pinned to
 // Vite 7 to match @simten/web, so path aliases come from the plugin instead.
@@ -14,7 +15,26 @@ const config = defineConfig({
     devtools(),
     cloudflare({ viteEnvironment: { name: 'ssr' } }),
     tailwindcss(),
-    tanstackStart(),
+    tanstackStart({
+      /**
+       * Sitemap only — no prerender.
+       *
+       * Every level is a real URL a crawler can reach and a person can share,
+       * so each belongs in the sitemap. Prerendering is a separate question and
+       * deliberately left off: it needs a Cloudflare token at build time (see
+       * @simten/web's config), and these pages are interactive rather than
+       * content, so there is little to bake.
+       *
+       * The page list is derived from `LEVELS` rather than typed out, so adding
+       * a level cannot silently leave it out. `levels.ts` imports only a type,
+       * so pulling it into the build config costs nothing at runtime.
+       */
+      sitemap: {
+        enabled: true,
+        host: 'https://play.simten.dev',
+      },
+      pages: [{ path: '/' }, ...LEVELS.map((level) => ({ path: `/${level.id}` }))],
+    }),
     viteReact(),
   ],
 });


### PR DESCRIPTION
Recovered from #330, which merged before GitHub had ingested these two commits.

**Per-level metadata.** Every page shipped the root's title, description and `og:url`, so eleven URLs were eleven duplicates to a crawler, and sharing a level produced a card naming the site and linking to its front page. `$levelId` now sets its own title, description, `og:url` and canonical from the level it already loads. The tagline doubles as the description, so there was no second set of copy to write.

**robots.txt and sitemap**, matching how `@simten/web` does it: TanStack Start's built-in sitemap plus a `robots.txt` pointing at it. The page list is derived from `LEVELS` rather than typed out, so adding a level cannot leave it out. `levels.ts` imports only a type, so pulling it into the vite config costs nothing at runtime.

Sitemap without prerender, deliberately: prerendering needs a Cloudflare token at build time and these pages are interactive rather than content. `/circuit` on the web app is sitemap-only for the same reason.

## Verification

Server-rendered HTML, no JS required:

```
/xor                 XOR | Simten                 · Light the lamp when the switches disagree.
/nor                 NOR | Simten                 · Light the lamp only when both switches are off.
/making-a-component  Making a Component | Simten  · Give a circuit ports, so other circuits can use it.
```

Each with a matching `og:url` and canonical.

A real `pnpm build` emits `dist/client/sitemap.xml` with all eleven URLs and ships `robots.txt`.

`pnpm test`, `pnpm typecheck`, `pnpm biome ci` clean.