### PR TITLE
Show the full gate collection on the level complete card

### DIFF
--- a/apps/game/src/components/LevelComplete.tsx
+++ b/apps/game/src/components/LevelComplete.tsx
@@ -21,7 +21,7 @@ import {
   DialogTitle,
 } from '@simten/ui/primitives/dialog';
 import { Link } from '@tanstack/react-router';
-import { gatesGainedAfter } from '../game/levels';
+import { ALL_GATES, gatesGainedAfter } from '../game/levels';
 import type { Level } from '../game/types';
 
 interface LevelCompleteProps {
@@ -82,18 +82,35 @@ export function LevelComplete({ open, onOpenChange, level, next }: LevelComplete
               Your gates
             </p>
             <ul className="flex flex-wrap gap-1.5">
-              {owned.map((name) => (
-                <li
-                  key={name}
-                  className={
-                    unlocked.includes(name)
-                      ? 'rounded border border-emerald-600/40 bg-emerald-500/10 px-2 py-1 font-mono text-xs font-medium text-emerald-600 dark:text-emerald-400'
-                      : 'rounded border border-border px-2 py-1 font-mono text-xs text-muted-foreground'
-                  }
-                >
-                  {name}
-                </li>
-              ))}
+              {ALL_GATES.map((name) => {
+                const isNew = unlocked.includes(name);
+                const isOwned = owned.includes(name);
+                return (
+                  <li
+                    key={name}
+                    // Green means "yours", so every earned gate is green and the
+                    // row reads as a collection filling up. The newest is the
+                    // filled one: same hue, more of it. A second accent colour
+                    // was tried and read as a warning rather than a reward,
+                    // which is what amber means everywhere else in a UI.
+                    //
+                    // Locked gates are dashed and dimmed. The contrast floor
+                    // does not apply to them (WCAG exempts inactive components,
+                    // and these are not actionable), but they stay readable on
+                    // purpose: wanting `Xor` before you have it is the reason to
+                    // show the whole row rather than just what you own.
+                    className={
+                      isNew
+                        ? 'motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-300 rounded border border-emerald-700 bg-emerald-700 px-2 py-1 font-mono text-xs font-medium text-white dark:border-emerald-400 dark:bg-emerald-400 dark:text-emerald-950'
+                        : isOwned
+                          ? 'rounded border border-emerald-600/40 bg-emerald-500/10 px-2 py-1 font-mono text-xs font-medium text-emerald-600 dark:text-emerald-400'
+                          : 'rounded border border-dashed border-border px-2 py-1 font-mono text-xs text-muted-foreground opacity-60'
+                    }
+                  >
+                    {name}
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}

--- a/apps/game/src/components/MobileNotice.tsx
+++ b/apps/game/src/components/MobileNotice.tsx
@@ -36,7 +36,7 @@ export function MobileNotice({ level }: { level: Level }) {
           </h1>
           <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
             You solve these by writing code, next to a circuit diagram wide enough to read. Neither
-            fits on a phone yet. Open this on a laptop and it will be waiting.
+            fits on a phone yet.
           </p>
 
           <div className="flex flex-col gap-2">
@@ -47,7 +47,7 @@ export function MobileNotice({ level }: { level: Level }) {
               See the map
             </Link>
             <div className="mt-2 text-xs text-muted-foreground">
-              Or read what this is about at{' '}
+              Read more at{' '}
               <a
                 href="https://simten.dev"
                 className="text-foreground underline-offset-2 hover:underline"

--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -132,7 +132,7 @@ export default circuit('Not1', {
     par: 1,
     outro: {
       headline: 'One gate down',
-      body: 'You built NOT out of nothing but NAND. Every other gate works the same way. AND is next.',
+      body: 'You built NOT out of nothing but NAND. AND is next.',
     },
   },
 
@@ -179,7 +179,7 @@ export default circuit('And2', {
     par: 2,
     outro: {
       headline: 'AND, rebuilt',
-      body: 'A NAND and the NOT you worked out last level. The gate you were handed in level one, this time made of parts. OR will not come this directly.',
+      body: "OR is next. It's a bit tougher.",
     },
   },
 
@@ -678,6 +678,22 @@ export function nextLevel(id: string): Level | undefined {
  * have unlocked NAND while showing no unlock at all, which is the one card
  * every player sees.
  */
+/**
+ * Every gate the campaign hands over, in unlock order.
+ *
+ * Walked out of LEVELS rather than written down, so it cannot drift from what
+ * the grader actually permits. The completion card shows the whole list with
+ * the unearned ones dimmed: a row that only grows tells you what you have, but
+ * a row with gaps in it tells you there is more to come.
+ */
+export const ALL_GATES: string[] = (() => {
+  const seen: string[] = [];
+  for (const level of LEVELS) {
+    for (const name of level.allowed) if (!seen.includes(name)) seen.push(name);
+  }
+  return seen;
+})();
+
 export function gatesGainedAfter(level: Level, next: Level | undefined): string[] {
   if (levelIndex(level.id) === 0) return level.allowed;
   return next ? next.allowed.filter((name) => !level.allowed.includes(name)) : [];


### PR DESCRIPTION
The completion card showed only the gates you already owned, as a short row that grew by one. Three chips side by side does not read as acquiring anything, and it gave no sense of how far through the campaign you were.

## The collection

The card now shows **every** gate the campaign hands over, in unlock order, with the unearned ones dashed and dimmed. A row that only grows tells you what you have; a row with gaps tells you there is more coming. Seeing `Xor` and `DFlipFlop` sitting there unearned is the point.

`ALL_GATES` is walked out of `LEVELS` rather than written down, so the card cannot advertise a gate the grader does not permit — the same rule `gatesGainedAfter` already follows.

Three states, one hue:

| State | Treatment |
|---|---|
| Just earned | filled green, inverted text |
| Owned | green outline, green text |
| Locked | dashed, dimmed |

Solid to outlined to dashed reads as a progression. Every earned gate is green because green means "yours"; colouring only the newest made the ones you already had look locked.

An amber border on the newest was tried first and looked wrong: two accent hues fighting inside a 60px chip, and an amber outline means *caution* everywhere else in a UI, so the reward read as an error.

Fill colours were picked for contrast rather than by eye — `emerald-700` on white is 5.48:1 and `emerald-400` with `emerald-950` is 7.88:1. The obvious `emerald-600` only reaches 3.77 against white, which fails AA at this text size.

Locked chips use `opacity-60`. WCAG exempts inactive components from the contrast minimum and these are not actionable, but they stay legible rather than ghosted, because wanting a gate you cannot use yet is the reason to show the whole row.

One `motion-safe:zoom-in-95` on the newly earned chip, and nothing else. Players see this card thirteen times; motion that delights once is irritating by the fifth, and the victory run is already the celebration — this dialog is the receipt.

## Copy

Three outros were doing work the player did not need.

- **NOT**: dropped "Every other gate works the same way", which pre-empted the next six levels' own discovery.
- **AND**: was a recap of the solution plus a garbled clause ("OR will not come this directly"). The headline already says the gate was rebuilt from parts, so the recap went and the sentence reads "OR is next. It's a bit tougher."
- **Mobile notice**: dropped "Open this on a laptop and it will be waiting" — the heading already says it needs a desktop. "Or read what this is about at" became "Read more at", since the "Or" referred to the removed sentence.

## Verification

`tsc --noEmit` clean, `@simten/game` 145/145.
