### PR TITLE
Stop $display and unused child clocks failing an import

### DIFF
--- a/.changeset/olive-jars-shake.md
+++ b/.changeset/olive-jars-shake.md
@@ -1,0 +1,27 @@
+---
+'@simten/core': patch
+---
+
+Stop two things that are not clock problems from failing a whole import.
+
+A port is treated as the module's clock when every consumer of its net is a
+clock pin. Two unrelated things could make that test fail:
+
+A `$display` in a clocked block. Yosys lowers it to a `$print` cell whose
+trigger hangs off the clock net. The importer already dropped those when
+lifting, so counting them as data consumers first was simply inconsistent — a
+debug statement should not decide what a clock is.
+
+A submodule taking a clock it never reads. With no consumers the port never
+classified, and because a parent's clock is only recognised when every consumer
+is a clock pin, one unused input disqualified the clock of every module above
+it. A port the child never reads argues neither way, so it no longer counts
+against the parent.
+
+Both were found by importing the NES core from `strigeus/fpganes`. Its simplest
+mapper takes a `clk` it has no use for, and the PPU and several mappers log with
+`$display`; between them the import failed outright. It now imports — 116
+circuits, 5972 nodes — and simulates, on unmodified upstream sources.
+
+Tested behaviourally: a register that latched every tick regardless of the clock
+would satisfy a structural check just as happily.

