### PR TITLE
Reword the Toggle tagline

### DIFF
--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -535,7 +535,7 @@ export default circuit('Latch1', {
   {
     id: 'toggle',
     title: 'Toggle',
-    tagline: 'Flip the lamp on every clock tick.',
+    tagline: 'Alternate the lamp between on and off, every tick.',
     brief:
       'This one has no switches. The lamp flips on its own, once per clock tick, forever. Your latch held a value until something changed it; this has to change itself, which means feeding its own output back in through something that flips it.',
     target: 'Toggle1',


### PR DESCRIPTION
Dropped from #332, which merged before GitHub had ingested the last commit.

`Flip the lamp on every clock tick.` → `Alternate the lamp between on and off, every tick.`

"Flip" is also what a switch does, so it read as an instruction to the player rather than a description of what the circuit does on its own — which is the whole point of the level, since it has no switches.