### PR TITLE
Recover the clock explainer and reward-block fix

### DIFF
--- a/apps/game/src/components/LevelComplete.tsx
+++ b/apps/game/src/components/LevelComplete.tsx
@@ -43,6 +43,7 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
    */
   const unlocked = gatesGainedAfter(level, next);
   const owned = next?.allowed ?? level.allowed;
+  const gained = unlocked.length > 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -70,30 +71,32 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
             reward is watching the set fill up — which a line of prose saying
             "Xor unlocked" cannot do.
 
-            The last three levels add no gate; they add a circuit. Showing that
-            keeps the block in place without pretending a part changed hands,
-            and "built" rather than "unlocked" is deliberate: the campaign does
-            not let a later level reuse your HalfAdder, so claiming an unlock
-            would promise something the grader rejects. */}
-        <div className="mt-5">
-          <p className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">
-            {unlocked.length > 0 ? 'Your gates' : 'You built'}
-          </p>
-          <ul className="flex flex-wrap gap-1.5">
-            {(unlocked.length > 0 ? owned : [level.target]).map((name) => (
-              <li
-                key={name}
-                className={
-                  unlocked.length === 0 || unlocked.includes(name)
-                    ? 'rounded border border-emerald-600/40 bg-emerald-500/10 px-2 py-1 font-mono text-xs font-medium text-emerald-600 dark:text-emerald-400'
-                    : 'rounded border border-border px-2 py-1 font-mono text-xs text-muted-foreground'
-                }
-              >
-                {name}
-              </li>
-            ))}
-          </ul>
-        </div>
+            Only when a gate actually changed hands. Levels that add none used
+            to show `level.target` here to keep every card the same shape, which
+            meant printing "You built Toggle1" — a variable name, and no answer
+            to a question anyone was asking. A missing block is better than a
+            block with nothing in it. */}
+        {gained && (
+          <div className="mt-5">
+            <p className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+              Your gates
+            </p>
+            <ul className="flex flex-wrap gap-1.5">
+              {owned.map((name) => (
+                <li
+                  key={name}
+                  className={
+                    unlocked.includes(name)
+                      ? 'rounded border border-emerald-600/40 bg-emerald-500/10 px-2 py-1 font-mono text-xs font-medium text-emerald-600 dark:text-emerald-400'
+                      : 'rounded border border-border px-2 py-1 font-mono text-xs text-muted-foreground'
+                  }
+                >
+                  {name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {/* One action. Going back to the circuit to beat par is still there —
             the dialog closes on its X, on Escape and on a click outside — but

--- a/apps/game/src/components/LevelIntro.tsx
+++ b/apps/game/src/components/LevelIntro.tsx
@@ -42,7 +42,7 @@ export function LevelIntro({
           <DialogTitle className="text-2xl leading-tight">{level.intro.headline}</DialogTitle>
         </DialogHeader>
 
-        <DialogDescription className="mt-4 text-sm leading-relaxed text-muted-foreground">
+        <DialogDescription className="mt-4 whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
           {level.intro.body}
         </DialogDescription>
 

--- a/apps/game/src/components/LevelIntro.tsx
+++ b/apps/game/src/components/LevelIntro.tsx
@@ -1,0 +1,61 @@
+/**
+ * A level's one-time explainer.
+ *
+ * For the moment a band introduces something the player cannot find on screen.
+ * The clock is the case that forced it: at Toggle a flip-flop starts advancing
+ * on edges the player never wires, from a clock they never placed, driven by
+ * controls that appear for the first time in the campaign. Everything else in
+ * the game is discoverable by reading the diagram; that is not.
+ *
+ * Shown before the level rather than after, unlike `LevelComplete` — this is
+ * the thing you need in order to start.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@simten/ui/primitives/dialog';
+import type { Level } from '../game/types';
+
+export function LevelIntro({
+  level,
+  open,
+  onDismiss,
+}: {
+  level: Level;
+  open: boolean;
+  onDismiss: () => void;
+}) {
+  if (!level.intro) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onDismiss()}>
+      <DialogContent className="gap-0 sm:max-w-lg">
+        <DialogHeader className="space-y-2">
+          <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Something new
+          </p>
+          <DialogTitle className="text-2xl leading-tight">{level.intro.headline}</DialogTitle>
+        </DialogHeader>
+
+        <DialogDescription className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          {level.intro.body}
+        </DialogDescription>
+
+        <DialogFooter className="mt-6">
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+          >
+            Got it
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/game/src/components/LevelIntro.tsx
+++ b/apps/game/src/components/LevelIntro.tsx
@@ -46,6 +46,20 @@ export function LevelIntro({
           {level.intro.body}
         </DialogDescription>
 
+        {level.intro.link && (
+          <p className="mt-4 text-xs text-muted-foreground">
+            Read more:{' '}
+            <a
+              href={level.intro.link.href}
+              target="_blank"
+              rel="noreferrer"
+              className="text-foreground underline underline-offset-4"
+            >
+              {level.intro.link.label} ↗
+            </a>
+          </p>
+        )}
+
         <DialogFooter className="mt-6">
           <button
             type="button"

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -600,8 +600,12 @@ export default circuit('DLatch1', {
     allowed: ['Nand', 'DFlipFlop'],
     sequential: true,
     intro: {
-      headline: 'You have a clock now',
-      body: 'A flip-flop only changes on a clock edge — and you never wire the clock up, because every sequential circuit gets one. The controls under the canvas are it. Tick advances a single edge, Run does it continuously, and between edges nothing in your circuit moves.',
+      headline: 'Now there is a clock',
+      body: 'Everything so far reacted to its switches straight away: flip one and the answer changed. A flip-flop is different. It only reads its input at the moment the clock ticks, and ignores it in between. That moment is called an edge. You never wire the clock up, because every circuit with memory gets one, and the controls under the canvas are it. Tick moves it forward by one edge.',
+      link: {
+        label: 'Sequential logic',
+        href: 'https://en.wikipedia.org/wiki/Sequential_logic',
+      },
     },
     stub: `// A flip-flop is memory with a clock.
 //

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -599,6 +599,10 @@ export default circuit('DLatch1', {
     outputs: ['q'],
     allowed: ['Nand', 'DFlipFlop'],
     sequential: true,
+    intro: {
+      headline: 'You have a clock now',
+      body: 'A flip-flop only changes on a clock edge — and you never wire the clock up, because every sequential circuit gets one. The controls under the canvas are it. Tick advances a single edge, Run does it continuously, and between edges nothing in your circuit moves.',
+    },
     stub: `// A flip-flop is memory with a clock.
 //
 // Your latch followed \`d\` the whole time \`en\` was high. A D

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -600,8 +600,11 @@ export default circuit('DLatch1', {
     allowed: ['Nand', 'DFlipFlop'],
     sequential: true,
     intro: {
-      headline: 'Now there is a clock',
-      body: 'Everything so far reacted to its switches straight away: flip one and the answer changed. A flip-flop is different. It only reads its input at the moment the clock ticks, and ignores it in between. That moment is called an edge. You never wire the clock up, because every circuit with memory gets one, and the controls under the canvas are it. Tick moves it forward by one edge.',
+      headline: 'Sequential circuits',
+      body:
+        'Everything so far reacted to its inputs straight away: flip one and the output updates instantly.\n\n' +
+        'A flip-flop is different. It only reads its input at the moment the clock ticks, and ignores it in between. That moment is called an edge.\n\n' +
+        'Simten runs on a single clock and implicitly wires it to every sequential component, so there is nothing for you to connect. Use the clock controls at the bottom of the screen to step through clock cycles and check your circuit runs as you expect.',
       link: {
         label: 'Sequential logic',
         href: 'https://en.wikipedia.org/wiki/Sequential_logic',

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -593,7 +593,7 @@ export default circuit('DLatch1', {
     title: 'Toggle',
     tagline: 'Alternate the lamp between on and off, every tick.',
     brief:
-      'This one has no switches. The lamp flips on its own, once per clock tick, forever. Your latch held a value until something changed it; this has to change itself, which means feeding its own output back in through something that flips it.',
+      'This one has no switches. The lamp alternates on its own, once per clock tick, forever. Your latch held a value until you changed it; this has to change itself, by feeding back the opposite of whatever it currently holds.',
     target: 'Toggle1',
     inputs: [],
     outputs: ['q'],
@@ -601,10 +601,15 @@ export default circuit('DLatch1', {
     sequential: true,
     stub: `// A flip-flop is memory with a clock.
 //
-// Your latch changed the instant its inputs did. A D flip-flop
-// only looks at \`d\` on a clock edge, and holds it steady until
-// the next one — so what it stores this tick is what \`d\` was
-// last tick.
+// Your latch followed \`d\` the whole time \`en\` was high. A D
+// flip-flop only looks at \`d\` on a clock edge, and holds it
+// steady until the next one — so what it stores this tick is
+// what \`d\` was last tick.
+//
+// Your latch could not do this. Wire its output back to its
+// own input and, while \`en\` was high, the loop would run as
+// fast as the gates allow. Looking once, on the edge, is what
+// turns that race into a single flip.
 //
 // \`dff.q\` is what it currently holds. \`dff.d\` is what it
 // will hold next. Give it the opposite of what it has and it

--- a/apps/game/src/game/storage.ts
+++ b/apps/game/src/game/storage.ts
@@ -62,6 +62,15 @@ export function writeStored<T>(key: string, data: T): void {
 /** Whether the player has already been shown what this is. */
 export const INTRO_SEEN_KEY = 'simten:game:intro-seen';
 
+/**
+ * Levels whose one-time explainer has been shown.
+ *
+ * Separate from `INTRO_SEEN_KEY`, which is the whole game's front door. This is
+ * per level and per concept: a band that introduces something the player has
+ * never met — a clock, say — says so once and then stops.
+ */
+export const LEVEL_INTROS_KEY = 'simten:game:level-intros-seen';
+
 /** Every level's editor contents, whether or not it has ever passed. */
 export const DRAFTS_KEY = 'simten:game:drafts';
 
@@ -109,6 +118,19 @@ export function clearDraft(levelId: string): void {
   const drafts = readDrafts();
   delete drafts[levelId];
   writeStored<Drafts>(DRAFTS_KEY, drafts);
+}
+
+/** Level ids whose explainer has already been shown. */
+export function readSeenIntros(): string[] {
+  const seen = readStored<string[]>(LEVEL_INTROS_KEY, []);
+  return Array.isArray(seen) ? seen : [];
+}
+
+/** Record that a level's explainer has been shown. Idempotent. */
+export function markIntroSeen(levelId: string): void {
+  const seen = readSeenIntros();
+  if (seen.includes(levelId)) return;
+  writeStored(LEVEL_INTROS_KEY, [...seen, levelId]);
 }
 
 export function readProgress(): Progress {

--- a/apps/game/src/game/types.ts
+++ b/apps/game/src/game/types.ts
@@ -69,6 +69,15 @@ export interface Level {
    * never need excluding.
    */
   allowed: string[];
+  /**
+   * A one-time explainer, shown on first arrival at this level.
+   *
+   * For a band that introduces something the player has never met and cannot
+   * discover from the brief — the clock arrives this way, with no wire to
+   * connect and no gate to place, so nothing on screen would otherwise account
+   * for it. Shown once, then never again.
+   */
+  intro?: { headline: string; body: string };
   /** Starting source in the editor. */
   stub: string;
   /**

--- a/apps/game/src/game/types.ts
+++ b/apps/game/src/game/types.ts
@@ -77,7 +77,15 @@ export interface Level {
    * connect and no gate to place, so nothing on screen would otherwise account
    * for it. Shown once, then never again.
    */
-  intro?: { headline: string; body: string };
+  intro?: {
+    headline: string;
+    body: string;
+    /**
+     * Somewhere to read more. Kept as data rather than markup so a level stays
+     * plain JSON — see the note at the top of this file.
+     */
+    link?: { label: string; href: string };
+  };
   /** Starting source in the editor. */
   stub: string;
   /**

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -32,6 +32,7 @@ import { Network, RotateCcw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DesktopOnly } from '../components/DesktopOnly';
 import { LevelComplete } from '../components/LevelComplete';
+import { LevelIntro } from '../components/LevelIntro';
 import { Logo } from '../components/Logo';
 import { MobileNotice } from '../components/MobileNotice';
 import { SpecPanel } from '../components/SpecPanel';
@@ -39,7 +40,14 @@ import { forbiddenPrimitives, grade, permittedFor } from '../game/grade';
 import { nameDiagnostics } from '../game/level-name';
 import { LEVELS_BY_ID, nextLevel } from '../game/levels';
 import { sandboxRuntime } from '../game/runtime';
-import { clearDraft, readDrafts, writeDraft, writeProgress } from '../game/storage';
+import {
+  clearDraft,
+  markIntroSeen,
+  readDrafts,
+  readSeenIntros,
+  writeDraft,
+  writeProgress,
+} from '../game/storage';
 import type { GradeResult, Level } from '../game/types';
 import { useVictoryRun } from '../game/useVictoryRun';
 import { SITE_URL } from './__root';
@@ -166,6 +174,24 @@ function PlayLevel({ level }: { level: Level }) {
   // Closing the completion dialog must not immediately reopen it, but a fresh
   // submit should bring it back.
   const [completeDismissed, setCompleteDismissed] = useState(false);
+
+  /**
+   * The level's one-time explainer, opened after mount.
+   *
+   * Read in an effect rather than an initialiser for the reason the map route
+   * documents for its own storage-derived state: reading during render would
+   * either mismatch hydration or flash the dialog at someone who has already
+   * dismissed it.
+   */
+  const [introOpen, setIntroOpen] = useState(false);
+  useEffect(() => {
+    if (level.intro && !readSeenIntros().includes(level.id)) setIntroOpen(true);
+  }, [level.id, level.intro]);
+
+  const dismissIntro = useCallback(() => {
+    markIntroSeen(level.id);
+    setIntroOpen(false);
+  }, [level.id]);
 
   /**
    * Store the draft, a beat after typing stops.
@@ -561,6 +587,8 @@ function PlayLevel({ level }: { level: Level }) {
           whatever the modal setting says. Outside interaction does not dismiss
           it either: clicking a switch is not a request to close the spec.
           Focus stays where it was, so opening this never interrupts typing. */}
+      <LevelIntro level={level} open={introOpen} onDismiss={dismissIntro} />
+
       {result?.status === 'pass' && (
         <LevelComplete
           // Held back until the victory run has finished demonstrating the


### PR DESCRIPTION
#334 merged only its first commit. The D Latch level reached `main`; the five commits after it did not. Cherry-picked here unchanged.

**The clock explainer.** A one-time dialog on the Toggle level — the first and only level where a clock exists, since both latches are combinational feedback and register as non-sequential. It answers the three questions a learner actually has there: where a clock came from, why they never wired one, and what the new row of controls is. Links out to sequential logic. `Level.intro` is optional and tracked per level, so it is a general mechanism with exactly one user today.

**Toggle's copy** now says why the flip-flop exists rather than just introducing it: your own latch could not do this, because while `en` was high the loop would race, and looking once on the edge is what turns that race into a single flip.

**The reward block** only renders when a gate actually changed hands. Levels that unlock none used to print `level.target` to keep every card the same shape — which meant showing "You built Toggle1", a variable name and no answer to a question anyone was asking.

## Verification

Driven in a browser:

- The explainer shows on first arrival at Toggle, persists its dismissal across a reload, and does not appear on D Latch even with the seen-flag cleared.
- The D Latch card shows `YOUR GATES / Nand / DFlipFlop` with the new one highlighted; the Toggle card shows no block and no stray identifier.

`pnpm test`, `pnpm typecheck`, `pnpm biome ci` clean.