--- a/packages/core/src/import/__fixtures__/clock-classification.json
+++ b/packages/core/src/import/__fixtures__/clock-classification.json
@@ -1,0 +1,192 @@
+{
+  "creator": "Yosys 0.64 (git sha1 d8dab5b32666564eca8e18f412973853ce006e61, clang++ 21.0.0 -fPIC -O3)",
+  "modules": {
+    "clock_classification": {
+      "attributes": {
+        "keep": "00000000000000000000000000000001",
+        "top": "00000000000000000000000000000001",
+        "src": "clock-classification.v:18.1-31.10"
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [2]
+        },
+        "d": {
+          "direction": "input",
+          "bits": [3, 4, 5, 6, 7, 8, 9, 10]
+        },
+        "latched": {
+          "direction": "output",
+          "bits": [11, 12, 13, 14, 15, 16, 17, 18]
+        },
+        "inverted": {
+          "direction": "output",
+          "bits": [19, 20, 21, 22, 23, 24, 25, 26]
+        }
+      },
+      "cells": {
+        "$display$0x77a858078:29$3": {
+          "hide_name": 1,
+          "type": "$print",
+          "parameters": {
+            "ARGS_WIDTH": "00000000000000000000000000001000",
+            "FORMAT": "latched {8:>02h-u}\n",
+            "PRIORITY": "11111111111111111111111111111111",
+            "TRG_ENABLE": "00000000000000000000000000000001",
+            "TRG_POLARITY": "1",
+            "TRG_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "clock-classification.v:29.9-29.35"
+          },
+          "port_directions": {
+            "ARGS": "input",
+            "EN": "input",
+            "TRG": "input"
+          },
+          "connections": {
+            "ARGS": [3, 4, 5, 6, 7, 8, 9, 10],
+            "EN": ["1"],
+            "TRG": [2]
+          }
+        },
+        "$procdff$5": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "clock-classification.v:27.5-30.8"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [2],
+            "D": [3, 4, 5, 6, 7, 8, 9, 10],
+            "Q": [11, 12, 13, 14, 15, 16, 17, 18]
+          }
+        },
+        "child": {
+          "hide_name": 0,
+          "type": "passthrough",
+          "parameters": {},
+          "attributes": {
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "clock-classification.v:24.17-24.55"
+          },
+          "port_directions": {
+            "clk": "input",
+            "d": "input",
+            "q": "output"
+          },
+          "connections": {
+            "clk": [2],
+            "d": [3, 4, 5, 6, 7, 8, 9, 10],
+            "q": [19, 20, 21, 22, 23, 24, 25, 26]
+          }
+        }
+      },
+      "netnames": {
+        "clk": {
+          "hide_name": 0,
+          "bits": [2],
+          "attributes": {
+            "src": "clock-classification.v:19.22-19.25"
+          }
+        },
+        "d": {
+          "hide_name": 0,
+          "bits": [3, 4, 5, 6, 7, 8, 9, 10],
+          "attributes": {
+            "src": "clock-classification.v:20.22-20.23"
+          }
+        },
+        "inverted": {
+          "hide_name": 0,
+          "bits": [19, 20, 21, 22, 23, 24, 25, 26],
+          "attributes": {
+            "src": "clock-classification.v:22.22-22.30"
+          }
+        },
+        "latched": {
+          "hide_name": 0,
+          "bits": [11, 12, 13, 14, 15, 16, 17, 18],
+          "attributes": {
+            "init": "00000000",
+            "src": "clock-classification.v:21.22-21.29"
+          }
+        }
+      }
+    },
+    "passthrough": {
+      "attributes": {
+        "src": "clock-classification.v:10.1-16.10"
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [2]
+        },
+        "d": {
+          "direction": "input",
+          "bits": [3, 4, 5, 6, 7, 8, 9, 10]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [11, 12, 13, 14, 15, 16, 17, 18]
+        }
+      },
+      "cells": {
+        "$not$clock-classification.v:15$1": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000001000",
+            "Y_WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "clock-classification.v:15.16-15.18"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [3, 4, 5, 6, 7, 8, 9, 10],
+            "Y": [11, 12, 13, 14, 15, 16, 17, 18]
+          }
+        }
+      },
+      "netnames": {
+        "clk": {
+          "hide_name": 0,
+          "bits": [2],
+          "attributes": {
+            "src": "clock-classification.v:11.18-11.21"
+          }
+        },
+        "d": {
+          "hide_name": 0,
+          "bits": [3, 4, 5, 6, 7, 8, 9, 10],
+          "attributes": {
+            "src": "clock-classification.v:12.18-12.19"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [11, 12, 13, 14, 15, 16, 17, 18],
+          "attributes": {
+            "src": "clock-classification.v:13.18-13.19"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/import/__fixtures__/clock-classification.v
+++ b/packages/core/src/import/__fixtures__/clock-classification.v
@@ -1,0 +1,31 @@
+// Two things that used to fail the clock check even though neither is a clock
+// problem at all.
+//
+// `passthrough` takes a `clk` it never reads — NES mappers do this, and a port
+// with no consumers used to count against the parent's clock.
+//
+// The `$display` becomes a `$print` cell whose trigger hangs off the clock net.
+// It is already dropped when lifting, but it used to count as a data consumer
+// of `clk` first, which failed the import over a debug statement.
+module passthrough (
+    input        clk,          // deliberately unused
+    input  [7:0] d,
+    output [7:0] q
+);
+    assign q = ~d;
+endmodule
+
+module clock_classification (
+    input            clk,
+    input      [7:0] d,
+    output reg [7:0] latched,
+    output     [7:0] inverted
+);
+    passthrough child (.clk(clk), .d(d), .q(inverted));
+
+    initial latched = 8'd0;
+    always @(posedge clk) begin
+        latched <= d;
+        $display("latched %h", d);
+    end
+endmodule

--- a/packages/core/src/import/__tests__/import-clock-classification.test.ts
+++ b/packages/core/src/import/__tests__/import-clock-classification.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Clock-port classification.
+ *
+ * A port is treated as the module's clock when every consumer of its net is a
+ * clock pin. Two things used to break that for reasons unrelated to clocking:
+ *
+ *   - a `$display` in a clocked block, which yosys lowers to a `$print` cell
+ *     whose trigger hangs off the clock net. The importer already drops those
+ *     when lifting, but they still counted as data consumers first.
+ *   - a submodule taking a clock it never reads, which left the port with no
+ *     consumers at all and so never classified — disqualifying the clock of
+ *     every module above it.
+ *
+ * Both were found by importing a real NES core (strigeus/fpganes), where the
+ * simplest mapper takes an unused `clk` and the PPU logs with `$display`.
+ * Between them they failed the whole import.
+ *
+ * The assertions are behavioural: a register that latched every tick regardless
+ * of the clock would satisfy a structural check just as happily.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { buildFromIR } from '../../circuit/index.js';
+import { simulate } from '../../sim/index.js';
+import type { YosysNetlist } from '../index.js';
+import { importNetlist } from '../index.js';
+
+function build() {
+  const netlist: YosysNetlist = JSON.parse(
+    readFileSync(new URL('../__fixtures__/clock-classification.json', import.meta.url), 'utf8'),
+  );
+  const result = importNetlist(netlist, 'clock_classification');
+  const deps = [...result.library.values()].filter((c) => c.name !== result.top.name);
+  return { result, sim: simulate(buildFromIR(result.top, deps) as never) };
+}
+
+describe('clock classification', () => {
+  it('imports a design that logs with $display and has an unused child clock', () => {
+    expect(() => build()).not.toThrow();
+  });
+
+  it('drops the clock port rather than leaving it as data', () => {
+    const { result } = build();
+    expect(result.top.inputs.map((p) => p.name)).not.toContain('clk');
+    expect(result.warnings.some((w) => w.includes("Dropped clock port 'clk'"))).toBe(true);
+  });
+
+  it('reports the dropped $display instead of swallowing it', () => {
+    const { result } = build();
+    expect(result.warnings.some((w) => /\$display/.test(w))).toBe(true);
+  });
+
+  it('the register still latches on the clock', () => {
+    const { sim } = build();
+    try {
+      sim.set({ d: 0x5a } as never);
+      sim.tick();
+      expect(sim.get('latched' as never)).toBe(0x5a);
+
+      // Changing d without a tick must not reach the register.
+      sim.set({ d: 0x11 } as never);
+      expect(sim.get('latched' as never)).toBe(0x5a);
+
+      sim.tick();
+      expect(sim.get('latched' as never)).toBe(0x11);
+    } finally {
+      sim.dispose();
+    }
+  });
+
+  it('the child with the unused clock still works', () => {
+    const { sim } = build();
+    try {
+      sim.set({ d: 0x0f } as never);
+      sim.tick();
+      // Combinational inverter: unaffected by the clock it never reads.
+      expect(sim.get('inverted' as never)).toBe(0xf0);
+    } finally {
+      sim.dispose();
+    }
+  });
+});

--- a/packages/core/src/import/import-netlist.ts
+++ b/packages/core/src/import/import-netlist.ts
@@ -558,6 +558,13 @@ interface ModuleShape {
 
 const DFF_FAMILY = new Set(['$dff', '$adff', '$sdff', '$dffe']);
 
+/** Cells that describe simulation output rather than hardware. `$print` is what
+ *  yosys lowers `$display` to, and it is already dropped when lifting — so it
+ *  must not get a say in what counts as a clock either. Its TRG pin hangs off
+ *  the clock net, and counting that as a data consumer stops the port being
+ *  recognised as a clock, which fails the whole import over a debug statement. */
+const SIMULATION_ONLY_CELLS = new Set(['$print', '$check']);
+
 /**
  * Reject flip-flops driven by a clock this model cannot represent.
  *
@@ -621,12 +628,18 @@ function isClockPin(
   cellType: string,
   pin: string,
   clockPortsByModule: Map<string, Set<string>>,
+  unusedPortsByModule?: Map<string, Set<string>>,
 ): boolean {
   if (cellType === '$dff' || cellType === '$adff' || cellType === '$sdff' || cellType === '$dffe')
     return pin === 'CLK';
   if (cellType === '$mem' || cellType === '$mem_v2') return pin === 'RD_CLK' || pin === 'WR_CLK';
   // Submodule instance: clock iff the child module identified this port as one.
-  return clockPortsByModule.get(cellType)?.has(pin) ?? false;
+  if (clockPortsByModule.get(cellType)?.has(pin)) return true;
+  // A port the child never reads argues neither way, so it must not be what
+  // stops the parent's clock from being recognised. NES mappers are the case in
+  // point: the simplest one takes a `clk` it has no use for, and treating that
+  // as a data consumer disqualified the clock of every module above it.
+  return unusedPortsByModule?.get(cellType)?.has(pin) ?? false;
 }
 
 /**
@@ -674,9 +687,13 @@ function moduleShapes(netlist: YosysNetlist): Map<string, ModuleShape> {
     string,
     { consumers: Map<string, Consumer[]>; feedsOutput: Set<string> }
   >();
+  /** Input ports no cell in the module reads. Dead either way, so they are never
+   *  the reason a parent's clock fails to be recognised. */
+  const unusedPortsByModule = new Map<string, Set<string>>();
   for (const [name, mod] of Object.entries(netlist.modules)) {
     const bitConsumers = new Map<number, Consumer[]>();
     for (const cell of Object.values(mod.cells)) {
+      if (SIMULATION_ONLY_CELLS.has(cell.type)) continue;
       for (const [pin, bits] of Object.entries(cell.connections)) {
         for (const b of bits) {
           if (typeof b !== 'number') continue;
@@ -708,6 +725,10 @@ function moduleShapes(netlist: YosysNetlist): Map<string, ModuleShape> {
       consumers.set(pn, acc);
     }
     analysis.set(name, { consumers, feedsOutput });
+    unusedPortsByModule.set(
+      name,
+      new Set([...consumers].filter(([, acc]) => acc.length === 0).map(([pn]) => pn)),
+    );
   }
 
   // Fixpoint: a submodule's clock ports aren't known until the child is resolved,
@@ -723,7 +744,9 @@ function moduleShapes(netlist: YosysNetlist): Map<string, ModuleShape> {
       const cp = clockPortsByModule.get(name)!;
       for (const [pn, cons] of consumers) {
         if (cp.has(pn) || feedsOutput.has(pn) || cons.length === 0) continue;
-        if (cons.every((c) => isClockPin(c.cellType, c.pin, clockPortsByModule))) {
+        if (
+          cons.every((c) => isClockPin(c.cellType, c.pin, clockPortsByModule, unusedPortsByModule))
+        ) {
           cp.add(pn);
           changed = true;
         }


### PR DESCRIPTION
A port is treated as the module's clock when every consumer of its net is a clock pin. Two unrelated things could make that test fail.

**A `$display` in a clocked block.** Yosys lowers it to a `$print` cell whose trigger hangs off the clock net. The importer already dropped those when lifting, so counting them as data consumers first was simply inconsistent — a debug statement should not decide what a clock is.

**A submodule taking a clock it never reads.** With no consumers the port never classified, and since a parent's clock is only recognised when every consumer is a clock pin, one unused input disqualified the clock of every module above it.

Both were found by importing the NES core from `strigeus/fpganes`. Its simplest mapper takes a `clk` it has no use for, and the PPU and several mappers log with `$display`; between them the import failed outright.

It now imports on unmodified upstream sources:

```
IMPORT OK in 0.1s — 116 circuits, 5972 nodes
top: NES — 180 nodes, 315 connections
```

and simulates, with the PPU advancing (cycle 295, scanline 5 after 2000 ticks).

Five tests, all behavioural — a register that latched every tick regardless of the clock would satisfy a structural check just as happily. All five fail on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)