### PR TITLE
One header for both pages, and the sequential explainer rewritten

### DIFF
--- a/apps/game/src/components/HeaderBar.tsx
+++ b/apps/game/src/components/HeaderBar.tsx
@@ -1,0 +1,58 @@
+/**
+ * The bar across the top of every page in the game.
+ *
+ * Owns two things the map and a level kept getting slightly wrong between
+ * them: the bar's height, and the brand at its left edge.
+ *
+ * Height is fixed here rather than left to padding and whatever is inside. Both
+ * pages had identical padding and still came out two pixels apart, because a
+ * header sizes itself to its tallest child and one of them holds buttons while
+ * the other holds text. Navigating between them nudged the whole page.
+ *
+ * The brand is rendered here for the same reason. It was written out twice, and
+ * the two copies drifted: a 22px mark beside 16px text on the map, a 20px mark
+ * beside 14px text on a level.
+ *
+ * A component rather than a shared class string, so neither can be edited
+ * without the other.
+ */
+
+import { Link } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+import { Logo } from './Logo';
+
+export function HeaderBar({
+  children,
+  /**
+   * Link the brand back to the map. Off on the map itself, where it would be a
+   * link to the page you are already looking at.
+   */
+  linkHome = false,
+}: {
+  children: ReactNode;
+  linkHome?: boolean;
+}) {
+  const brand = (
+    <>
+      <Logo size={20} />
+      <span className="text-sm font-semibold tracking-tight">Simten</span>
+    </>
+  );
+
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
+      {linkHome ? (
+        <Link
+          to="/"
+          aria-label="Simten — home"
+          className="flex shrink-0 items-center gap-2 text-foreground no-underline transition-colors hover:text-foreground/80"
+        >
+          {brand}
+        </Link>
+      ) : (
+        <span className="flex shrink-0 items-center gap-2 text-foreground">{brand}</span>
+      )}
+      {children}
+    </header>
+  );
+}

--- a/apps/game/src/components/LevelIntro.tsx
+++ b/apps/game/src/components/LevelIntro.tsx
@@ -21,6 +21,29 @@ import {
 } from '@simten/ui/primitives/dialog';
 import type { Level } from '../game/types';
 
