### PR TITLE
Make eval-only stdlib primitives drillable on the canvas

### DIFF
--- a/.changeset/nervous-pans-attend.md
+++ b/.changeset/nervous-pans-attend.md
@@ -1,0 +1,38 @@
+---
+'@simten/core': minor
+'@simten/ui': minor
+---
+
+Make eval-only stdlib primitives drillable on the canvas.
+
+All 51 stdlib primitives are eval-only, so `Adder(16)`, `Mux(16)` and
+`Comparator(16)` were dead ends: double-clicking one did nothing. That
+contradicts the README — "any component can be opened up and shown as what it is
+made of" — and a reader following the drill-down hit a wall at the first piece of
+arithmetic.
+
+The fix is not to make them composites. The synth voice is 18 nodes at ~78k
+ticks/s; all-gates it is ~2,000 nodes at ~700 ticks/s, too slow for the audio
+demo to run at all. Verilog export would degrade from `assign sum = a + b + c` to
+a thousand structural assigns, which is worse for Verilator and denies Yosys the
+chance to infer an adder and map it to the target's carry chain.
+
+Instead `MADE_OF` holds a gate-level build per primitive, keyed by name, built
+from the node's own arguments so `Adder({width: 16})` opens 16 stages and
+`Adder({width: 8})` opens 8. It is display only — constructed on demand for a
+dialog that runs its own simulator, never elaborated into the running netlist, so
+it costs nothing until someone drills. Covers Adder, Subtractor, Incrementer, Mux
+and Comparator; skips Multiplier/Divider (a 256-adder array teaches nothing) and
+memory (ROM/RAM map to hardened blocks, so a gate build would misrepresent them).
+
+Each level stays small because it is hierarchical: `Adder(16)` is 16 FullAdders,
+and a FullAdder is five gates. `FullAdder` is new to the stdlib.
+
+Two descriptions of addition maintained by hand can drift, so they are proven not
+to: `made-of.verify.ts` walks every entry, reads its primitive's port widths, and
+sweeps the whole input space — exhaustive at widths 1, 2 and 8 (2^17 cases for an
+adder), sampled at 16. Every diagram is proven to compute what the primitive it
+explains computes.
+
+The builds stop at Xor/And/Or/Not. The game already teaches NAND to gates level
+by level; this covers gates to arithmetic.

--- a/apps/game/src/components/LevelDrilldown.tsx
+++ b/apps/game/src/components/LevelDrilldown.tsx
@@ -20,7 +20,6 @@
  * shows what the shape of an answer looks like.
  */
 
-import type { Circuit } from '@simten/core';
 import { useCompiledCircuit } from '@simten/embed';
 import { CompositeInspectorDialog, type InspectorFrame } from '@simten/ui/canvas';
 import { useCallback, useEffect, useState } from 'react';
@@ -74,8 +73,8 @@ export function LevelDrilldown({ level, draft, expanded, onCloseExpanded }: Leve
     }
   }, [expanded, preview.circuit, level.title]);
 
-  const onPushLevel = useCallback((componentName: string, def: Circuit, nodeLabel: string) => {
-    setStack((s) => [...s, { componentName, componentDef: def, nodeLabel }]);
+  const onPushLevel = useCallback((frame: InspectorFrame) => {
+    setStack((s) => [...s, frame]);
   }, []);
 
   const onPopLevel = useCallback(() => setStack((s) => s.slice(0, -1)), []);

--- a/apps/web/src/features/learn/adders/circuits.ts
+++ b/apps/web/src/features/learn/adders/circuits.ts
@@ -5,12 +5,13 @@
  * works, extending it to a full adder with carry-in, then chaining N of them
  * in a ripple-carry configuration to make the depth problem visible.
  *
- * TODO: every circuit below is a stub. Replace each with a real definition
- * that exercises the concept the corresponding section is teaching.
+ * HalfAdder, FullAdder and RippleCarryDemo are real. DepthDemo and
+ * CarryLookaheadDemo are still stubs aliased to RippleCarryDemo — see the
+ * TODOs on each.
  */
 
 import { bit, circuit } from '@simten/core/circuit';
-import { Adder, And, Constant, HexDisplay, Input, Led, Or, Xor } from '@simten/core/std';
+import { And, Concat, Constant, HexDisplay, Input, Led, Or, Slice, Xor } from '@simten/core/std';
 import type { BlogCircuit } from '@/features/blog/types';
 
 // ── Half adder ─────────────────────────────────────────────────────────
@@ -52,25 +53,41 @@ export const FullAdder = circuit('FullAdder', {
 });
 
 // ── Ripple-carry adder ─────────────────────────────────────────────────
-// TODO: 8 full-adders chained together. The schematic visibly elongates,
-// which is the whole pedagogical point. Replace this with a hand-wired
-// chain of 8 FullAdders rather than the stdlib Adder, so the depth is
-// visible in the canvas.
+// Eight of the FullAdder above, chained tail-to-head. Deliberately NOT the
+// stdlib `Adder`: that one is eval-only, so it draws as a single box and the
+// depth this section is about would be invisible. Wiring the chain by hand
+// makes the schematic elongate, which is the whole point.
+//
+// The Slice/Concat nodes are not gates — they are how this IR spells "take
+// bit i of a bus" and "put these bits back together", because a Connection
+// addresses a port, not a bit within one.
 const RippleCarryDemo = circuit('RippleCarry8', {
   nodes: {
     a: Input({ value: 0b00001111 }),
     b: Input({ value: 0b00000001 }),
-    add: Adder({ width: 8 }),
     zero: Constant({ value: 0 }),
+    aBit: Array.from({ length: 8 }, (_, i) => Slice({ inWidth: 8, offset: i, width: 1 })),
+    bBit: Array.from({ length: 8 }, (_, i) => Slice({ inWidth: 8, offset: i, width: 1 })),
+    fa: Array.from({ length: 8 }, () => FullAdder),
+    join: Array.from({ length: 7 }, (_, i) => Concat({ hiWidth: 1, loWidth: i + 1 })),
     sum: HexDisplay,
     cout: Led,
   },
-  connect: ({ nodes: { a, b, add, zero, sum, cout } }) => [
-    a.out.to(add.a),
-    b.out.to(add.b),
-    zero.out.to(add.carry_in),
-    add.sum.to(sum.in),
-    add.carry_out.to(cout.in),
+  connect: ({ nodes: { a, b, zero, aBit, bBit, fa, join, sum, cout } }) => [
+    ...aBit.map((s) => a.out.to(s.in)),
+    ...bBit.map((s) => b.out.to(s.in)),
+    ...aBit.map((s, i) => s.out.to(fa[i].a)),
+    ...bBit.map((s, i) => s.out.to(fa[i].b)),
+    // The chain: bit 0 starts from a hard zero, every later stage waits on the
+    // stage below it.
+    zero.out.to(fa[0].cin),
+    ...fa.slice(0, -1).map((stage, i) => stage.cout.to(fa[i + 1].cin)),
+    fa[7].cout.to(cout.in),
+    // Fold the sum bits back into one bus, LSB first.
+    fa[0].sum.to(join[0].low),
+    ...join.map((j, i) => fa[i + 1].sum.to(j.high)),
+    ...join.slice(0, -1).map((j, i) => j.out.to(join[i + 1].low)),
+    join[6].out.to(sum.in),
   ],
 });
 

--- a/packages/core/src/std/__tests__/made-of.test.ts
+++ b/packages/core/src/std/__tests__/made-of.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Guards for the gate-level reference builds.
+ *
+ * The load-bearing one is the containment suite. `STDLIB_CIRCUITS` materializes
+ * every exported function in the std modules by calling it with no arguments
+ * and keeping whatever returns a `BuiltCircuit` (see `_materialize` in
+ * `std/index.ts`). A `MADE_OF` builder called with no arguments returns exactly
+ * that, so exporting one bare from a std module — or adding `made-of.js` to
+ * `_allExports` — would silently register a second, structurally different
+ * "Adder" in the stdlib. Nothing else would fail; the canvas and the exporter
+ * would just start disagreeing about what an Adder is.
+ *
+ * Also spawns `made-of.verify.ts` so the equivalence proof runs in CI. It lives
+ * in a subprocess because the verify harness is a module singleton — one
+ * testbench per process.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { STDLIB_CIRCUITS } from '../index.js';
+import * as MadeOfModule from '../made-of.js';
+import { hasMadeOf, MADE_OF, MADE_OF_NAMES } from '../made-of.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../../../..');
+const stdDir = resolve(here, '..');
+
+const stdlibNames = STDLIB_CIRCUITS.map((c) => c.circuit.name);
+
+describe('MADE_OF containment', () => {
+  it('never leaks a reference build into STDLIB_CIRCUITS', () => {
+    // Every builder names its output `<Primitive><width>_madeOf`, so a leak is
+    // visible by name regardless of which module let it through.
+    const leaked = stdlibNames.filter((n) => n.endsWith('_madeOf'));
+    expect(leaked).toEqual([]);
+  });
+
+  it('exports nothing that survives _materialize', () => {
+    // The real guard. What makes a leak possible is not where the module sits
+    // in the import graph — it is whether the module exports a bare function
+    // that returns a BuiltCircuit when called with no arguments. This is
+    // `_materialize`'s exact predicate, applied to this module's public
+    // surface, so it fails the moment someone exports a builder directly
+    // (`export function adderMadeOf(...)`) whether or not index.ts changes.
+    const materializes = Object.entries(MadeOfModule).filter(([, v]) => {
+      if (typeof v !== 'function') return false;
+      try {
+        const built = (v as () => unknown)();
+        return !!built && typeof built === 'object' && 'circuit' in built;
+      } catch {
+        return false;
+      }
+    });
+    expect(materializes.map(([k]) => k)).toEqual([]);
+  });
+
+  it('produces exactly the circuits a bare export would leak', () => {
+    // Pin the mechanism the guard above protects against: these builders really
+    // do return a BuiltCircuit when called with no arguments, which is what
+    // `_materialize` does to every exported function.
+    for (const name of MADE_OF_NAMES) {
+      const built = MADE_OF[name]({}) as { circuit?: { name?: string } };
+      expect(built).toHaveProperty('circuit');
+      expect(built.circuit?.name).toMatch(/_madeOf$/);
+    }
+  });
+
+  it('keeps made-of.js out of the _allExports list in index.ts', () => {
+    // The behavioural checks above catch a leak after the fact; this catches
+    // the specific edit that would cause one.
+    const indexSrc = readFileSync(resolve(stdDir, 'index.ts'), 'utf8');
+    const allExportsBlock = indexSrc.slice(
+      indexSrc.indexOf('const _allExports'),
+      indexSrc.indexOf('const _materialize'),
+    );
+    expect(allExportsBlock).not.toMatch(/made-?of/i);
+    expect(indexSrc).not.toMatch(/import \* as \w+ from '\.\/made-of\.js'/);
+  });
+
+  it('registers no duplicate circuit names in the stdlib', () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const n of stdlibNames) {
+      if (seen.has(n)) dupes.push(n);
+      seen.add(n);
+    }
+    expect(dupes).toEqual([]);
+  });
+});
+
+describe('MADE_OF table', () => {
+  it('keys every entry to a real stdlib primitive', () => {
+    for (const name of MADE_OF_NAMES) {
+      expect(stdlibNames, `${name} is not a stdlib circuit`).toContain(name);
+    }
+  });
+
+  it('reports drillability by name', () => {
+    expect(hasMadeOf('Adder')).toBe(true);
+    expect(hasMadeOf('Comparator')).toBe(true);
+    // Deliberately absent: a 256-adder array teaches nothing, and memory maps
+    // to hardened blocks so a gate build would misrepresent the hardware.
+    expect(hasMadeOf('Multiplier')).toBe(false);
+    expect(hasMadeOf('RAM')).toBe(false);
+    expect(hasMadeOf('Constant')).toBe(false);
+    // Not inherited from Object.prototype.
+    expect(hasMadeOf('toString')).toBe(false);
+    expect(hasMadeOf('constructor')).toBe(false);
+  });
+
+  it('builds to the width it is given, not the default', () => {
+    for (const w of [1, 4, 16]) {
+      const built = MADE_OF.Adder({ width: w }) as { circuit: { name: string; nodes: unknown[] } };
+      expect(built.circuit.name).toBe(`Adder${w}_madeOf`);
+      // One FullAdder per bit.
+      const stages = built.circuit.nodes.filter(
+        (n) => (n as { componentRef: string }).componentRef === 'FullAdder',
+      );
+      expect(stages).toHaveLength(w);
+    }
+  });
+
+  it('falls back to the default width on a malformed argument', () => {
+    for (const bad of [undefined, 0, -4, 2.5, 'wide']) {
+      const built = MADE_OF.Adder({ width: bad } as never) as { circuit: { name: string } };
+      expect(built.circuit.name).toBe('Adder8_madeOf');
+    }
+  });
+});
+
+describe('FullAdder', () => {
+  it('is a composite in the stdlib, so it can be drilled into', () => {
+    const fa = STDLIB_CIRCUITS.find((c) => c.circuit.name === 'FullAdder');
+    expect(fa).toBeDefined();
+    expect(fa?.circuit.implementation.kind).toBe('composite');
+    expect(fa?.circuit.nodes.length).toBeGreaterThan(0);
+  });
+
+  it('stops at Xor/And/Or — the game already covers NAND', () => {
+    const fa = STDLIB_CIRCUITS.find((c) => c.circuit.name === 'FullAdder');
+    const refs = new Set(fa?.circuit.nodes.map((n) => n.componentRef));
+    expect([...refs].sort()).toEqual(['And', 'Or', 'Xor']);
+  });
+});
+
+describe('made-of.verify.ts', () => {
+  it('proves every reference build equivalent to its primitive', { timeout: 120_000 }, () => {
+    // Strip VITEST so the harness runs in its real tsx mode (emit JSON +
+    // exit code) rather than vitest mode (throw).
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    delete env.VITEST;
+    delete env.VITEST_POOL_ID;
+    delete env.VITEST_WORKER_ID;
+    const r = spawnSync(
+      resolve(repoRoot, 'node_modules/.bin/tsx'),
+      [resolve(stdDir, 'made-of.verify.ts')],
+      { cwd: repoRoot, env, encoding: 'utf8' },
+    );
+    expect(r.stdout, r.stderr).toContain('"testbench_passed": true');
+    expect(r.status).toBe(0);
+  });
+});

