### PR TITLE
Add the D Latch, so the flip-flop is earned

### DIFF
--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -528,7 +528,63 @@ export default circuit('Latch1', {
     par: 2,
     outro: {
       headline: 'It remembers',
-      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of.",
+      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of — but it has a state you were told to avoid, and the next level gets rid of it.",
+    },
+  },
+
+  {
+    id: 'd-latch',
+    title: 'D Latch',
+    tagline: 'Store one bit, only while you allow it.',
+    brief:
+      'Your latch had a state you had to avoid, and it needed two switches to say one thing. Fix both: `d` is the bit to store, `en` says whether to listen. While `en` is high the lamp follows `d`; while it is low the lamp holds, whatever `d` does.',
+    target: 'DLatch1',
+    inputs: ['d', 'en'],
+    outputs: ['q'],
+    allowed: ['Nand'],
+    sequential: true,
+    stub: `// Keep your latch. Put a gate in front of each input.
+//
+// The pair you built holds when both its inputs are high. So
+// the job of the two new gates is: when \`en\` is low, force
+// both high no matter what \`d\` is — and when \`en\` is high,
+// send \`d\` to one side and its opposite to the other.
+//
+// A NAND already gives you the opposite of something for
+// free. Look at what the first new gate produces before you
+// reach for another one.
+
+export default circuit('DLatch1', {
+  nodes: {
+    d: Switch,
+    en: Switch,
+    n1: Nand,
+    n2: Nand,
+    n3: Nand,
+    n4: Nand,
+    q: Led,
+  },
+  connect: ({ nodes: { d, en, n1, n2, n3, n4, q } }) => [
+    //
+  ],
+});
+`,
+    // Steps 2 and 5 carry identical inputs and demand different answers,
+    // which is the proof no combinational circuit can pass — without a repeat
+    // like that, `XNOR(d, en)` satisfies the whole table with no memory at
+    // all. Step 1 stores deliberately, so the run does not depend on whatever
+    // state the circuit powers up in.
+    vectors: [
+      { inputs: { d: 1, en: 1 }, expect: { q: 1 } },
+      { inputs: { d: 0, en: 0 }, expect: { q: 1 } },
+      { inputs: { d: 0, en: 1 }, expect: { q: 0 } },
+      { inputs: { d: 1, en: 0 }, expect: { q: 0 } },
+      { inputs: { d: 0, en: 0 }, expect: { q: 0 } },
+    ],
+    par: 4,
+    outro: {
+      headline: 'One bit, on demand',
+      body: 'One input to store, one to decide when. A flip-flop is this with an edge instead of a level: it looks at `d` the instant the clock rises rather than the whole time it is high. You get one next level.',
     },
   },
 

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -31,6 +31,7 @@ export const MAP_ROWS: string[][] = [
   ['half-adder'],
   ['full-adder'],
   ['latch'],
+  ['d-latch'],
   ['toggle'],
 ];
 

--- a/apps/game/src/game/solutions/d-latch.ts
+++ b/apps/game/src/game/solutions/d-latch.ts
@@ -1,0 +1,20 @@
+/** Reference solution for `d-latch`. Proven by `__tests__/levels.test.ts`. */
+
+import { circuit } from '@simten/core/circuit';
+import { Led, Nand, Switch } from '@simten/core/std';
+
+export const DLatch1 = circuit('DLatch1', {
+  // The SR latch from last level (n3, n4) with two steering gates in front.
+  // `en` low forces both steering outputs high, which is the latch's hold
+  // state; `en` high lets `d` and its inverse through as set and reset, so the
+  // pair can never be asked for the invalid both-low case.
+  nodes: { d: Switch, en: Switch, n1: Nand, n2: Nand, n3: Nand, n4: Nand, q: Led },
+  connect: ({ nodes: { d, en, n1, n2, n3, n4, q } }) => [
+    d.out.to(n1.a),
+    en.out.to(n1.b, n2.b),
+    n1.out.to(n2.a, n3.a),
+    n2.out.to(n4.b),
+    n3.out.to(n4.a, q.in),
+    n4.out.to(n3.b),
+  ],
+});

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -29,6 +29,7 @@
  */
 
 import andGate from './and.ts?raw';
+import dLatch from './d-latch.ts?raw';
 import firstWire from './first-wire.ts?raw';
 import fullAdder from './full-adder.ts?raw';
 import halfAdder from './half-adder.ts?raw';
@@ -51,6 +52,7 @@ export const SOLUTIONS: Record<string, string> = {
   xnor: xnorGate,
   'making-a-component': makingAComponent,
   'half-adder': halfAdder,
+  'd-latch': dLatch,
   latch,
   toggle,
   'full-adder': fullAdder,


### PR DESCRIPTION
The campaign's rule is that everything handed to you is something you built first — Nand, Not, And, Or, Nor, Xor, Xnor, all earned. `DFlipFlop` broke it: the SR latch's completion card announced "DFlipFlop unlocked" as a reward for building something else entirely, and Toggle then used a clocked component the player had never seen the inside of.

A gated D latch closes the gap. Four NANDs — the SR latch you just built, with two steering gates in front — and it fixes the SR latch's own wart at the same time: `en` low forces both latch inputs high, so the invalid both-low state becomes unreachable by construction.

The unlock moves with it:

| level | announces |
|---|---|
| SR Latch | (You built Latch1) |
| **D Latch** | **DFlipFlop unlocked** |
| Toggle | (You built Toggle1) |

So the flip-flop now arrives after you have built the level-sensitive version by hand, and its outro says plainly what the difference is: an edge instead of a level.

**The invariant test earned its keep.** My first draft used four steps with four distinct input pairs — and `XNOR(d, en)` satisfies all four exactly. A memory level would have been passable with one combinational gate. The suite rejected it, and the vectors are now five steps where `d=0, en=0` appears twice demanding different answers, which is a proof no combinational circuit can pass.

## Verification

Solved end to end in a browser from the level page, victory run and all.

`pnpm test` (145 game tests), `pnpm typecheck`, `pnpm biome ci` clean.