+/**
+ * `**bold**`, and nothing else.
+ *
+ * A level is data that could be fetched as plain JSON, so its copy stays a
+ * string rather than becoming markup — but the two words this dialog exists to
+ * teach deserve to stand out from the paragraph explaining them. One delimiter,
+ * parsed here, is cheaper than a markdown dependency and cannot grow into one
+ * by accident.
+ */
+function withEmphasis(text: string) {
+  return text.split(/\*\*(.+?)\*\*/g).map((part, i) =>
+    // Odd indices are the captured groups, so they are the emphasised runs.
+    i % 2 === 1 ? (
+      // biome-ignore lint/suspicious/noArrayIndexKey: position is the identity in a split string
+      <strong key={i} className="font-semibold text-foreground">
+        {part}
+      </strong>
+    ) : (
+      part
+    ),
+  );
+}
+
 export function LevelIntro({
   level,
   open,
@@ -43,7 +66,7 @@ export function LevelIntro({
         </DialogHeader>
 
         <DialogDescription className="mt-4 whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
-          {level.intro.body}
+          {withEmphasis(level.intro.body)}
         </DialogDescription>
 
         {level.intro.link && (

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -602,9 +602,10 @@ export default circuit('DLatch1', {
     intro: {
       headline: 'Sequential circuits',
       body:
-        'Everything so far reacted to its inputs straight away: flip one and the output updates instantly.\n\n' +
-        'A flip-flop is different. It only reads its input at the moment the clock ticks, and ignores it in between. That moment is called an edge.\n\n' +
-        'Simten runs on a single clock and implicitly wires it to every sequential component, so there is nothing for you to connect. Use the clock controls at the bottom of the screen to step through clock cycles and check your circuit runs as you expect.',
+        'Everything so far has been **combinational**: the output depends only on the inputs right now. Flip one, the output follows instantly.\n\n' +
+        "A flip-flop is **sequential**. It watches a clock, a signal ticking steadily on and off, and only looks at its input at the instant the clock goes from off to on. That instant is called a rising edge. In between, it ignores its input and holds the value it captured. That's memory: your circuit can now remember something.\n\n" +
+        "Simten runs on a single clock and wires it to every sequential component for you, so there's nothing to connect. The wire is real; it is just handled, the same way it is in real hardware design. Every flip-flop in your circuit ticks on the same edge, at the same moment.\n\n" +
+        'Use the clock controls at the bottom to step one cycle at a time and watch the output change only on the tick.',
       link: {
         label: 'Sequential logic',
         href: 'https://en.wikipedia.org/wiki/Sequential_logic',

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -31,11 +31,12 @@ import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { Network, RotateCcw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DesktopOnly } from '../components/DesktopOnly';
+import { HeaderBar } from '../components/HeaderBar';
 import { LevelComplete } from '../components/LevelComplete';
 import { LevelIntro } from '../components/LevelIntro';
-import { Logo } from '../components/Logo';
 import { MobileNotice } from '../components/MobileNotice';
 import { SpecPanel } from '../components/SpecPanel';
+import ThemeToggle from '../components/ThemeToggle';
 import { forbiddenPrimitives, grade, permittedFor } from '../game/grade';
 import { nameDiagnostics } from '../game/level-name';
 import { LEVELS_BY_ID, nextLevel } from '../game/levels';
@@ -381,16 +382,7 @@ function PlayLevel({ level }: { level: Level }) {
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-gray-50 dark:bg-[#111113]">
-      <header className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2">
-        {/* Same brand lockup as apps/web's SiteHeader: mark, then wordmark. */}
-        <Link
-          to="/"
-          aria-label="Simten — home"
-          className="flex shrink-0 items-center gap-2 text-foreground no-underline transition-colors hover:text-foreground/80"
-        >
-          <Logo size={20} />
-          <span className="text-sm font-semibold tracking-tight">Simten</span>
-        </Link>
+      <HeaderBar linkHome>
         <div className="h-5 w-px bg-border" />
         <span className="shrink-0 text-sm font-semibold text-foreground/80">{level.title}</span>
         {/* The brief is read once and then ignored, so it belongs here rather
@@ -439,7 +431,10 @@ function PlayLevel({ level }: { level: Level }) {
           <button
             type="button"
             onClick={() => setSpecOpen((v) => !v)}
-            className="whitespace-nowrap rounded-md border border-border px-3 py-1.5 text-xs font-medium"
+            // A floor wide enough for the longer of its two labels. Without it
+            // the button resizes as the word changes and shoves everything to
+            // its right along, which makes a toggle look like a layout bug.
+            className="min-w-[5.5rem] whitespace-nowrap rounded-md border border-border px-3 py-1.5 text-xs font-medium"
           >
             {specOpen ? 'Hide spec' : 'Show spec'}
           </button>
@@ -451,8 +446,9 @@ function PlayLevel({ level }: { level: Level }) {
           >
             {submitting ? 'Checking…' : 'Submit'}
           </button>
+          <ThemeToggle />
         </div>
-      </header>
+      </HeaderBar>
 
       <div className="min-h-0 flex-1">
         <ResizablePanelGroup>

--- a/apps/game/src/routes/index.tsx
+++ b/apps/game/src/routes/index.tsx
@@ -13,10 +13,10 @@
 
 import { createFileRoute } from '@tanstack/react-router';
 import { useCallback, useEffect, useState } from 'react';
+import { HeaderBar } from '../components/HeaderBar';
 import { IntroDialog } from '../components/IntroDialog';
 import { LevelDrilldown } from '../components/LevelDrilldown';
 import { LevelMap } from '../components/LevelMap';
-import { Logo } from '../components/Logo';
 import ThemeToggle from '../components/ThemeToggle';
 import { LEVELS_BY_ID } from '../game/levels';
 import { type Drafts, INTRO_SEEN_KEY, readDrafts, readProgress, readStored } from '../game/storage';
@@ -83,11 +83,7 @@ function MapPage() {
 
   return (
     <div className="flex h-screen flex-col">
-      <header className="flex items-center gap-3 border-b border-border px-4 py-2">
-        <span className="flex items-center gap-2 text-foreground">
-          <Logo size={22} />
-          <span className="font-semibold tracking-tight">Simten</span>
-        </span>
+      <HeaderBar>
         <span className="text-sm text-muted-foreground">Build a computer</span>
         <div className="ml-auto flex items-center gap-3">
           <button
@@ -99,7 +95,7 @@ function MapPage() {
           </button>
           <ThemeToggle />
         </div>
-      </header>
+      </HeaderBar>
 
       <main className="min-h-0 flex-1">
         <LevelMap solved={solved} onHoverLevel={onHoverLevel} onExpandLevel={onExpandLevel} />


### PR DESCRIPTION
Two unrelated fixes, one commit each.

## The header

The map and a level had headers two pixels apart, with a different logo size and a different wordmark size. Both had identical padding — the difference was that a header sizes itself to its tallest child, and one held buttons while the other held text. Navigating between them nudged the page.

Both now render a `HeaderBar` that owns the geometry and the brand, so the two cannot drift again by someone editing one copy:

| | before | after |
|---|---|---|
| map header | 45px | 48px |
| level header | 47px | 48px |
| logo | 22 vs 20 | 20 |
| wordmark | 16px/400 vs 14px/600 | 14px/600 |

Also: levels now have the theme toggle the map already had, and the spec toggle has a width floor. It was 81px reading "Hide spec" and 88px reading "Show spec", so clicking it shoved everything to its right along by 7px. Verified at 88px in both states with the neighbouring button's x unchanged.

## The explainer

The clock dialog's copy, rewritten. It leads on the distinction the level exists to teach, defines a rising edge in passing rather than assuming it, and says plainly that Simten wires the clock for you and that the wire is real. `**combinational**` and `**sequential**` are emphasised, which needed a six-line `**bold**` parser in the intro renderer — a level stays a plain string that could be fetched as JSON, so the alternative was markup in the data.

## Verification

Measured in a browser on both pages: heights, logo, wordmark size and weight all match; the spec button holds 88px across both labels and its neighbour does not move.

`pnpm test`, `pnpm typecheck`, `pnpm biome ci` clean.