--- a/packages/core/src/std/arithmetic.ts
+++ b/packages/core/src/std/arithmetic.ts
@@ -4,6 +4,7 @@
 
 import { bit, bus } from '../circuit/bit-bus.js';
 import { circuit } from '../circuit/circuit.js';
+import { And, Or, Xor } from './logic.js';
 
 /**
  * Adds 1 to the input. 8-bit value, wraps at 256 (`(in + 1) & 0xFF`).
@@ -29,6 +30,54 @@ export const Incrementer = circuit('Incrementer', {
   outputs: { out: bus(8) },
   meta: { category: 'arithmetic', icon: '+1', description: 'Adds 1 to the input' },
   eval: ({ in: a }) => ({ out: (a + 1) & 0xff }),
+});
+
+/**
+ * One bit of addition: `sum = a ^ b ^ carry_in`, and a carry out when at
+ * least two of the three inputs are set. Single-bit full adder built from gates.
+ *
+ * Chain `carry_out` -> `carry_in` across N of these and you have the
+ * ripple-carry adder that `Adder({ width: N })` computes in one step.
+ *
+ * **Inputs:** `a`, `b`, `carry_in` — `bit`
+ * **Outputs:** `sum`, `carry_out` — `bit`
+ *
+ * **Example:** two bits of a ripple-carry chain
+ * ```ts
+ * circuit('TwoBitAdd', {
+ *   inputs:  { a0: bit, b0: bit, a1: bit, b1: bit, cin: bit },
+ *   outputs: { s0: bit, s1: bit, cout: bit },
+ *   nodes:   { fa0: FullAdder, fa1: FullAdder },
+ *   connect: ({ inputs, outputs, nodes: { fa0, fa1 } }) => [
+ *     inputs.a0.to(fa0.a), inputs.b0.to(fa0.b), inputs.cin.to(fa0.carry_in),
+ *     inputs.a1.to(fa1.a), inputs.b1.to(fa1.b),
+ *     fa0.carry_out.to(fa1.carry_in),
+ *     fa0.sum.to(outputs.s0),
+ *     fa1.sum.to(outputs.s1),
+ *     fa1.carry_out.to(outputs.cout),
+ *   ],
+ * })
+ * ```
+ */
+export const FullAdder = circuit('FullAdder', {
+  inputs: { a: bit, b: bit, carry_in: bit },
+  outputs: { sum: bit, carry_out: bit },
+  meta: {
+    category: 'arithmetic',
+    icon: 'FA',
+    description: 'Single-bit full adder built from gates',
+  },
+  nodes: { ab: Xor, sum2: Xor, andAB: And, andC: And, carry: Or },
+  connect: ({ inputs, outputs, nodes: { ab, sum2, andAB, andC, carry } }) => [
+    inputs.a.to(ab.a, andAB.a),
+    inputs.b.to(ab.b, andAB.b),
+    ab.out.to(sum2.a, andC.a),
+    inputs.carry_in.to(sum2.b, andC.b),
+    sum2.out.to(outputs.sum),
+    andAB.out.to(carry.a),
+    andC.out.to(carry.b),
+    carry.out.to(outputs.carry_out),
+  ],
 });
 
 /**

--- a/packages/core/src/std/index.ts
+++ b/packages/core/src/std/index.ts
@@ -21,6 +21,7 @@ export {
   BusXor,
   Comparator,
   Divider,
+  FullAdder,
   Incrementer,
   LeftShifter,
   Modulo,
@@ -57,6 +58,10 @@ export {
   Xnor,
   Xor,
 } from './logic.js';
+// Gate-level reference builds for the canvas drill-down. Display only — never
+// elaborated into a netlist. Re-exported here (not via `_allExports`) so the
+// builders stay out of STDLIB_CIRCUITS; see made-of.ts and its test.
+export { hasMadeOf, MADE_OF, MADE_OF_NAMES, type MadeOfBuilder } from './made-of.js';
 
 // Memory
 export { DualPortRAM, RAM, ROM, romFromBytes, romFromEntries, romFromWords } from './memory.js';

--- a/packages/core/src/std/made-of.ts
+++ b/packages/core/src/std/made-of.ts
@@ -1,0 +1,362 @@
+/** Standard Library — gate-level reference builds ("made of"). Display only. */
+
+// Every stdlib primitive is eval-only: `Adder({ width: 16 })` computes
+// `a + b + carry_in` in one step and has no internal structure, so drilling into
+// one on the canvas hits a wall. These builders supply the missing picture — one
+// way to construct the same function out of gates.
+//
+// DISPLAY ONLY. Nothing here is elaborated into a running netlist. The simulator,
+// the Verilog exporter and the FPGA flow never see these circuits; they exist so
+// the canvas can show a reader what an adder *is*. Keeping the primitives
+// primitive is what keeps the synth voice at ~78k ticks/s and lets Yosys infer a
+// carry chain instead of reading a thousand structural assigns.
+//
+// These are honest but not literal: a ripple-carry adder is the right way to
+// teach addition and is not what synthesis emits. That distinction matters to
+// whoever edits this file; it is not surfaced in the UI, because what the reader
+// runs is the primitive's eval either way and the two are proven equivalent.
+//
+// They stop at Xor/And/Or/Not. The game already teaches NAND -> gates level by
+// level; this covers gates -> arithmetic. No overlap.
+//
+// Each entry is checked against its primitive's `eval` by `made-of.verify.ts`,
+// so a diagram cannot drift from the thing it explains.
+//
+// NOTE: this module is deliberately absent from `_allExports` in `index.ts`.
+// `STDLIB_CIRCUITS` materializes exported functions by calling them with no
+// arguments and keeping anything that returns a `BuiltCircuit`, so a builder
+// exported bare from a std module could be silently registered as a duplicate
+// stdlib circuit. `std/__tests__/made-of.test.ts` guards that.
+//
+// Skipped on purpose: Multiplier/Divider (a 256-adder array teaches nothing),
+// memory (ROM/RAM map to hardened blocks, so a gate build would misrepresent the
+// hardware), Constant, and the display peripherals.
+
+import { bit, bus } from '../circuit/bit-bus.js';
+import { circuit } from '../circuit/circuit.js';
+import type { ArgumentValue } from '../types/circuit.js';
+import { FullAdder } from './arithmetic.js';
+import { Constant } from './io.js';
+import { And, Not, Or, Xnor, Xor } from './logic.js';
+import { Slice } from './reconstruction.js';
+import { Concat } from './routing.js';
+
+/** A gate-level build of a primitive, specialized to that node's arguments. */
+export type MadeOfBuilder = (args: Record<string, ArgumentValue>) => unknown;
+
+/** Read a positive integer `width`, falling back when absent or malformed. */
+function widthOf(args: Record<string, ArgumentValue>, fallback: number): number {
+  const raw = args.width;
+  const n = typeof raw === 'number' ? raw : Number.NaN;
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * Fan a bus out to individual bits. Slicing is free in real hardware — it is
+ * which wire you grab — but the IR connects port to port, so it needs a node.
+ */
+const bitsOf = (width: number) =>
+  Array.from({ length: width }, (_, i) => Slice({ inWidth: width, offset: i, width: 1 }));
+
+/**
+ * Nodes to reassemble bits into a bus, LSB first. Folds left so each Concat
+ * widens the accumulator by one.
+ */
+const joinNodes = (width: number) =>
+  Array.from({ length: Math.max(0, width - 1) }, (_, i) => Concat({ hiWidth: 1, loWidth: i + 1 }));
+
+// ============================================================================
+// Adder — ripple carry
+// ============================================================================
+
+/**
+ * `Adder({ width: N })` as N FullAdders in a ripple-carry chain.
+ *
+ * Each stage waits on the carry from the stage below it, which is why the
+ * drill-down shows the carry rippling: bit 0 settles first, bit N-1 last.
+ * Synthesis maps this to a carry-lookahead structure or the target's dedicated
+ * carry chain, which is faster and looks nothing like this.
+ */
+function adderMadeOf(args: Record<string, ArgumentValue>) {
+  const width = widthOf(args, 8);
+  return circuit(`Adder${width}_madeOf`, {
+    inputs: { a: bus(width), b: bus(width), carry_in: bit },
+    outputs: { sum: bus(width), carry_out: bit },
+    nodes: {
+      aBit: bitsOf(width),
+      bBit: bitsOf(width),
+      fa: Array.from({ length: width }, () => FullAdder),
+      join: joinNodes(width),
+    },
+    connect: ({ inputs, outputs, nodes: { aBit, bBit, fa, join } }) => [
+      ...aBit.map((s) => inputs.a.to(s.in)),
+      ...bBit.map((s) => inputs.b.to(s.in)),
+      ...aBit.map((s, i) => s.out.to(fa[i].a)),
+      ...bBit.map((s, i) => s.out.to(fa[i].b)),
+      inputs.carry_in.to(fa[0].carry_in),
+      ...fa.slice(0, -1).map((stage, i) => stage.carry_out.to(fa[i + 1].carry_in)),
+      fa[width - 1].carry_out.to(outputs.carry_out),
+      ...(width === 1
+        ? [fa[0].sum.to(outputs.sum)]
+        : [
+            fa[0].sum.to(join[0].low),
+            ...join.map((j, i) => fa[i + 1].sum.to(j.high)),
+            ...join.slice(0, -1).map((j, i) => j.out.to(join[i + 1].low)),
+            join[join.length - 1].out.to(outputs.sum),
+          ]),
+    ],
+  });
+}
+
+// ============================================================================
+// Subtractor — add the two's complement
+// ============================================================================
+
+/**
+ * `Subtractor({ width: N })` as `a + ~b + !borrow_in`.
+ *
+ * Two's complement makes subtraction addition with the subtrahend inverted and
+ * a carry forced in, so this is the adder again with a row of inverters on `b`.
+ * `borrow_out` is the inverted carry: the chain carries out exactly when it did
+ * *not* need to borrow.
+ */
+function subtractorMadeOf(args: Record<string, ArgumentValue>) {
+  const width = widthOf(args, 8);
+  return circuit(`Subtractor${width}_madeOf`, {
+    inputs: { a: bus(width), b: bus(width), borrow_in: bit },
+    outputs: { difference: bus(width), borrow_out: bit },
+    nodes: {
+      aBit: bitsOf(width),
+      bBit: bitsOf(width),
+      inv: Array.from({ length: width }, () => Not),
+      notBorrow: Not,
+      fa: Array.from({ length: width }, () => FullAdder),
+      invCarry: Not,
+      join: joinNodes(width),
+    },
+    connect: ({ inputs, outputs, nodes: { aBit, bBit, inv, notBorrow, fa, invCarry, join } }) => [
+      ...aBit.map((s) => inputs.a.to(s.in)),
+      ...bBit.map((s) => inputs.b.to(s.in)),
+      ...aBit.map((s, i) => s.out.to(fa[i].a)),
+      ...bBit.map((s, i) => s.out.to(inv[i].in)),
+      ...inv.map((n, i) => n.out.to(fa[i].b)),
+      inputs.borrow_in.to(notBorrow.in),
+      notBorrow.out.to(fa[0].carry_in),
+      ...fa.slice(0, -1).map((stage, i) => stage.carry_out.to(fa[i + 1].carry_in)),
+      fa[width - 1].carry_out.to(invCarry.in),
+      invCarry.out.to(outputs.borrow_out),
+      ...(width === 1
+        ? [fa[0].sum.to(outputs.difference)]
+        : [
+            fa[0].sum.to(join[0].low),
+            ...join.map((j, i) => fa[i + 1].sum.to(j.high)),
+            ...join.slice(0, -1).map((j, i) => j.out.to(join[i + 1].low)),
+            join[join.length - 1].out.to(outputs.difference),
+          ]),
+    ],
+  });
+}
+
+// ============================================================================
+// Incrementer — half adders are enough
+// ============================================================================
+
+/**
+ * `Incrementer` as a chain of half adders. Fixed 8-bit: the primitive is not
+ * width-parameterized.
+ *
+ * Adding a constant 1 needs no full adder — there is no second operand, only
+ * the carry. Bit 0 always flips, so it is a bare inverter. Bit i flips when
+ * every bit below it was set, which is what the AND chain accumulates. The
+ * carry out of the top bit is dropped, so 255 + 1 wraps to 0, matching
+ * `(in + 1) & 0xff`.
+ */
+function incrementerMadeOf(_args: Record<string, ArgumentValue>) {
+  const width = 8;
+  // carry[1] is in[0] itself; carry[i] = in[i-1] & carry[i-1] for i >= 2.
+  return circuit('Incrementer_madeOf', {
+    inputs: { in: bus(width) },
+    outputs: { out: bus(width) },
+    nodes: {
+      inBit: bitsOf(width),
+      lsb: Not,
+      flip: Array.from({ length: width - 1 }, () => Xor),
+      carry: Array.from({ length: width - 2 }, () => And),
+      join: joinNodes(width),
+    },
+    connect: ({ inputs, outputs, nodes: { inBit, lsb, flip, carry, join } }) => {
+      // carrySig[i] drives flip[i - 1] (which produces out[i]).
+      const carrySig = [inBit[0].out, ...carry.map((g) => g.out)];
+      return [
+        ...inBit.map((s) => inputs.in.to(s.in)),
+        inBit[0].out.to(lsb.in),
+        // carry[j] = in[j + 1] & carrySig[j]  ->  carrySig[j + 1]
+        ...carry.map((g, j) => inBit[j + 1].out.to(g.a)),
+        ...carry.map((g, j) => carrySig[j].to(g.b)),
+        // out[i + 1] = in[i + 1] ^ carrySig[i]
+        ...flip.map((x, i) => inBit[i + 1].out.to(x.a)),
+        ...flip.map((x, i) => carrySig[i].to(x.b)),
+        lsb.out.to(join[0].low),
+        ...join.map((j, i) => flip[i].out.to(j.high)),
+        ...join.slice(0, -1).map((j, i) => j.out.to(join[i + 1].low)),
+        join[join.length - 1].out.to(outputs.out),
+      ];
+    },
+  });
+}
+
+// ============================================================================
+// Mux — one select line, N bit slices
+// ============================================================================
+
+/** The one-bit select: `out = (in0 & !sel) | (in1 & sel)`. */
+function muxBitMadeOf() {
+  return circuit('Mux1_madeOf', {
+    inputs: { in0: bit, in1: bit, sel: bit },
+    outputs: { out: bit },
+    nodes: { notSel: Not, keep: And, take: And, pick: Or },
+    connect: ({ inputs, outputs, nodes: { notSel, keep, take, pick } }) => [
+      inputs.sel.to(notSel.in, take.b),
+      notSel.out.to(keep.a),
+      inputs.in0.to(keep.b),
+      inputs.in1.to(take.a),
+      keep.out.to(pick.a),
+      take.out.to(pick.b),
+      pick.out.to(outputs.out),
+    ],
+  });
+}
+
+/**
+ * `Mux({ width: N })` as N copies of the one-bit select.
+ *
+ * The select line fans out to every bit and nothing ripples, so this one is
+ * wide and flat where the adder is long and sequential — the picture of why a
+ * mux is cheap and an adder is not.
+ */
+function muxMadeOf(args: Record<string, ArgumentValue>) {
+  const width = widthOf(args, 1);
+  if (width === 1) return muxBitMadeOf();
+  return circuit(`Mux${width}_madeOf`, {
+    inputs: { in0: bus(width), in1: bus(width), sel: bit },
+    outputs: { out: bus(width) },
+    nodes: {
+      in0Bit: bitsOf(width),
+      in1Bit: bitsOf(width),
+      notSel: Not,
+      keep: Array.from({ length: width }, () => And),
+      take: Array.from({ length: width }, () => And),
+      pick: Array.from({ length: width }, () => Or),
+      join: joinNodes(width),
+    },
+    connect: ({ inputs, outputs, nodes: { in0Bit, in1Bit, notSel, keep, take, pick, join } }) => [
+      ...in0Bit.map((s) => inputs.in0.to(s.in)),
+      ...in1Bit.map((s) => inputs.in1.to(s.in)),
+      inputs.sel.to(notSel.in, ...take.map((g) => g.b)),
+      notSel.out.to(...keep.map((g) => g.a)),
+      ...in0Bit.map((s, i) => s.out.to(keep[i].b)),
+      ...in1Bit.map((s, i) => s.out.to(take[i].a)),
+      ...keep.map((g, i) => g.out.to(pick[i].a)),
+      ...take.map((g, i) => g.out.to(pick[i].b)),
+      pick[0].out.to(join[0].low),
+      ...join.map((j, i) => pick[i + 1].out.to(j.high)),
+      ...join.slice(0, -1).map((j, i) => j.out.to(join[i + 1].low)),
+      join[join.length - 1].out.to(outputs.out),
+    ],
+  });
+}
+
+// ============================================================================
+// Comparator — equality by XNOR, ordering by subtraction
+// ============================================================================
+
+/**
+ * `Comparator({ width: N })` as an equality tree plus one subtraction.
+ *
+ * `eq` is every bit pair agreeing: an AND reduction over XNORs. Ordering falls
+ * out of `a - b` — if the subtraction borrows, `a < b`. The remaining four
+ * outputs are combinations of those two facts, which is why a comparator costs
+ * about one adder rather than six separate circuits.
+ */
+function comparatorMadeOf(args: Record<string, ArgumentValue>) {
+  const width = widthOf(args, 8);
+  return circuit(`Comparator${width}_madeOf`, {
+    inputs: { a: bus(width), b: bus(width) },
+    outputs: { eq: bit, ne: bit, lt: bit, le: bit, gt: bit, ge: bit },
+    nodes: {
+      aBit: bitsOf(width),
+      bBit: bitsOf(width),
+      // Equality per bit is exactly XNOR. Building it from Xor + Not would add
+      // a gate per bit and teach nothing extra.
+      same: Array.from({ length: width }, () => Xnor),
+      allSame: Array.from({ length: Math.max(0, width - 1) }, () => And),
+      notEq: Not,
+      // a < b is the borrow out of a - b == a + ~b + 1.
+      inv: Array.from({ length: width }, () => Not),
+      one: Constant({ value: 1 }),
+      fa: Array.from({ length: width }, () => FullAdder),
+      isLt: Not,
+      le: Or,
+      gt: And,
+    },
+    connect: ({
+      inputs,
+      outputs,
+      nodes: { aBit, bBit, same, allSame, notEq, inv, one, fa, isLt, le, gt },
+    }) => {
+      // With one bit there is nothing to reduce; `same[0]` is already equality.
+      const eqSignal = width === 1 ? same[0].out : allSame[allSame.length - 1].out;
+      return [
+        ...aBit.map((s) => inputs.a.to(s.in)),
+        ...bBit.map((s) => inputs.b.to(s.in)),
+        ...aBit.map((s, i) => s.out.to(same[i].a, fa[i].a)),
+        ...bBit.map((s, i) => s.out.to(same[i].b, inv[i].in)),
+        // Fold the per-bit agreements: allSame[0] = same[0] & same[1], then
+        // each further gate ANDs in the next bit.
+        ...(width === 1
+          ? []
+          : [
+              same[0].out.to(allSame[0].a),
+              same[1].out.to(allSame[0].b),
+              ...allSame.slice(1).map((g, i) => same[i + 2].out.to(g.b)),
+              ...allSame.slice(0, -1).map((g, i) => g.out.to(allSame[i + 1].a)),
+            ]),
+        eqSignal.to(outputs.eq, notEq.in, le.b),
+        notEq.out.to(outputs.ne, gt.b),
+        // a + ~b + 1
+        ...inv.map((n, i) => n.out.to(fa[i].b)),
+        one.out.to(fa[0].carry_in),
+        ...fa.slice(0, -1).map((stage, i) => stage.carry_out.to(fa[i + 1].carry_in)),
+        // carry_out == 1 means no borrow, so a >= b.
+        fa[width - 1].carry_out.to(outputs.ge, isLt.in, gt.a),
+        isLt.out.to(outputs.lt, le.a),
+        le.out.to(outputs.le),
+        gt.out.to(outputs.gt),
+      ];
+    },
+  });
+}
+
+// ============================================================================
+// The table
+// ============================================================================
+
+// Deliberately not a mutable registry: the set is fixed at build time and
+// nothing registers into it at runtime, unlike `eval-registry`, which exists
+// because user code defines evals dynamically.
+/** Gate-level reference builds, keyed by primitive name. Display only. */
+export const MADE_OF: Readonly<Record<string, MadeOfBuilder>> = Object.freeze({
+  Adder: adderMadeOf,
+  Subtractor: subtractorMadeOf,
+  Incrementer: incrementerMadeOf,
+  Mux: muxMadeOf,
+  Comparator: comparatorMadeOf,
+});
+
+/** The primitives that have a gate-level reference build. */
+export const MADE_OF_NAMES: readonly string[] = Object.freeze(Object.keys(MADE_OF));
+
+/** Whether a primitive has a gate-level reference build to drill into. */
+export function hasMadeOf(componentRef: string): boolean {
+  return Object.hasOwn(MADE_OF, componentRef);
+}

--- a/packages/core/src/std/made-of.verify.ts
+++ b/packages/core/src/std/made-of.verify.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env tsx
+/**
+ * made-of.verify.ts — Tier-B testbench: every gate-level reference build in
+ * `MADE_OF` computes exactly what the primitive it explains computes.
+ *
+ * The risk this removes is drift. `MADE_OF.Adder` and `Adder` are two
+ * descriptions of addition maintained by hand in different files; without a
+ * proof they are equal, the canvas eventually shows a diagram that lies about
+ * the thing the user is looking at. Exhaustive equivalence turns that risk into
+ * a guarantee — every diagram is proven to compute what it claims.
+ *
+ * Generic by construction: it reads each primitive's port widths and sweeps the
+ * whole input space, so a new `MADE_OF` entry is covered the moment it is added.
+ * No per-primitive test to remember to write.
+ *
+ * NOTE this proves *functional* equivalence only. A ripple-carry adder is not
+ * what synthesis emits, and this says nothing about gate count or timing — see
+ * the header of `made-of.ts`.
+ *
+ * Run: tsx packages/core/src/std/made-of.verify.ts
+ * (also spawned by `std/__tests__/made-of.test.ts` so CI covers it)
+ */
+
+import * as fc from 'fast-check';
+import { circuit } from '../circuit/circuit.js';
+import type { BuiltCircuit } from '../circuit/types.js';
+import { simulate } from '../sim/index.js';
+import type { SimulationHandle } from '../sim/simulate.js';
+import { declareOracle, describe, verify } from '../verify/index.js';
+import { Adder, Comparator, Incrementer, Subtractor } from './arithmetic.js';
+import { MADE_OF } from './made-of.js';
+import { Mux } from './routing.js';
+
+describe('MADE_OF');
+declareOracle({
+  tier: 'B',
+  type: "each primitive's own eval — closed-form arithmetic in JS",
+  independence_basis:
+    'The two descriptions are paradigm-diverse. The reference is a closed-form ' +
+    'expression ((a >>> 0) + (b >>> 0) + carry, masked); the circuit under test is a ' +
+    'netlist of Xor/And/Or/Not with an explicit carry chain and per-bit slicing. ' +
+    'Neither is derived from the other — they were written independently and share ' +
+    'no code path below simulate().',
+});
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+const open: SimulationHandle[] = [];
+const track = <T extends SimulationHandle>(h: T): T => {
+  open.push(h as SimulationHandle);
+  return h;
+};
+
+/**
+ * A parameterized primitive only sees its `width` when it is a *node* — the
+ * bridge merges `node.arguments` into the eval inputs. Simulating one bare
+ * would silently fall back to the literal default (see Adder's eval comment),
+ * so wrap it in a pass-through composite to get the real behaviour.
+ */
+function wrapPrimitive(prim: BuiltCircuit, name: string): BuiltCircuit {
+  const ins = Object.fromEntries(
+    Object.entries(prim.inputs).map(([k, d]) => [k, (d as { portType: unknown }).portType]),
+  );
+  const outs = Object.fromEntries(
+    Object.entries(prim.outputs).map(([k, d]) => [k, (d as { portType: unknown }).portType]),
+  );
+  return circuit(name, {
+    inputs: ins,
+    outputs: outs,
+    nodes: { p: prim },
+    // Generic port walk over an arbitrary primitive; the shape is proven by
+    // the equivalence sweep below rather than by the type system.
+    connect: ({ inputs, outputs, nodes: { p } }: ConnectArg) => [
+      ...Object.keys(ins).map((k) => inputs[k].to(p[k])),
+      ...Object.keys(outs).map((k) => p[k].to(outputs[k])),
+    ],
+  } as never) as unknown as BuiltCircuit;
+}
+
+/** The shape `connect` receives for a wrapper built from arbitrary ports. */
+type PortRef = { to: (...targets: unknown[]) => unknown };
+interface ConnectArg {
+  inputs: Record<string, PortRef>;
+  outputs: Record<string, PortRef>;
+  nodes: { p: Record<string, PortRef> };
+}
+
+/** Number of distinct values a port can hold. */
+function spaceOf(d: unknown): number {
+  const t = (d as { portType: { kind: string; width?: number } }).portType;
+  return t.kind === 'bit' ? 2 : 2 ** (t.width ?? 1);
+}
+
+interface Subject {
+  label: string;
+  made: BuiltCircuit;
+  ref: BuiltCircuit;
+  inputNames: string[];
+  spaces: number[];
+}
+
+function subject(label: string, made: unknown, prim: BuiltCircuit): Subject {
+  const ref = wrapPrimitive(prim, `${label.replace(/[^A-Za-z0-9]/g, '_')}_ref`);
+  return {
+    label,
+    made: made as BuiltCircuit,
+    ref,
+    inputNames: Object.keys(prim.inputs),
+    spaces: Object.values(prim.inputs).map(spaceOf),
+  };
+}
+
+/** Compare every output of the two circuits for one input assignment. */
+function agree(
+  a: SimulationHandle,
+  b: SimulationHandle,
+  names: string[],
+  vals: number[],
+  outputs: string[],
+): boolean {
+  const assignment = Object.fromEntries(names.map((n, i) => [n, vals[i]]));
+  a.set(assignment);
+  b.set(assignment);
+  for (const o of outputs) {
+    if (a.get(o) !== b.get(o)) return false;
+  }
+  return true;
+}
+
+/** Exhaustive equivalence over the primitive's whole input space. */
+function proveExhaustive(s: Subject): void {
+  const made = track(simulate(s.made));
+  const ref = track(simulate(s.ref));
+  const outputs = Object.keys((s.ref as unknown as { outputs: object }).outputs);
+  verify.exhaustive(`${s.label} matches its primitive on every input`, s.spaces, (...vals) =>
+    agree(made, ref, s.inputNames, vals, outputs),
+  );
+}
+
+/** Sampled equivalence, for spaces too large to sweep. */
+function proveSampled(s: Subject, numRuns: number): void {
+  const made = track(simulate(s.made));
+  const ref = track(simulate(s.ref));
+  const outputs = Object.keys((s.ref as unknown as { outputs: object }).outputs);
+  // One arbitrary per input port; fc.property's variadic overload does not
+  // survive a spread of a computed array, so build the tuple then assert it.
+  const arbs = s.spaces.map((n) => fc.integer({ min: 0, max: n - 1 }));
+  const property = fc.property(...(arbs as unknown as [fc.Arbitrary<number>]), ((
+    ...vals: number[]
+  ) => agree(made, ref, s.inputNames, vals, outputs)) as (v: number) => boolean);
+  verify.check(`${s.label} matches its primitive on sampled inputs`, property, { numRuns });
+}
+
+// ── Subjects ─────────────────────────────────────────────────────────────────
+
+// Widths 1 and 2 are the edges the builders special-case (no Concat fold at
+// width 1; a single reduction gate at width 2). 8 is the default everything
+// else in the stdlib is sized against.
+const EXHAUSTIVE_WIDTHS = [1, 2, 8];
+
+const subjects: Subject[] = [
+  ...EXHAUSTIVE_WIDTHS.flatMap((w) => [
+    subject(`Adder(${w})`, MADE_OF.Adder({ width: w }), Adder({ width: w }) as BuiltCircuit),
+    subject(
+      `Subtractor(${w})`,
+      MADE_OF.Subtractor({ width: w }),
+      Subtractor({ width: w }) as BuiltCircuit,
+    ),
+    subject(
+      `Comparator(${w})`,
+      MADE_OF.Comparator({ width: w }),
+      Comparator({ width: w }) as BuiltCircuit,
+    ),
+    subject(`Mux(${w})`, MADE_OF.Mux({ width: w }), Mux({ width: w }) as BuiltCircuit),
+  ]),
+  subject('Incrementer', MADE_OF.Incrementer({}), Incrementer as BuiltCircuit),
+];
+
+for (const s of subjects) proveExhaustive(s);
+
+// Width 16 is the size the README and the synth voice actually instantiate, and
+// its space (2^33 for an adder) is far past the exhaustive cutoff. Sample it:
+// masking and carry-chain bugs that only bite above 8 bits show up here.
+for (const w of [16]) {
+  proveSampled(
+    subject(`Adder(${w})`, MADE_OF.Adder({ width: w }), Adder({ width: w }) as BuiltCircuit),
+    300,
+  );
+  proveSampled(
+    subject(
+      `Subtractor(${w})`,
+      MADE_OF.Subtractor({ width: w }),
+      Subtractor({ width: w }) as BuiltCircuit,
+    ),
+    300,
+  );
+  proveSampled(
+    subject(
+      `Comparator(${w})`,
+      MADE_OF.Comparator({ width: w }),
+      Comparator({ width: w }) as BuiltCircuit,
+    ),
+    300,
+  );
+  proveSampled(
+    subject(`Mux(${w})`, MADE_OF.Mux({ width: w }), Mux({ width: w }) as BuiltCircuit),
+    300,
+  );
+}
+
+// Every entry in the table must be covered by at least one subject above — a
+// new MADE_OF entry with no subject would otherwise pass by doing nothing.
+const covered = new Set(subjects.map((s) => s.label.replace(/\(.*$/, '')));
+const uncovered = Object.keys(MADE_OF).filter((n) => !covered.has(n));
+verify.exhaustive('every MADE_OF entry is covered by a subject', [1], () => {
+  if (uncovered.length > 0) {
+    throw new Error(`MADE_OF entries with no equivalence check: ${uncovered.join(', ')}`);
+  }
+  return true;
+});
+
+for (const h of open) h.dispose();
+
+verify.run();

--- a/packages/ui/src/canvas/CircuitCanvas.tsx
+++ b/packages/ui/src/canvas/CircuitCanvas.tsx
@@ -26,6 +26,7 @@ import React, {
 } from 'react';
 import type { NodeData } from '../nodes';
 import { CompositeInspectorDialog } from './CompositeInspectorDialog';
+import { resolveDrillTarget } from './drill-target';
 import { useDetectTheme } from './hooks/useDetectTheme';
 import { useIsMobile } from './hooks/useIsMobile';
 import { cleanCircuitLabels } from './label-utils';
@@ -441,11 +442,8 @@ function CircuitCanvasInner({
   // ── Inspector stack for automatic drill-down ──
   const [inspectorStack, setInspectorStack] = useState<InspectorFrame[]>([]);
 
-  const pushInspectorLevel = useCallback((name: string, def: Circuit, label: string) => {
-    setInspectorStack((prev) => [
-      ...prev,
-      { componentName: name, componentDef: def, nodeLabel: label },
-    ]);
+  const pushInspectorLevel = useCallback((frame: InspectorFrame) => {
+    setInspectorStack((prev) => [...prev, frame]);
   }, []);
 
   const popInspectorLevel = useCallback(() => {
@@ -463,19 +461,9 @@ function CircuitCanvasInner({
   // Default double-click handler: opens inspector for composites
   const defaultNodeDoubleClick = useCallback(
     (nodeData: NodeData) => {
-      if (!nodeData.isComposite) return;
-      const componentDef = library.resolveCircuit(nodeData.componentRef);
-      if (!componentDef) return;
-
-      if (componentDef.implementation.kind === 'composite' && componentDef.nodes.length > 0) {
-        setInspectorStack([
-          {
-            componentName: nodeData.componentRef,
-            componentDef,
-            nodeLabel: nodeData.label ?? nodeData.componentRef,
-          },
-        ]);
-      }
+      if (!nodeData.isComposite && !nodeData.hasReference) return;
+      const frame = resolveDrillTarget(nodeData, library);
+      if (frame) setInspectorStack([frame]);
     },
     [library],
   );

--- a/packages/ui/src/canvas/CompositeInspectorDialog.tsx
+++ b/packages/ui/src/canvas/CompositeInspectorDialog.tsx
@@ -23,6 +23,7 @@ import { useSandboxContext } from '../sandbox/SandboxProvider';
 import { CircuitCanvas } from './CircuitCanvas';
 import { ClockControls } from './ClockControls';
 import { createDrillDownViewCircuit } from './drill-down-view';
+import { resolveDrillTarget } from './drill-target';
 import { EDGE_TYPES, NODE_TYPES } from './node-types';
 import type { InspectorFrame } from './types';
 
@@ -31,7 +32,7 @@ import type { InspectorFrame } from './types';
 interface InspectorCanvasProps {
   frame: InspectorFrame;
   componentLibrary: CircuitLibrary;
-  onPushLevel: (name: string, def: Circuit, label: string) => void;
+  onPushLevel: (frame: InspectorFrame) => void;
   theme?: 'light' | 'dark';
 }
 
@@ -41,27 +42,28 @@ function InspectorCanvas({
   onPushLevel,
   theme = 'dark',
 }: InspectorCanvasProps) {
+  // A reference build brings its own circuits; the page's library has never
+  // heard of them. Everything below — simulation, projection, nested drilling —
+  // must resolve against the frame's library, or internal nodes vanish.
+  const library = frame.library ?? componentLibrary;
+
   const viewCircuit = useMemo(
     () => createDrillDownViewCircuit(frame.componentDef),
     [frame.componentDef],
   );
 
   const isSequential = useMemo(
-    () => isSequentialCircuit(viewCircuit, componentLibrary.resolveCircuit),
-    [viewCircuit, componentLibrary],
+    () => isSequentialCircuit(viewCircuit, library.resolveCircuit),
+    [viewCircuit, library],
   );
 
   const handleNodeDoubleClick = useCallback(
     (nodeData: NodeData) => {
-      if (!nodeData.isComposite) return;
-      const componentDef = componentLibrary.resolveCircuit(nodeData.componentRef);
-      if (!componentDef) return;
-
-      if (componentDef.implementation.kind === 'composite' && componentDef.nodes.length > 0) {
-        onPushLevel(nodeData.componentRef, componentDef, nodeData.label ?? nodeData.componentRef);
-      }
+      if (!nodeData.isComposite && !nodeData.hasReference) return;
+      const next = resolveDrillTarget(nodeData, library);
+      if (next) onPushLevel(next);
     },
-    [componentLibrary, onPushLevel],
+    [library, onPushLevel],
   );
 
   // ── Simulation: prefer sandbox, fall back to local simulator ──
@@ -99,8 +101,8 @@ function InspectorCanvas({
     // composite children and their outputs stay stuck.
     const allLib: Circuit[] = [];
     const seen = new Set<string>();
-    for (const name of componentLibrary.getAllPrimitiveNames()) {
-      const c = componentLibrary.resolveCircuit(name);
+    for (const name of library.getAllPrimitiveNames()) {
+      const c = library.resolveCircuit(name);
       if (c && !seen.has(name)) {
         seen.add(name);
         allLib.push(c);
@@ -109,7 +111,7 @@ function InspectorCanvas({
     const walk = (c: Circuit) => {
       for (const node of c.nodes) {
         if (seen.has(node.componentRef)) continue;
-        const resolved = componentLibrary.resolveCircuit(node.componentRef);
+        const resolved = library.resolveCircuit(node.componentRef);
         if (!resolved) continue;
         seen.add(node.componentRef);
         allLib.push(resolved);
@@ -122,7 +124,7 @@ function InspectorCanvas({
       if ('error' in result) {
         // Fall back to local simulator (for embed contexts where no source was compiled)
         try {
-          const engine = createSimulatorFromCircuit(viewCircuit, componentLibrary);
+          const engine = createSimulatorFromCircuit(viewCircuit, library);
           engine.runCombinational();
           localEngineRef.current = engine;
           setUseSandbox(false);
@@ -149,7 +151,7 @@ function InspectorCanvas({
       setHistoryIndex(historyRef.current.length === 0 ? -1 : 0);
       setCycle(0);
     });
-  }, [viewCircuit, componentLibrary, sandbox, slotId, isSequential]);
+  }, [viewCircuit, library, sandbox, slotId, isSequential]);
 
   const handleToggle = useCallback(
     (nodeId: string) => {
@@ -278,7 +280,7 @@ function InspectorCanvas({
 
       <CircuitCanvas
         circuit={viewCircuit}
-        componentLibrary={componentLibrary}
+        componentLibrary={library}
         portValues={portValues as Map<string, boolean | number>}
         sequentialState={null}
         onToggleNode={handleToggle}
@@ -362,7 +364,7 @@ export interface CompositeInspectorDialogProps {
   theme?: 'light' | 'dark';
   onClose: () => void;
   onPopLevel: () => void;
-  onPushLevel: (name: string, def: Circuit, label: string) => void;
+  onPushLevel: (frame: InspectorFrame) => void;
   onNavigate: (index: number) => void;
 }
 
@@ -445,10 +447,13 @@ export function CompositeInspectorDialog({
           {/* Dialog panel */}
           <motion.div
             key="inspector-dialog"
-            className="fixed inset-0 z-50 flex items-center justify-center p-8 pointer-events-none"
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6 pointer-events-none"
           >
             <motion.div
-              className={`flex h-[80vh] w-full max-w-5xl flex-col rounded-lg shadow-xl pointer-events-auto overflow-hidden ${
+              // A reference build is the widest thing this dialog ever shows —
+              // Comparator(8) is an equality tree plus a full subtraction, ~60
+              // nodes laid out left-to-right. max-w-5xl shrank that to specks.
+              className={`flex h-[88vh] w-full max-w-[1600px] flex-col rounded-lg shadow-xl pointer-events-auto overflow-hidden ${
                 theme === 'dark' ? 'bg-gray-900' : 'bg-white'
               }`}
               initial={{ opacity: 0 }}

--- a/packages/ui/src/canvas/__tests__/drill-target.test.ts
+++ b/packages/ui/src/canvas/__tests__/drill-target.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The drill gate. Both double-click paths (CircuitCanvas's built-in handler and
+ * the one inside CompositeInspectorDialog) route through `resolveDrillTarget`,
+ * so this is where "can this node be opened, and into what" is decided.
+ */
+
+import type { Circuit, CircuitLibrary } from '@simten/core';
+import { bit, circuit } from '@simten/core/circuit';
+import { And, Xor } from '@simten/core/std';
+import { describe, expect, it } from 'vitest';
+import type { NodeData } from '../../nodes';
+import { resolveDrillTarget } from '../drill-target';
+
+const HalfAdder = circuit('HalfAdder', {
+  inputs: { a: bit, b: bit },
+  outputs: { sum: bit, carry: bit },
+  nodes: { x: Xor, n: And },
+  connect: ({ inputs, outputs, nodes: { x, n } }) => [
+    inputs.a.to(x.a, n.a),
+    inputs.b.to(x.b, n.b),
+    x.out.to(outputs.sum),
+    n.out.to(outputs.carry),
+  ],
+});
+
+function libraryOf(...circuits: Circuit[]): CircuitLibrary {
+  const byName = new Map(circuits.map((c) => [c.name, c]));
+  return {
+    resolveCircuit: (name) => byName.get(name),
+    getAllPrimitiveNames: () =>
+      [...byName.values()].filter((c) => c.implementation.kind === 'primitive').map((c) => c.name),
+  };
+}
+
+function nodeData(componentRef: string, args: Record<string, unknown> = {}): NodeData {
+  return {
+    nodeId: 'n1',
+    componentRef,
+    label: componentRef.toLowerCase(),
+    inputCount: 0,
+    outputCount: 0,
+    inputNames: [],
+    outputNames: [],
+    arguments: args,
+  };
+}
+
+describe('resolveDrillTarget', () => {
+  it('opens a composite into its own structure', () => {
+    const lib = libraryOf(HalfAdder.circuit);
+    const frame = resolveDrillTarget(nodeData('HalfAdder'), lib);
+    expect(frame?.componentName).toBe('HalfAdder');
+    expect(frame?.componentDef.nodes).toHaveLength(2);
+  });
+
+  it('opens an eval-only primitive into its gate-level reference build', () => {
+    // The whole point: Adder has no `connect` and no nodes, so before MADE_OF
+    // this was a dead end.
+    const frame = resolveDrillTarget(nodeData('Adder', { width: 8 }), libraryOf());
+    expect(frame).not.toBeNull();
+    const stages = frame?.componentDef.nodes.filter((n) => n.componentRef === 'FullAdder');
+    expect(stages).toHaveLength(8);
+  });
+
+  it('builds to the node’s own width, not a fixed one', () => {
+    for (const width of [1, 4, 16]) {
+      const frame = resolveDrillTarget(nodeData('Adder', { width }), libraryOf());
+      const stages = frame?.componentDef.nodes.filter((n) => n.componentRef === 'FullAdder');
+      expect(stages, `width ${width}`).toHaveLength(width);
+    }
+  });
+
+  it('prefers real structure over a reference build', () => {
+    // A user who defines their own Adder with actual internals should see those
+    // internals, not the stdlib's explanation of a different circuit.
+    const UserAdder = circuit('Adder', {
+      inputs: { a: bit, b: bit },
+      outputs: { sum: bit },
+      nodes: { x: Xor },
+      connect: ({ inputs, outputs, nodes: { x } }) => [
+        inputs.a.to(x.a),
+        inputs.b.to(x.b),
+        x.out.to(outputs.sum),
+      ],
+    });
+    const frame = resolveDrillTarget(nodeData('Adder', { width: 8 }), libraryOf(UserAdder.circuit));
+    expect(frame?.componentDef.nodes).toHaveLength(1);
+    expect(frame?.componentDef.nodes[0].componentRef).toBe('Xor');
+  });
+
+  it('returns null for a leaf primitive', () => {
+    expect(resolveDrillTarget(nodeData('Xor'), libraryOf(Xor.circuit))).toBeNull();
+    // Deliberately excluded from MADE_OF.
+    expect(resolveDrillTarget(nodeData('Multiplier', { width: 8 }), libraryOf())).toBeNull();
+    expect(resolveDrillTarget(nodeData('Constant', { value: 1 }), libraryOf())).toBeNull();
+  });
+
+  it('returns null rather than throwing on a malformed argument bag', () => {
+    // A bad width should leave the node inert, not break the canvas.
+    for (const width of ['wide', Number.NaN, -1]) {
+      expect(() => resolveDrillTarget(nodeData('Adder', { width }), libraryOf())).not.toThrow();
+    }
+    // Missing arguments entirely — falls back to the default width.
+    const frame = resolveDrillTarget(nodeData('Adder'), libraryOf());
+    expect(frame?.componentDef.nodes.filter((n) => n.componentRef === 'FullAdder')).toHaveLength(8);
+  });
+
+  it('carries a library that resolves every node in the reference build', () => {
+    // The bug this pins: FigletStream depends on Adder, not on the FullAdder /
+    // Slice / Concat / gates that explain it. `projection.ts` drops any node it
+    // cannot resolve, so a frame without its own library renders the boundary
+    // ports and an empty middle.
+    const pageLibrary = libraryOf(); // knows nothing
+    const frame = resolveDrillTarget(nodeData('Adder', { width: 8 }), pageLibrary);
+    expect(frame?.library).toBeDefined();
+    for (const node of frame?.componentDef.nodes ?? []) {
+      expect(
+        frame?.library?.resolveCircuit(node.componentRef),
+        `${node.componentRef} unresolvable — it would be dropped from the canvas`,
+      ).toBeDefined();
+    }
+  });
+
+  it('keeps that library reachable when drilling deeper', () => {
+    // FullAdder is only known because the Adder build introduced it; drilling
+    // into it must still resolve Xor/And/Or.
+    const frame = resolveDrillTarget(nodeData('Adder', { width: 4 }), libraryOf());
+    const inner = resolveDrillTarget(nodeData('FullAdder'), frame!.library!);
+    expect(inner?.componentDef.nodes.length).toBeGreaterThan(0);
+    for (const node of inner?.componentDef.nodes ?? []) {
+      expect(inner?.library?.resolveCircuit(node.componentRef)).toBeDefined();
+    }
+  });
+
+  it('carries the node label so the breadcrumb reads as the instance', () => {
+    const data = nodeData('Adder', { width: 8 });
+    data.label = 'adder';
+    expect(resolveDrillTarget(data, libraryOf())?.nodeLabel).toBe('adder');
+  });
+});

--- a/packages/ui/src/canvas/drill-target.ts
+++ b/packages/ui/src/canvas/drill-target.ts
@@ -1,0 +1,93 @@
+/**
+ * What opens when a node is double-clicked.
+ *
+ * Two kinds of node are drillable and they mean different things:
+ *
+ * - A composite has real internal structure. Opening it shows what it *is*.
+ * - An eval-only primitive with an entry in `MADE_OF` has no internal
+ *   structure at all — `Adder({ width: 8 })` computes `a + b + carry_in` in one
+ *   step. Opening it shows a gate-level build of the same function, proven
+ *   equivalent to it by `made-of.verify.ts`.
+ *
+ * The reference build is never elaborated into the running netlist; it is
+ * constructed here, on demand, for display in a dialog that runs its own
+ * simulator. Drilling an Adder costs nothing until someone drills it.
+ *
+ * Frames carry their own library. A reference build introduces circuits the
+ * page has never heard of — FigletStream depends on `Adder`, not on the
+ * `FullAdder`/`Slice`/`Concat`/`Xor` that explain it — and `projection.ts`
+ * silently drops any node it cannot resolve. Without the layered library the
+ * dialog renders the boundary ports and nothing in between.
+ */
+
+import type { Circuit, CircuitLibrary } from '@simten/core';
+import { MADE_OF } from '@simten/core/std';
+import type { NodeData } from '../nodes';
+import type { InspectorFrame } from './types';
+
+/** The shape `circuit()` returns: the IR plus its transitive dependencies. */
+interface BuiltLike {
+  circuit: Circuit;
+  _dependencies?: Map<string, { circuit?: Circuit } | undefined>;
+}
+
+/** A library that answers from `extra` first, then falls back to `base`. */
+function layer(base: CircuitLibrary, extra: Map<string, Circuit>): CircuitLibrary {
+  return {
+    resolveCircuit: (name) => extra.get(name) ?? base.resolveCircuit(name),
+    getAllPrimitiveNames: () => {
+      const names = new Set(base.getAllPrimitiveNames());
+      for (const c of extra.values()) {
+        if (c.implementation.kind === 'primitive') names.add(c.name);
+      }
+      return [...names];
+    },
+  };
+}
+
+/**
+ * Resolve the frame a double-click should push, or null if the node is a leaf.
+ *
+ * Composites win over reference builds: if a user has defined their own Adder
+ * with real structure, that structure is the truth and should be what opens.
+ */
+export function resolveDrillTarget(
+  nodeData: NodeData,
+  library: CircuitLibrary,
+): InspectorFrame | null {
+  const { componentRef } = nodeData;
+  const nodeLabel = nodeData.label ?? componentRef;
+
+  const componentDef = library.resolveCircuit(componentRef);
+  if (componentDef?.implementation.kind === 'composite' && componentDef.nodes.length > 0) {
+    // Carry the library forward so a frame opened from inside a reference build
+    // keeps seeing the gates that build introduced.
+    return { componentName: componentRef, componentDef, nodeLabel, library };
+  }
+
+  const build = MADE_OF[componentRef];
+  if (!build) return null;
+
+  // Build to this node's own arguments, so Adder({width:16}) opens 16 stages
+  // and Adder({width:8}) opens 8.
+  const args = (nodeData.arguments ?? {}) as Record<string, never>;
+  let built: BuiltLike;
+  try {
+    built = build(args) as BuiltLike;
+  } catch {
+    // A malformed argument bag should leave the node inert, not break the canvas.
+    return null;
+  }
+
+  const extra = new Map<string, Circuit>([[built.circuit.name, built.circuit]]);
+  for (const dep of built._dependencies?.values() ?? []) {
+    if (dep?.circuit) extra.set(dep.circuit.name, dep.circuit);
+  }
+
+  return {
+    componentName: componentRef,
+    componentDef: built.circuit,
+    nodeLabel,
+    library: layer(library, extra),
+  };
+}

--- a/packages/ui/src/canvas/projection.ts
+++ b/packages/ui/src/canvas/projection.ts
@@ -12,6 +12,7 @@ import type {
   FlatPortValueMap,
   FlatSequentialState,
 } from '@simten/core/simulator';
+import { hasMadeOf } from '@simten/core/std';
 import type { Edge, Node as ReactFlowNode } from '@xyflow/react';
 import type { NodeData } from '../nodes';
 import type { MetadataState } from './types';
@@ -107,6 +108,9 @@ function projectCircuitToNodes(
     const inputNames = node.inputs.map((p) => p.name);
     const outputNames = node.outputs.map((p) => p.name);
     const isComposite = componentDef.implementation.kind === 'composite';
+    // Eval-only primitives with a gate-level reference build can also be
+    // opened. Kept out of `isComposite` so the node still renders as itself.
+    const hasReference = !isComposite && hasMadeOf(node.componentRef);
     const nodeType = getNodeTypeForComponent(
       node.componentRef,
       inputCount,
@@ -258,6 +262,7 @@ function projectCircuitToNodes(
         inputNames,
         outputNames,
         isComposite,
+        hasReference,
         arguments: node.arguments,
         __pixels: pixels,
         __consoleText: consoleText,

--- a/packages/ui/src/canvas/types.ts
+++ b/packages/ui/src/canvas/types.ts
@@ -13,12 +13,19 @@ export type {
 
 // --- Inspector types (used by the canvas-level drill-down inspector) ---
 
-import type { Circuit as CircuitType } from '@simten/core';
+import type { CircuitLibrary as CircuitLibraryType, Circuit as CircuitType } from '@simten/core';
 
 export interface InspectorFrame {
   componentName: string;
   componentDef: CircuitType;
   nodeLabel: string;
+  /**
+   * Library to resolve this frame's nodes against, when the page's own library
+   * is not enough. A gate-level reference build pulls in circuits the page
+   * never depended on; without them `projection.ts` drops every internal node
+   * and the dialog renders an empty canvas.
+   */
+  library?: CircuitLibraryType;
 }
 
 /** Screen rect of the node that triggered the dialog (for animate-from-origin) */

--- a/packages/ui/src/nodes/CompositeBadge.tsx
+++ b/packages/ui/src/nodes/CompositeBadge.tsx
@@ -1,7 +1,7 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../primitives/tooltip';
 
 /**
- * Badge shown on composite nodes indicating they can be drilled into.
+ * Badge shown on nodes that can be drilled into.
  * Renders in the top-right corner with a magnifying glass and pulse ring.
  */
 export function CompositeBadge() {

--- a/packages/ui/src/nodes/InputNode.tsx
+++ b/packages/ui/src/nodes/InputNode.tsx
@@ -135,7 +135,7 @@ export function InputNode({ data, selected }: InputNodeProps) {
       glowUnconnected={data.glowUnconnected}
     >
       <div className="relative flex flex-col items-center gap-2">
-        {data.isComposite && <CompositeBadge />}
+        {(data.isComposite || data.hasReference) && <CompositeBadge />}
         <div className="px-2 py-1 rounded text-xs font-medium text-[var(--embed-text-primary)]">
           {data.label || data.componentRef}
         </div>

--- a/packages/ui/src/nodes/LogicGateNode.tsx
+++ b/packages/ui/src/nodes/LogicGateNode.tsx
@@ -89,12 +89,12 @@ export function LogicGateNode({ data, selected }: LogicGateNodeProps) {
       glowUnconnected={data.glowUnconnected}
     >
       <div className="relative flex flex-col items-center gap-1">
-        {data.isComposite && <CompositeBadge />}
+        {(data.isComposite || data.hasReference) && <CompositeBadge />}
         <div className="text-xs font-medium text-[var(--embed-text-secondary)]">
           {data.label || data.componentRef}
         </div>
         <div className="flex items-center justify-center">{renderGateSymbol()}</div>
-        {data.isComposite && (
+        {(data.isComposite || data.hasReference) && (
           <div className="text-[9px] text-[var(--embed-text-muted)] italic">
             double-click to inspect
           </div>

--- a/packages/ui/src/nodes/NodeData.ts
+++ b/packages/ui/src/nodes/NodeData.ts
@@ -15,6 +15,12 @@ export interface NodeData extends Record<string, unknown> {
   inputNames: string[];
   outputNames: string[];
   isComposite?: boolean;
+  /**
+   * Primitive with a gate-level reference build in `MADE_OF` — drillable, but
+   * what opens is an explanation rather than its actual implementation.
+   * Deliberately separate from `isComposite`, which selects the node type.
+   */
+  hasReference?: boolean;
   arguments?: Record<string, unknown>;
   __pixels?: number[];
   __consoleText?: string;

--- a/packages/ui/src/nodes/OutputNode.tsx
+++ b/packages/ui/src/nodes/OutputNode.tsx
@@ -91,7 +91,7 @@ export function OutputNode({ data, selected }: OutputNodeProps) {
       glowUnconnected={data.glowUnconnected}
     >
       <div className="relative">
-        {data.isComposite && <CompositeBadge />}
+        {(data.isComposite || data.hasReference) && <CompositeBadge />}
         {renderDisplay()}
       </div>
     </BaseNode>

--- a/packages/ui/src/nodes/RAMNode.tsx
+++ b/packages/ui/src/nodes/RAMNode.tsx
@@ -40,7 +40,7 @@ export function RAMNode({ data, selected }: RAMNodeProps) {
       glowUnconnected={data.glowUnconnected}
     >
       <div className="relative flex flex-col items-center gap-2">
-        {data.isComposite && <CompositeBadge />}
+        {(data.isComposite || data.hasReference) && <CompositeBadge />}
         <div className="px-2 py-1 text-xs font-medium text-[var(--embed-text-primary)]">
           {data.label || 'RAM'}
         </div>

--- a/packages/ui/src/nodes/ROMNode.tsx
+++ b/packages/ui/src/nodes/ROMNode.tsx
@@ -40,7 +40,7 @@ export function ROMNode({ data, selected }: ROMNodeProps) {
       glowUnconnected={data.glowUnconnected}
     >
       <div className="relative flex flex-col items-center gap-2">
-        {data.isComposite && <CompositeBadge />}
+        {(data.isComposite || data.hasReference) && <CompositeBadge />}
         <div className="px-2 py-1 text-xs font-medium text-[var(--embed-text-primary)]">
           {data.label || 'ROM'}
         </div>

--- a/packages/ui/src/nodes/RegisterNode.tsx
+++ b/packages/ui/src/nodes/RegisterNode.tsx
@@ -33,7 +33,7 @@ export function RegisterNode({ data, selected }: RegisterNodeProps) {
       glowUnconnected={data.glowUnconnected}
     >
       <div className="relative flex flex-col items-center gap-2">
-        {data.isComposite && <CompositeBadge />}
+        {(data.isComposite || data.hasReference) && <CompositeBadge />}
         <div className="px-2 py-1 text-xs font-medium text-[var(--embed-text-primary)]">
           {data.label || 'Register'}
         </div>


### PR DESCRIPTION
## The problem

All 51 stdlib primitives are eval-only — none have `connect:`. So `Adder(16)`, `Mux(16)` and `Comparator(16)` were dead ends: double-clicking one on the canvas did nothing. That contradicts the README —

> any component can be opened up and shown as what it is made of

— and a reader following the drill-down hit a wall at the first piece of arithmetic.

## Why not just make them composites

The synth voice (`apps/web/src/features/blog/synth-in-hardware/circuits.ts`) is 18 nodes at ~78k ticks/s. All-gates it is ~2,000 nodes at ~700 ticks/s — 30× too slow for the audio demo to run at all. Verilog export would degrade from `assign sum = a + b + carry_in` to a thousand structural assigns, which is worse for Verilator and denies Yosys the chance to infer an adder and map it to the target's carry chain.

## What this does instead

`MADE_OF` (`packages/core/src/std/made-of.ts`) holds a gate-level build per primitive, keyed by name, built from the node's own arguments — so `Adder({width: 16})` opens 16 stages and `Adder({width: 8})` opens 8.

**Display only.** Constructed on demand for a dialog that already runs its own simulator, never elaborated into the running netlist. Drilling an Adder costs nothing until someone drills it.

Hierarchical, so each level stays small: `Adder(16)` → 16 × `FullAdder` → five gates. `FullAdder` is new to the stdlib; it did not exist before, despite being the worked example in both the `circuit()` header docs and the README.

Covers Adder, Subtractor, Incrementer, Mux, Comparator. Skips Multiplier/Divider (a 256-adder array teaches nothing) and memory (ROM/RAM map to hardened blocks, so a gate build would misrepresent the hardware). Stops at Xor/And/Or/Not — the game already teaches NAND → gates level by level, so this covers gates → arithmetic with no overlap.

## Verification turns the risk into a feature

Two descriptions of addition maintained by hand in different files can drift. `made-of.verify.ts` proves they cannot: it walks every `MADE_OF` entry, reads that primitive's port widths, and sweeps the whole input space. Exhaustive at widths 1, 2 and 8 (2^17 cases for an adder), fast-check sampled at 16. Generic by construction, so a new entry is covered the moment it is added — plus a check that fails if any entry has no subject.

Both guards were fault-injected rather than trusted green:

- Mis-wiring the adder's `b` bits by one stage → `testbench_passed: false`, exit 1. `Adder(1)` still passed there, since `(i+1) % 1 == 0` is correct at width 1 — which is why the sweep runs widths 1, 2 and 8 rather than one representative width.
- The containment guard (below) correctly flags the one builder that can actually leak and stays quiet for the one that cannot.

## Design notes

**Not a registry.** `eval-registry` exists because user code defines evals dynamically at runtime. `MADE_OF` is a fixed set known at build time, so it is a frozen lookup table — no registration, no mutation, no metadata field, and nothing new crossing the sandbox's JSON boundary.

**Containment guard.** `STDLIB_CIRCUITS` materializes every exported function in the std modules by calling it with no arguments and keeping whatever returns a `BuiltCircuit`. A builder exported bare would be silently registered as a second, structurally different "Adder" — nothing else would fail; the canvas and the exporter would just quietly disagree. `made-of.test.ts` applies `_materialize`'s exact predicate to the module's public surface, so it fails on the dangerous edit itself rather than after the fact.

**Frames carry their own library.** A reference build introduces circuits the page has never depended on — FigletStream depends on `Adder`, not on the `FullAdder`/`Slice`/`Concat`/gates that explain it — and `projection.ts` silently drops any node it cannot resolve. Without this the dialog rendered the boundary ports and an empty middle. Caught in the browser, now pinned by two tests including the nested case.

**`hasReference` is separate from `isComposite`** because `isComposite` also selects which node renderer to use; overloading it would have made an Adder draw as a generic box.

## Also in here

- `RippleCarryDemo` on `/learn/adders` was faking it with the stdlib `Adder`, so the depth that section is entirely about was invisible. Now 8 of the page's own `FullAdder` chained tail-to-head, closing the `TODO` at `circuits.ts:54`. Verified against all 65,536 input pairs.
- Inspector dialog widened `max-w-5xl` → `max-w-[1600px]`, `80vh` → `88vh`. The reference builds are the widest thing it ever shows.
- `Comparator` uses `Xnor` for per-bit equality instead of `Xor` + `Not`: 60 → 52 nodes, same level of abstraction, no teaching value lost.

## Testing

- core 749 passed, ui 130, web 20; typecheck clean across core/ui/web/game; biome clean
- `check-exports` and `check-synth-limits` clean
- Browser (Playwright): `SnakeCore > Snake_HeadUnit > Adder`, `FigletStream > adder > fa0 (FullAdder)`, and `/learn/adders` `fa3 > ha1` all drill correctly. Ripple demo shows 15+1 = `0x10` carry off, and 255+1 = `0x00` carry **on** — the case that forces the carry through all 8 stages. No console errors.

## Known, deliberate

Roughly half of each build is `Slice`/`Concat` plumbing (74% for `Adder(8)`) — artifacts of the IR addressing ports rather than bits, not hardware. `Mux(16)` and `Comparator(16)` are ~100 nodes and render small; the dialog has pan/zoom/fit for that. Measured ELK, tighter ranks and contracting the plumbing as fixes; the binding constraints are rank count and parallel-row count, both properties of the circuit rather than the layout engine, so none of them move the number much. Left as-is on purpose — a 16-bit adder really is that big, and seeing that is the point.
