### PR TITLE
Stop the spec sheet and level intro leaking onto mobile

### DIFF
--- a/apps/game/src/components/LevelIntro.tsx
+++ b/apps/game/src/components/LevelIntro.tsx
@@ -57,7 +57,10 @@ export function LevelIntro({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onDismiss()}>
-      <DialogContent className="gap-0 sm:max-w-lg">
+      {/* `hidden md:grid` for the same reason the spec sheet needs it: the
+          portal escapes <DesktopOnly>, and the open effect does not check
+          the viewport. */}
+      <DialogContent className="hidden md:grid gap-0 sm:max-w-lg">
         <DialogHeader className="space-y-2">
           <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
             Something new

--- a/apps/game/src/routes/$levelId.tsx
+++ b/apps/game/src/routes/$levelId.tsx
@@ -605,7 +605,10 @@ function PlayLevel({ level }: { level: Level }) {
           showOverlay={false}
           onInteractOutside={(e) => e.preventDefault()}
           onOpenAutoFocus={(e) => e.preventDefault()}
-          className="max-h-[45vh] gap-0 overflow-y-auto"
+          // Portalled to document.body, so <DesktopOnly>'s `hidden md:contents`
+          // wrapper never applies. Without this the spec sheet opens over the
+          // mobile notice on every level, since `specOpen` starts true.
+          className="hidden md:flex max-h-[45vh] gap-0 overflow-y-auto"
         >
           <SheetTitle className="sr-only">Level spec</SheetTitle>
           <SpecPanel


### PR DESCRIPTION
On play.simten.dev, the spec sheet opened over the mobile notice on every level, and the level intro did the same on first visit.

## Cause

`DesktopOnly` is CSS-gated by design — it wraps children in `hidden md:contents` rather than conditionally rendering them, so the markup works before JS arrives and there is no hydration flicker.

Both of these are Radix overlays, and Radix renders overlay content through a portal onto `document.body`. They are not descendants of that wrapper, so the `hidden` class never reaches them. The page looked correctly gated while two overlays leaked through it.

## Fix

The responsive class has to live on the portalled element itself:

- `SheetContent` in `$levelId.tsx` gets `hidden md:flex`. This is the one that shows constantly, because `specOpen` is `useState(true)` and so opens on every level.
- `DialogContent` in `LevelIntro.tsx` gets `hidden md:grid`. Its effect opens on mount for any level with an unseen intro and never checks the viewport. Different base display, hence `grid` rather than `flex`.

CSS rather than a JS media query, to stay consistent with the gating the app already chose.

## Not changed

`LevelComplete` portals the same way, but only renders when `result?.status === 'pass'` — which needs the editor, which is desktop-only. Unreachable on mobile, so no speculative fix.

Desktop behaviour is untouched. The spec still opens by default there, which is right: it is the truth table the level is asking you to satisfy, and the Hide toggle covers the case where you want the canvas room.

## Verification

`tsc --noEmit` clean, `@simten/game` 145/145.
