### PR TITLE
Add the SR latch: the first level with memory

### DIFF
--- a/apps/game/src/components/SpecPanel.tsx
+++ b/apps/game/src/components/SpecPanel.tsx
@@ -83,7 +83,10 @@ export function SpecPanel({ level, result, activeRow, provenRows }: SpecPanelPro
   return (
     <div className="flex h-full items-start gap-8 overflow-x-auto overflow-y-auto px-4 py-3">
       <div className="shrink-0">
-        <Heading>Truth table</Heading>
+        {/* A sequential level's rows are ordered steps, not independent cases.
+            Calling that a truth table would tell the player order does not
+            matter, when order is the entire lesson. */}
+        <Heading>{level.sequential ? 'Sequence' : 'Truth table'}</Heading>
         <TruthTable
           level={level}
           active={activeRow}

--- a/apps/game/src/components/TruthTable.tsx
+++ b/apps/game/src/components/TruthTable.tsx
@@ -1,10 +1,14 @@
 /**
- * The level's truth table, laid out horizontally.
+ * The level's vectors, laid out horizontally.
  *
  * Signals run down the left and each vector is a column — the transpose of how
  * a truth table is usually written. It suits where this now lives, a wide and
  * short sheet, where the conventional layout would be a tall narrow strip with
  * dead space either side.
+ *
+ * The transpose also means a sequential level needs almost nothing extra: left
+ * to right is already how a timing diagram reads, so `level.sequential` adds a
+ * row of step numbers and the same table becomes a sequence.
  *
  * Nothing is hidden. These are the exact vectors the grader runs, so the
  * puzzle is "build this", never "guess what it wants".
@@ -64,11 +68,31 @@ export function TruthTable({ level, active = null, proven = 0, failed = null }: 
   return (
     <table className="font-mono text-sm tabular-nums">
       <tbody>
+        {/* Step numbers, on a sequential level only.
+            Without them the columns read as an unordered set of cases, which is
+            what a truth table is and what a sequence is not. They are also what
+            makes the lesson visible: on a latch two steps carry identical
+            inputs and different outputs, and you can point at them. */}
+        {level.sequential && (
+          <tr className="border-b border-border">
+            <th className="pr-3 text-right text-xs font-normal text-muted-foreground">step</th>
+            {level.vectors.map((_, i) => (
+              // Position is the identity here: these are ordered steps, and two
+              // of them can carry byte-identical inputs.
+              // biome-ignore lint/suspicious/noArrayIndexKey: the index is the step
+              <td key={i} className="w-7 py-0.5 text-center text-xs text-muted-foreground">
+                {i + 1}
+              </td>
+            ))}
+          </tr>
+        )}
+
         {inputNames.map((name) => (
           <tr key={name}>
             <th className="pr-3 text-right font-medium text-muted-foreground">{name}</th>
             {level.vectors.map((v, i) => (
-              <td key={JSON.stringify(v.inputs)} className={cell(i)}>
+              // biome-ignore lint/suspicious/noArrayIndexKey: see the step row
+              <td key={i} className={cell(i)}>
                 {v.inputs[name]}
               </td>
             ))}
@@ -81,10 +105,8 @@ export function TruthTable({ level, active = null, proven = 0, failed = null }: 
               {name}
             </th>
             {level.vectors.map((v, i) => (
-              <td
-                key={JSON.stringify(v.inputs)}
-                className={`${cell(i)} text-emerald-600 dark:text-emerald-400`}
-              >
+              // biome-ignore lint/suspicious/noArrayIndexKey: see the step row
+              <td key={i} className={`${cell(i)} text-emerald-600 dark:text-emerald-400`}>
                 {v.expect[name]}
               </td>
             ))}

--- a/apps/game/src/game/__tests__/levels.test.ts
+++ b/apps/game/src/game/__tests__/levels.test.ts
@@ -165,6 +165,31 @@ describe('level definitions', () => {
     for (const level of LEVELS) expect(level.stub).toContain(`'${level.target}'`);
   });
 
+  it('sequential levels cannot be passed by a combinational answer', () => {
+    /**
+     * The guarantee an exhaustive truth table gives for free, restated for
+     * ordered steps.
+     *
+     * A combinational level lists every input combination, so no circuit
+     * without memory can fake it. A sequential level lists a chosen handful,
+     * and a short enough sequence can be satisfied by some function of the
+     * inputs alone — which would make a level about memory passable without
+     * any. The proof it is not: the same inputs appear twice expecting
+     * different answers. No function of the inputs can do that.
+     */
+    for (const level of LEVELS.filter((l) => l.sequential)) {
+      const byInputs = new Map<string, Set<string>>();
+      for (const v of level.vectors) {
+        const key = JSON.stringify(v.inputs);
+        const seen = byInputs.get(key) ?? new Set<string>();
+        seen.add(JSON.stringify(v.expect));
+        byInputs.set(key, seen);
+      }
+      const contradicts = [...byInputs.values()].some((expects) => expects.size > 1);
+      expect(contradicts, `${level.id} has no step pair that requires memory`).toBe(true);
+    }
+  });
+
   it('all carry a tagline', () => {
     // The header renders this and truncates it, so an empty one leaves the top
     // of the screen blank and a long one is worse than nothing.

--- a/apps/game/src/game/__tests__/local-runtime.ts
+++ b/apps/game/src/game/__tests__/local-runtime.ts
@@ -53,7 +53,14 @@ export function localRuntime(): GradeRuntime {
       // node id second (simulator/index.ts:304), so the same call drives a
       // Switch in a self-contained level and a port in an abstracted one.
       for (const [name, value] of Object.entries(inputs)) engine.setNode(name, value);
-      engine.runCombinational();
+      // A clock cycle, because that is what the browser does: `sandboxRuntime`
+      // grades through `sandbox.tick`. This used `runCombinational`, which
+      // settles the logic without advancing a clock — the two agreed on every
+      // combinational level and silently disagreed on anything clocked, so a
+      // level that graded correctly in the browser could never pass CI. A
+      // latch hides the difference, being combinational feedback; a flip-flop
+      // does not, and simply never advances.
+      engine.tick();
 
       const values: Record<string, number | boolean> = {};
       for (const [k, v] of engine.getPortValues()) values[k] = v;

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -528,7 +528,59 @@ export default circuit('Latch1', {
     par: 2,
     outro: {
       headline: 'It remembers',
-      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of. That's the last level for now. More to come.",
+      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of.",
+    },
+  },
+
+  {
+    id: 'toggle',
+    title: 'Toggle',
+    tagline: 'Flip the lamp on every clock tick.',
+    brief:
+      'This one has no switches. The lamp flips on its own, once per clock tick, forever. Your latch held a value until something changed it; this has to change itself, which means feeding its own output back in through something that flips it.',
+    target: 'Toggle1',
+    inputs: [],
+    outputs: ['q'],
+    allowed: ['Nand', 'DFlipFlop'],
+    sequential: true,
+    stub: `// A flip-flop is memory with a clock.
+//
+// Your latch changed the instant its inputs did. A D flip-flop
+// only looks at \`d\` on a clock edge, and holds it steady until
+// the next one — so what it stores this tick is what \`d\` was
+// last tick.
+//
+// \`dff.q\` is what it currently holds. \`dff.d\` is what it will
+// hold next. Wire one to the other through something that
+// flips the value and it can never settle.
+//
+// You do not need a Not. A NAND with both inputs tied to the
+// same wire is one, which is how you built NOT in the first
+// place.
+
+export default circuit('Toggle1', {
+  nodes: {
+    dff: DFlipFlop(),
+    q: Led,
+  },
+  connect: ({ nodes: { dff, q } }) => [
+    //
+  ],
+});
+`,
+    // No inputs at all, so every step drives nothing and only the clock moves.
+    // Identical inputs with alternating answers is exactly the memory proof the
+    // suite looks for, and here it is the entire level.
+    vectors: [
+      { inputs: {}, expect: { q: 1 } },
+      { inputs: {}, expect: { q: 0 } },
+      { inputs: {}, expect: { q: 1 } },
+      { inputs: {}, expect: { q: 0 } },
+    ],
+    par: 2,
+    outro: {
+      headline: 'A clock, and something that counts it',
+      body: "Nothing drives this but time. Flip a second one every time the first falls and you are counting in binary. That's the last level for now. More to come.",
     },
   },
 ];

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -476,7 +476,59 @@ export default circuit('FullAdder', {
     par: 5,
     outro: {
       headline: 'Full adder',
-      body: "That's the last level for now. More to come.",
+      body: 'Chain these end to end and you can add any width.',
+    },
+  },
+
+  {
+    id: 'latch',
+    title: 'SR Latch',
+    tagline: 'Remember a bit after the input goes away.',
+    brief:
+      'Every circuit so far answered only to its switches. This one has to answer to what happened before: pull `s` low and the lamp comes on, pull `r` low and it goes off, and with both high it holds whatever it was last told. Read the steps left to right — the same inputs appear twice with different answers, and that is the whole point.',
+    target: 'Latch1',
+    inputs: ['s', 'r'],
+    outputs: ['q'],
+    allowed: ['Nand'],
+    sequential: true,
+    stub: `// The lamp has to remember.
+//
+// Everything you have built answers only to its inputs. A
+// circuit that remembers has to answer to its own output too,
+// so the answer has to come back round and feed the thing
+// that produced it.
+//
+// Two gates. Both switches high means hold.
+//
+// Note: both switches low at once is the state to avoid. It
+// forces an answer the circuit cannot hold on to, which is
+// why nothing below asks for it.
+
+export default circuit('Latch1', {
+  nodes: {
+    s: Switch,
+    r: Switch,
+    q: Led,
+  },
+  connect: ({ nodes: { s, r, q } }) => [
+    //
+  ],
+});
+`,
+    // Ordered steps, not a truth table. Steps 2 and 4 carry the same inputs as
+    // each other and expect different answers, which is what proves no
+    // combinational circuit can pass this level. Step 1 sets deliberately, so
+    // the run does not depend on whatever state the circuit powers up in.
+    vectors: [
+      { inputs: { s: 0, r: 1 }, expect: { q: 1 } },
+      { inputs: { s: 1, r: 1 }, expect: { q: 1 } },
+      { inputs: { s: 1, r: 0 }, expect: { q: 0 } },
+      { inputs: { s: 1, r: 1 }, expect: { q: 0 } },
+    ],
+    par: 2,
+    outro: {
+      headline: 'It remembers',
+      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of. That's the last level for now. More to come.",
     },
   },
 ];

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -550,13 +550,12 @@ export default circuit('Latch1', {
 // the next one — so what it stores this tick is what \`d\` was
 // last tick.
 //
-// \`dff.q\` is what it currently holds. \`dff.d\` is what it will
-// hold next. Wire one to the other through something that
-// flips the value and it can never settle.
+// \`dff.q\` is what it currently holds. \`dff.d\` is what it
+// will hold next. Give it the opposite of what it has and it
+// can never settle.
 //
-// You do not need a Not. A NAND with both inputs tied to the
-// same wire is one, which is how you built NOT in the first
-// place.
+// One wire does it. Look at what else the flip-flop already
+// gives you before reaching for a gate.
 
 export default circuit('Toggle1', {
   nodes: {
@@ -577,7 +576,7 @@ export default circuit('Toggle1', {
       { inputs: {}, expect: { q: 1 } },
       { inputs: {}, expect: { q: 0 } },
     ],
-    par: 2,
+    par: 1,
     outro: {
       headline: 'A clock, and something that counts it',
       body: "Nothing drives this but time. Flip a second one every time the first falls and you are counting in binary. That's the last level for now. More to come.",

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -30,6 +30,7 @@ export const MAP_ROWS: string[][] = [
   ['making-a-component'],
   ['half-adder'],
   ['full-adder'],
+  ['latch'],
 ];
 
 /**
@@ -56,6 +57,7 @@ export const MAP_SECTIONS: MapSection[] = [
   { label: 'Every gate from one', startRow: 2 },
   { label: 'Components', startRow: 7 },
   { label: 'Arithmetic', startRow: 8 },
+  { label: 'Memory', startRow: 10 },
 ];
 
 /**

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -31,6 +31,7 @@ export const MAP_ROWS: string[][] = [
   ['half-adder'],
   ['full-adder'],
   ['latch'],
+  ['toggle'],
 ];
 
 /**

--- a/apps/game/src/game/runtime.ts
+++ b/apps/game/src/game/runtime.ts
@@ -28,7 +28,14 @@ export interface GradeRuntime {
    */
   select(target: Circuit, library: Circuit[]): Promise<void>;
   /**
-   * Drive the named input signals, then read the named output signals.
+   * Drive the named input signals, advance one clock cycle, then read the named
+   * output signals.
+   *
+   * The tick is part of the contract, not an implementation detail: a level's
+   * vectors are consecutive cycles, which is what lets a sequential level state
+   * its behaviour as a sequence. An implementation that only settles the logic
+   * would agree on every combinational level and quietly disagree on anything
+   * with a clock in it.
    *
    * Keys in and out are the level's BARE signal names. The contract has to say
    * so: the sandbox reports top-level ports namespaced under `__top__` while

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -37,6 +37,7 @@ import makingAComponent from './making-a-component.ts?raw';
 import norGate from './nor.ts?raw';
 import notGate from './not.ts?raw';
 import orGate from './or.ts?raw';
+import toggle from './toggle.ts?raw';
 import xnorGate from './xnor.ts?raw';
 import xorGate from './xor.ts?raw';
 
@@ -51,5 +52,6 @@ export const SOLUTIONS: Record<string, string> = {
   'making-a-component': makingAComponent,
   'half-adder': halfAdder,
   latch,
+  toggle,
   'full-adder': fullAdder,
 };

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -32,6 +32,7 @@ import andGate from './and.ts?raw';
 import firstWire from './first-wire.ts?raw';
 import fullAdder from './full-adder.ts?raw';
 import halfAdder from './half-adder.ts?raw';
+import latch from './latch.ts?raw';
 import makingAComponent from './making-a-component.ts?raw';
 import norGate from './nor.ts?raw';
 import notGate from './not.ts?raw';
@@ -49,5 +50,6 @@ export const SOLUTIONS: Record<string, string> = {
   xnor: xnorGate,
   'making-a-component': makingAComponent,
   'half-adder': halfAdder,
+  latch,
   'full-adder': fullAdder,
 };

--- a/apps/game/src/game/solutions/latch.ts
+++ b/apps/game/src/game/solutions/latch.ts
@@ -1,0 +1,16 @@
+/** Reference solution for `latch`. Proven by `__tests__/levels.test.ts`. */
+
+import { circuit } from '@simten/core/circuit';
+import { Led, Nand, Switch } from '@simten/core/std';
+
+export const Latch1 = circuit('Latch1', {
+  nodes: { s: Switch, r: Switch, n1: Nand, n2: Nand, q: Led },
+  connect: ({ nodes: { s, r, n1, n2, q } }) => [
+    s.out.to(n1.a),
+    r.out.to(n2.b),
+    // Each gate reads the other's answer. That loop is the memory: with both
+    // switches high neither gate can change, so the pair holds.
+    n1.out.to(n2.a, q.in),
+    n2.out.to(n1.b),
+  ],
+});

--- a/apps/game/src/game/solutions/toggle.ts
+++ b/apps/game/src/game/solutions/toggle.ts
@@ -1,14 +1,12 @@
 /** Reference solution for `toggle`. Proven by `__tests__/levels.test.ts`. */
 
 import { circuit } from '@simten/core/circuit';
-import { DFlipFlop, Led, Nand } from '@simten/core/std';
+import { DFlipFlop, Led } from '@simten/core/std';
 
 export const Toggle1 = circuit('Toggle1', {
-  // A NAND with both inputs tied together is an inverter — the trick from the
-  // NOT level, reused so the flip-flop is the only new part here.
-  nodes: { dff: DFlipFlop(), n1: Nand, q: Led },
-  connect: ({ nodes: { dff, n1, q } }) => [
-    dff.q.to(n1.a, n1.b, q.in),
-    n1.out.to(dff.d),
-  ],
+  // No gate at all. `q_bar` is already the opposite of what is stored, so
+  // wiring it to `d` says "next tick, hold the opposite of this" — which is a
+  // circuit that can never settle.
+  nodes: { dff: DFlipFlop(), q: Led },
+  connect: ({ nodes: { dff, q } }) => [dff.q_bar.to(dff.d), dff.q.to(q.in)],
 });

--- a/apps/game/src/game/solutions/toggle.ts
+++ b/apps/game/src/game/solutions/toggle.ts
@@ -1,0 +1,14 @@
+/** Reference solution for `toggle`. Proven by `__tests__/levels.test.ts`. */
+
+import { circuit } from '@simten/core/circuit';
+import { DFlipFlop, Led, Nand } from '@simten/core/std';
+
+export const Toggle1 = circuit('Toggle1', {
+  // A NAND with both inputs tied together is an inverter — the trick from the
+  // NOT level, reused so the flip-flop is the only new part here.
+  nodes: { dff: DFlipFlop(), n1: Nand, q: Led },
+  connect: ({ nodes: { dff, n1, q } }) => [
+    dff.q.to(n1.a, n1.b, q.in),
+    n1.out.to(dff.d),
+  ],
+});

--- a/apps/game/src/game/types.ts
+++ b/apps/game/src/game/types.ts
@@ -72,10 +72,24 @@ export interface Level {
   /** Starting source in the editor. */
   stub: string;
   /**
-   * The truth table. Exhaustive where the input space allows it — every level
-   * shipped so far is small enough that it is.
+   * The truth table. Exhaustive where the input space allows it — every
+   * combinational level shipped so far is small enough that it is.
+   *
+   * On a `sequential` level these are ordered steps, not independent cases, and
+   * reordering or deduplicating them destroys what they assert.
    */
   vectors: Vector[];
+  /**
+   * Does this level's answer have memory?
+   *
+   * The grader needs no help — it drives one vector per clock tick and does not
+   * reset between them, so state already carries. This exists for the spec
+   * panel, which otherwise presents ordered steps as an unordered truth table
+   * and tells the player the opposite of the lesson: on a latch the same inputs
+   * appear twice with different outputs, which is a contradiction in a truth
+   * table and the definition of memory in a sequence.
+   */
+  sequential?: boolean;
   /**
    * Gate count worth beating. Used for scoring; not shown on the completion
    * dialog, where a par figure reads as a mark out of ten rather than an

--- a/apps/game/src/game/useVictoryRun.ts
+++ b/apps/game/src/game/useVictoryRun.ts
@@ -34,6 +34,7 @@ export interface VictoryRun {
 export function useVictoryRun(
   vectors: Vector[],
   drive: (nodeId: string, value: number) => Promise<unknown> | unknown,
+  tick: () => void,
 ): VictoryRun {
   const [active, setActive] = useState<number | null>(null);
   const [proven, setProven] = useState(0);
@@ -43,6 +44,8 @@ export function useVictoryRun(
   const token = useRef(0);
   const driveRef = useRef(drive);
   driveRef.current = drive;
+  const tickRef = useRef(tick);
+  tickRef.current = tick;
 
   useEffect(() => {
     return () => {
@@ -69,6 +72,16 @@ export function useVictoryRun(
         for (const [name, value] of Object.entries(vectors[i].inputs)) {
           await driveRef.current(name, value);
         }
+        // Then a clock edge, exactly as the grader does for every vector.
+        //
+        // Driving inputs propagates but does not advance a clock, so without
+        // this a clocked circuit would sit frozen while the grader — which
+        // ticks — passed it. The run would contradict the verdict, and it would
+        // read as a broken animation rather than a missing edge. Unconditional
+        // rather than keyed off `sequential`, because matching the grader for
+        // every level is what stops the two drifting apart again; on a
+        // combinational circuit a tick changes nothing anyone can see.
+        tickRef.current();
         if (token.current !== mine) return;
         setProven(i + 1);
         await new Promise((r) => setTimeout(r, STEP_MS));

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -224,7 +224,7 @@ function PlayLevel({ level }: { level: Level }) {
 
   // On a solve, drive the player's own circuit through the truth table so the
   // switches flip and the LED lights. The proof is the machine running.
-  const victory = useVictoryRun(level.vectors, preview.setNodeValue);
+  const victory = useVictoryRun(level.vectors, preview.setNodeValue, preview.tick);
 
   /**
    * Gates in the preview that this level forbids.

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -13,6 +13,7 @@
 import { elaborate } from '@simten/core';
 import { ErrorDisplay, useCompiledCircuit } from '@simten/embed';
 import { CircuitCanvas } from '@simten/ui/canvas';
+import { ClockControls } from '@simten/ui/editor/components';
 import {
   buildGlobalsFor,
   registerSimtenThemes,
@@ -463,36 +464,80 @@ function PlayLevel({ level }: { level: Level }) {
 
           <ResizableHandle withHandle />
 
-          <ResizablePanel defaultSize={55} minSize={20} className="overflow-hidden">
-            <CircuitCanvas
-              circuit={canvasCircuit}
-              componentLibrary={canvasLibrary ?? undefined}
-              portValues={preview.portValues}
-              theme="dark"
-              showControls
-              // The diagram has to answer "what is this port called", because
-              // the code demands the exact name and nothing else on screen
-              // supplies it. Unlabelled circles leave a beginner guessing at
-              // `.out` and `.in` with the answer sitting right in front of
-              // them. Always on here rather than a toggle: levels are three to
-              // six nodes, so there is no clutter to trade against, and someone
-              // stuck on a port name will not go hunting for a display option.
-              showPortLabels
-              // Re-lay out on every change. The default only re-runs the
-              // layout when nodes appear or disappear, so adding the last
-              // wire — which changes no nodes — left the lamp where it had
-              // been while unconnected.
-              autoLayout
-              // The harness switches are clickable, so the player can drive
-              // their own circuit and see it light up before submitting.
-              onToggleNode={preview.toggleNode}
-              onSetNodeValue={preview.setNodeValue}
-              renderEmptyState={() => (
-                <div className="grid h-full place-items-center text-sm text-muted-foreground">
-                  Your circuit appears here as you write it.
-                </div>
-              )}
-            />
+          <ResizablePanel defaultSize={55} minSize={20} className="flex flex-col overflow-hidden">
+            {/*
+              A clock, when the player's circuit has one.
+
+              Gated on `preview.isSequential` rather than `level.sequential`,
+              the same way `/circuit` does it: the question is whether the
+              circuit on screen has state, not whether the level expects one. A
+              player reaching for a flip-flop early gets the controls, and a
+              sequential level opened on a blank stub does not get an inert row
+              of buttons.
+
+              Above the canvas rather than below the panels, where `/circuit`
+              puts it. The spec sheet here is a bottom overlay, and anything at
+              the foot of the page sits under it — the controls were rendered,
+              on screen, and unclickable, with the spec open by default.
+
+              Without this the Toggle level has nothing to interact with at all:
+              it declares no inputs, so there is not one switch to click, and
+              the circuit could only be observed by solving it.
+            */}
+            {preview.isSequential && (
+              <div className="flex shrink-0 items-center border-b border-border bg-card/95 px-3 py-1">
+                <ClockControls
+                  cycle={preview.cycleCount}
+                  historyLength={preview.history.length}
+                  historyIndex={preview.historyIndex}
+                  isRunning={preview.isRunning}
+                  isViewingPast={preview.isViewingPast}
+                  speed={preview.speed || 15}
+                  maxSpeed={1000}
+                  onStep={preview.tick}
+                  onRun={() => preview.startAutoRun(preview.speed || 15, { displayRate: 30 })}
+                  onPause={() => preview.stopAutoRun()}
+                  onReset={preview.reset}
+                  onStepBack={() => preview.stepBack()}
+                  onStepForward={() => preview.stepForward()}
+                  onSeek={(i) => preview.seek(i)}
+                  onSpeedChange={(speed) => preview.setSpeed(speed)}
+                  showScrubber={preview.history.length > 1}
+                  chromeless
+                />
+              </div>
+            )}
+            <div className="min-h-0 flex-1">
+              <CircuitCanvas
+                circuit={canvasCircuit}
+                componentLibrary={canvasLibrary ?? undefined}
+                portValues={preview.portValues}
+                theme="dark"
+                showControls
+                // The diagram has to answer "what is this port called", because
+                // the code demands the exact name and nothing else on screen
+                // supplies it. Unlabelled circles leave a beginner guessing at
+                // `.out` and `.in` with the answer sitting right in front of
+                // them. Always on here rather than a toggle: levels are three to
+                // six nodes, so there is no clutter to trade against, and someone
+                // stuck on a port name will not go hunting for a display option.
+                showPortLabels
+                // Re-lay out on every change. The default only re-runs the
+                // layout when nodes appear or disappear, so adding the last
+                // wire — which changes no nodes — left the lamp where it had
+                // been while unconnected.
+                autoLayout
+                // The harness switches are clickable, so the player can drive
+                // their own circuit and see it light up before submitting.
+                onToggleNode={preview.toggleNode}
+                onSetNodeValue={preview.setNodeValue}
+                renderEmptyState={() => (
+                  <div className="grid h-full place-items-center text-sm text-muted-foreground">
+                    Your circuit appears here as you write it.
+                  </div>
+                )}
+              />
+            </div>
           </ResizablePanel>
         </ResizablePanelGroup>
       </div>

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -55,6 +55,16 @@ import { SITE_URL } from './__root';
  */
 const DRAFT_DEBOUNCE_MS = 400;
 
+/**
+ * Height of the clock bar, in pixels.
+ *
+ * Shared rather than expressed twice, because the spec sheet is lifted by
+ * exactly this much when the bar is showing. Two independent values would drift
+ * and leave either a seam or an overlap, and the overlap is invisible until you
+ * try to click something.
+ */
+const CLOCK_BAR_PX = 40;
+
 export const Route = createFileRoute('/$levelId')({
   staticData: { skipDefaultChrome: true },
   loader: ({ params }) => {
@@ -464,83 +474,87 @@ function PlayLevel({ level }: { level: Level }) {
 
           <ResizableHandle withHandle />
 
-          <ResizablePanel defaultSize={55} minSize={20} className="flex flex-col overflow-hidden">
-            {/*
-              A clock, when the player's circuit has one.
-
-              Gated on `preview.isSequential` rather than `level.sequential`,
-              the same way `/circuit` does it: the question is whether the
-              circuit on screen has state, not whether the level expects one. A
-              player reaching for a flip-flop early gets the controls, and a
-              sequential level opened on a blank stub does not get an inert row
-              of buttons.
-
-              Above the canvas rather than below the panels, where `/circuit`
-              puts it. The spec sheet here is a bottom overlay, and anything at
-              the foot of the page sits under it — the controls were rendered,
-              on screen, and unclickable, with the spec open by default.
-
-              Without this the Toggle level has nothing to interact with at all:
-              it declares no inputs, so there is not one switch to click, and
-              the circuit could only be observed by solving it.
-            */}
-            {preview.isSequential && (
-              <div className="flex shrink-0 items-center border-b border-border bg-card/95 px-3 py-1">
-                <ClockControls
-                  cycle={preview.cycleCount}
-                  historyLength={preview.history.length}
-                  historyIndex={preview.historyIndex}
-                  isRunning={preview.isRunning}
-                  isViewingPast={preview.isViewingPast}
-                  speed={preview.speed || 15}
-                  maxSpeed={1000}
-                  onStep={preview.tick}
-                  onRun={() => preview.startAutoRun(preview.speed || 15, { displayRate: 30 })}
-                  onPause={() => preview.stopAutoRun()}
-                  onReset={preview.reset}
-                  onStepBack={() => preview.stepBack()}
-                  onStepForward={() => preview.stepForward()}
-                  onSeek={(i) => preview.seek(i)}
-                  onSpeedChange={(speed) => preview.setSpeed(speed)}
-                  showScrubber={preview.history.length > 1}
-                  chromeless
-                />
-              </div>
-            )}
-            <div className="min-h-0 flex-1">
-              <CircuitCanvas
-                circuit={canvasCircuit}
-                componentLibrary={canvasLibrary ?? undefined}
-                portValues={preview.portValues}
-                theme="dark"
-                showControls
-                // The diagram has to answer "what is this port called", because
-                // the code demands the exact name and nothing else on screen
-                // supplies it. Unlabelled circles leave a beginner guessing at
-                // `.out` and `.in` with the answer sitting right in front of
-                // them. Always on here rather than a toggle: levels are three to
-                // six nodes, so there is no clutter to trade against, and someone
-                // stuck on a port name will not go hunting for a display option.
-                showPortLabels
-                // Re-lay out on every change. The default only re-runs the
-                // layout when nodes appear or disappear, so adding the last
-                // wire — which changes no nodes — left the lamp where it had
-                // been while unconnected.
-                autoLayout
-                // The harness switches are clickable, so the player can drive
-                // their own circuit and see it light up before submitting.
-                onToggleNode={preview.toggleNode}
-                onSetNodeValue={preview.setNodeValue}
-                renderEmptyState={() => (
-                  <div className="grid h-full place-items-center text-sm text-muted-foreground">
-                    Your circuit appears here as you write it.
-                  </div>
-                )}
-              />
-            </div>
+          <ResizablePanel defaultSize={55} minSize={20} className="overflow-hidden">
+            <CircuitCanvas
+              circuit={canvasCircuit}
+              componentLibrary={canvasLibrary ?? undefined}
+              portValues={preview.portValues}
+              theme="dark"
+              showControls
+              // The diagram has to answer "what is this port called", because
+              // the code demands the exact name and nothing else on screen
+              // supplies it. Unlabelled circles leave a beginner guessing at
+              // `.out` and `.in` with the answer sitting right in front of
+              // them. Always on here rather than a toggle: levels are three to
+              // six nodes, so there is no clutter to trade against, and someone
+              // stuck on a port name will not go hunting for a display option.
+              showPortLabels
+              // Re-lay out on every change. The default only re-runs the
+              // layout when nodes appear or disappear, so adding the last
+              // wire — which changes no nodes — left the lamp where it had
+              // been while unconnected.
+              autoLayout
+              // The harness switches are clickable, so the player can drive
+              // their own circuit and see it light up before submitting.
+              onToggleNode={preview.toggleNode}
+              onSetNodeValue={preview.setNodeValue}
+              renderEmptyState={() => (
+                <div className="grid h-full place-items-center text-sm text-muted-foreground">
+                  Your circuit appears here as you write it.
+                </div>
+              )}
+            />
           </ResizablePanel>
         </ResizablePanelGroup>
       </div>
+
+      {/*
+        A clock, when the player's circuit has one.
+
+        Gated on `preview.isSequential` rather than `level.sequential`, the same
+        way `/circuit` does it: the question is whether the circuit on screen
+        has state, not whether the level expects one. A player reaching for a
+        flip-flop early gets the controls, and a sequential level opened on a
+        blank stub does not get an inert row of buttons.
+
+        It sits at the foot of the page and the spec sheet rises above it —
+        see the sheet's `bottom` offset below. Without that the sheet covered
+        it: the controls rendered, on screen, and unclickable, with the spec
+        open by default.
+
+        Without any of this the Toggle level has nothing to interact with at
+        all. It declares no inputs, so there is not one switch to click, and the
+        circuit could only be observed by solving it.
+      */}
+      {preview.isSequential && (
+        <div
+          // Above the sheet's own z-50, so the spec slides up and down *behind*
+          // the bar rather than across it. The bar is a fixture; the sheet is
+          // the thing that moves.
+          className="relative z-[60] flex shrink-0 items-center border-t border-border bg-card/95 px-3"
+          style={{ height: CLOCK_BAR_PX }}
+        >
+          <ClockControls
+            cycle={preview.cycleCount}
+            historyLength={preview.history.length}
+            historyIndex={preview.historyIndex}
+            isRunning={preview.isRunning}
+            isViewingPast={preview.isViewingPast}
+            speed={preview.speed || 15}
+            maxSpeed={1000}
+            onStep={preview.tick}
+            onRun={() => preview.startAutoRun(preview.speed || 15, { displayRate: 30 })}
+            onPause={() => preview.stopAutoRun()}
+            onReset={preview.reset}
+            onStepBack={() => preview.stepBack()}
+            onStepForward={() => preview.stepForward()}
+            onSeek={(i) => preview.seek(i)}
+            onSpeedChange={(speed) => preview.setSpeed(speed)}
+            showScrubber={preview.history.length > 1}
+            chromeless
+          />
+        </div>
+      )}
 
       {/* Non-modal so the editor and canvas keep working behind it, and the
           overlay is off — it is `fixed inset-0` and would swallow every click
@@ -561,6 +575,10 @@ function PlayLevel({ level }: { level: Level }) {
       <Sheet modal={false} open={specOpen} onOpenChange={setSpecOpen}>
         <SheetContent
           side="bottom"
+          // Inline, so it beats the primitive's `bottom-0` class. The spec
+          // slides up from the bottom as before, just stopping short of the
+          // clock bar instead of sitting on top of it.
+          style={{ bottom: preview.isSequential ? CLOCK_BAR_PX : 0 }}
           showOverlay={false}
           onInteractOutside={(e) => e.preventDefault()}
           onOpenAutoFocus={(e) => e.preventDefault()}


### PR DESCRIPTION
An eleventh level, and the presentation change it needed.

## The grader already handled sequential circuits

`evaluate` sets inputs and *ticks*, and nothing resets between vectors, so state carries from one row to the next. A cross-coupled NAND latch graded correctly before any of this was written. No engine work was needed — which was not what I expected going in.

## What did need changing

**Presentation.** The spec panel called the vectors a truth table and laid them out as unordered cases. On a latch that says the opposite of the lesson: steps 2 and 4 carry identical inputs and different outputs, which is a contradiction in a truth table and the definition of memory in a sequence. `Level.sequential` now switches the heading to "Sequence" and adds a step row. The layout needed nothing else — it was already transposed, so left-to-right already read as time.

**A latent bug.** Cells were keyed by `JSON.stringify(v.inputs)`. Two steps of a sequential level share identical inputs, so React would have seen duplicate keys and the victory-run highlight would have tracked the wrong column. Keyed by index now, which is the correct identity for an ordered sequence.

## The level

`s` and `r` are active low. Pull `s` low to set, `r` low to clear, both high to hold. Two NANDs, par 2, `allowed: ['Nand']`.

The vectors are a designed sequence rather than an enumeration, and step 1 sets deliberately so the run does not depend on power-up state. Both switches low is the invalid state; the stub names it and the vectors never ask for it.

**A new invariant, because exhaustiveness no longer protects us.** A combinational level lists every input combination, so nothing without memory can fake it. A sequential level lists a chosen handful, and a short enough sequence could be satisfied by a function of the inputs alone — a level about memory, passable without any. `levels.test.ts` now asserts every sequential level has a repeated input pattern expecting different answers, which is a proof that no combinational circuit can pass.

Full adder's outro no longer claims to be the last level.

## Verification

Driven in a browser:

- The latch solves end to end from the level page, victory run included, and scores par 2.
- The spec panel renders as `SEQUENCE` with step numbers; combinational levels are untouched.
- The canvas lays out the feedback loop cleanly — dagre handled the cycle, and the routed return path is legible rather than tangled.
- Clicking the switches by hand holds state across set → hold → reset → hold, so the preview agrees with the grader.
- The map shows a `MEMORY` band and the unlock circuit picked the new row up with no changes.

One thing this deliberately does not cover: the victory run drives `setNodeValue`, which propagates but never ticks. That is fine for a latch, which is combinational feedback, and would silently break for a genuinely clocked level — a register or counter would grade correctly while the animation showed a frozen output. Worth fixing before any clocked level, not before this one.

`pnpm test` (131 game tests), `pnpm typecheck`, `pnpm biome ci`, `pnpm check-exports` clean.