### PR TITLE
Fork the campaign, and give it somewhere to arrive

### DIFF
--- a/apps/game/src/game/levels.ts
+++ b/apps/game/src/game/levels.ts
@@ -652,7 +652,47 @@ export default circuit('Toggle1', {
     par: 1,
     outro: {
       headline: 'A clock, and something that counts it',
-      body: "Nothing drives this but time. Flip a second one every time the first falls and you are counting in binary. That's the last level for now. More to come.",
+      body: 'Nothing drives this but time. Flip a second one every time the first falls and you are counting in binary.',
+    },
+  },
+  {
+    id: 'counter',
+    title: 'Counter',
+    tagline: 'Count 0, 1, 2, 3, and back to 0.',
+    brief:
+      'Two lamps, no switches. Read them as a binary number and they should count up once per tick, then wrap. `bit0` alternates every tick, exactly as your toggle did. `bit1` is the harder half: it flips only on the ticks where `bit0` is already on.',
+    target: 'Counter2',
+    inputs: [],
+    outputs: ['bit0', 'bit1'],
+    allowed: ['Nand', 'DFlipFlop'],
+    sequential: true,
+    stub: `// One clock drives every flip-flop, so bit1 cannot be clocked off
+// bit0. Both tick together, and the logic decides which one changes.
+// Work out what each \`d\` should be from what the two of them hold now.
+const Counter2 = circuit('Counter2', {
+  nodes: {
+    dff0: DFlipFlop(),
+    dff1: DFlipFlop(),
+    bit0: Led,
+    bit1: Led,
+  },
+  connect: ({ nodes: { dff0, dff1, bit0, bit1 } }) => [
+    dff0.q.to(bit0.in),
+    dff1.q.to(bit1.in),
+  ],
+});
+`,
+    vectors: [
+      { inputs: {}, expect: { bit0: 1, bit1: 0 } },
+      { inputs: {}, expect: { bit0: 0, bit1: 1 } },
+      { inputs: {}, expect: { bit0: 1, bit1: 1 } },
+      { inputs: {}, expect: { bit0: 0, bit1: 0 } },
+      { inputs: {}, expect: { bit0: 1, bit1: 0 } },
+    ],
+    par: 6,
+    outro: {
+      headline: 'It counts',
+      body: 'Memory holds the number and logic works out the next one. Widen it and that is every counter in every clock, every program counter in every CPU.',
     },
   },
 ];

--- a/apps/game/src/game/map-circuit.ts
+++ b/apps/game/src/game/map-circuit.ts
@@ -20,7 +20,7 @@
 
 import type { Circuit } from '@simten/core';
 import { And, Constant, circuit, createSimulatorFromCircuit, Led, Switch } from '@simten/core';
-import { MAP_ROWS } from './map';
+import { MAP_REQUIRES, MAP_ROWS } from './map';
 
 /** Node ids must be identifier-safe; level ids contain hyphens. */
 function sane(levelId: string): string {
@@ -51,12 +51,12 @@ export function buildMapCircuit() {
     }
   }
 
-  // One AND per extra prerequisite: a row of k levels needs k-1 gates to
-  // reduce to a single "all of these are done" signal.
-  MAP_ROWS.forEach((row, rowIndex) => {
-    if (rowIndex === MAP_ROWS.length - 1) return;
-    for (let i = 0; i < row.length - 1; i++) nodes[`gate_${rowIndex}_${i}`] = And;
-  });
+  // One AND per extra prerequisite: a level with k of them needs k-1 gates to
+  // reduce to a single "all of these are done" signal. Most have one and need
+  // none; the gate is there for wherever two branches rejoin.
+  for (const [levelId, requires] of Object.entries(MAP_REQUIRES)) {
+    for (let i = 0; i < requires.length - 1; i++) nodes[`gate_${levelId}_${i}`] = And;
+  }
 
   return circuit('CampaignMap', {
     nodes,
@@ -65,24 +65,25 @@ export function buildMapCircuit() {
       // biome-ignore lint/suspicious/noExplicitAny: connection defs.
       const wires: any[] = [];
 
-      for (const levelId of MAP_ROWS[0] ?? []) {
-        wires.push(n[ALWAYS_ON].out.to(n[unlockId(levelId)].in));
-      }
+      for (const levelId of MAP_ROWS.flat()) {
+        const requires = MAP_REQUIRES[levelId] ?? [];
 
-      MAP_ROWS.forEach((row, rowIndex) => {
-        const above = MAP_ROWS[rowIndex + 1];
-        if (!above) return;
+        // No prerequisites means the level is open from the start.
+        if (requires.length === 0) {
+          wires.push(n[ALWAYS_ON].out.to(n[unlockId(levelId)].in));
+          continue;
+        }
 
-        // Reduce this row to one signal, then fan it out to every level above.
-        let signal = n[switchId(row[0])].out;
-        for (let i = 1; i < row.length; i++) {
-          const gate = n[`gate_${rowIndex}_${i - 1}`];
-          wires.push(signal.to(gate.a), n[switchId(row[i])].out.to(gate.b));
+        // Reduce this level's prerequisites to one "all done" signal.
+        let signal = n[switchId(requires[0])].out;
+        for (let i = 1; i < requires.length; i++) {
+          const gate = n[`gate_${levelId}_${i - 1}`];
+          wires.push(signal.to(gate.a), n[switchId(requires[i])].out.to(gate.b));
           signal = gate.out;
         }
 
-        wires.push(signal.to(...above.map((levelId) => n[unlockId(levelId)].in)));
-      });
+        wires.push(signal.to(n[unlockId(levelId)].in));
+      }
 
       return wires;
     },

--- a/apps/game/src/game/map.ts
+++ b/apps/game/src/game/map.ts
@@ -1,13 +1,14 @@
 /**
  * The campaign as a map.
  *
- * `MAP_ROWS` is the campaign's shape, listed bottom to top; row 0 is where a
- * player starts and the last row is the end of the act. A row holds more than
- * one level when those levels are siblings rather than a sequence: Turing
- * Complete puts AND, NOR and OR side by side precisely so three levels read as
- * one beat instead of a vertical grind. Nothing today branches, but the shape
- * is here so that adding a cluster is an edit to this list rather than a
- * rewrite of the layout.
+ * Two structures, deliberately separate. `MAP_ROWS` is layout: which rank and
+ * column a level is drawn at, bottom to top. `MAP_REQUIRES` is the graph: what
+ * actually gates what. Rows carried both until the campaign branched, at which
+ * point they could not, because two branches of different lengths put unrelated
+ * levels on the same rank.
+ *
+ * The campaign runs as a trunk of gate levels, forks into arithmetic and memory
+ * once every gate is earned, and rejoins at a counter that needs both.
  *
  * Order lives here rather than in `levels.ts` because it is presentation: a
  * level stays pure data that could be fetched as JSON, and the map decides how
@@ -28,12 +29,56 @@ export const MAP_ROWS: string[][] = [
   ['xor'],
   ['xnor'],
   ['making-a-component'],
-  ['half-adder'],
-  ['full-adder'],
-  ['latch'],
-  ['d-latch'],
+  // The fork: arithmetic on the left, memory on the right. Rows are ranks, so
+  // the shorter branch simply stops and `toggle` sits alone on the last one.
+  ['half-adder', 'latch'],
+  ['full-adder', 'd-latch'],
   ['toggle'],
+  ['counter'],
 ];
+
+/**
+ * What each level needs finished before it opens.
+ *
+ * Rows used to carry this implicitly: everything on a row fed everything on the
+ * row above. That reads a straight campaign correctly and cannot describe a
+ * branching one, because two branches of different lengths put unrelated levels
+ * on the same rank and the adjacency rule then invents a dependency between
+ * them. Arithmetic and memory are genuinely independent — an adder needs no
+ * flip-flop and a latch needs no carry — so the line the map drew through them
+ * was never real.
+ *
+ * Rows are now layout only. This is the graph. A level absent from here opens
+ * from the start.
+ */
+export const MAP_REQUIRES: Record<string, string[]> = {
+  not: ['first-wire'],
+  and: ['not'],
+  or: ['and'],
+  nor: ['or'],
+  xor: ['nor'],
+  xnor: ['xor'],
+  'making-a-component': ['xnor'],
+
+  // The fork. Both branches need every gate, so it splits after the last one:
+  // nothing downstream can reach for a gate the player skipped.
+  'half-adder': ['making-a-component'],
+  latch: ['making-a-component'],
+
+  'full-adder': ['half-adder'],
+  'd-latch': ['latch'],
+  toggle: ['d-latch'],
+
+  // Where the branches rejoin. The AND is honest: a counter is memory holding
+  // the number and logic working out the next one, so it needs both halves.
+  counter: ['full-adder', 'toggle'],
+};
+
+export interface MapSection {
+  label: string;
+  /** Index into `MAP_ROWS` where this band begins, counting from the bottom. */
+  startRow: number;
+}
 
 /**
  * Bands, labelled where they begin.
@@ -41,19 +86,11 @@ export const MAP_ROWS: string[][] = [
  * Turing Complete rules its map into `BOOLEAN LOGIC`, `ARITHMETIC`, `CPU
  * ARCHITECTURE` and so on, and the labels do more than decorate: they turn a
  * column of nodes into a structure, and they say that what you can see is a
- * *section* rather than the whole game. That second part matters here, because
- * eight levels presented as the entire campaign reads as thin, while eight
- * presented as its first band reads as a start.
+ * *section* rather than the whole game.
  *
  * Declared by the row a band opens on rather than by a range, so adding a level
  * to the middle of a band does not require renumbering the one above it.
  */
-export interface MapSection {
-  label: string;
-  /** Index into `MAP_ROWS` where this band begins, counting from the bottom. */
-  startRow: number;
-}
-
 export const MAP_SECTIONS: MapSection[] = [
   // One band from the first wire to the last gate. It was two: a short
   // "First circuits" and then "Every gate from one", which split a single
@@ -61,8 +98,10 @@ export const MAP_SECTIONS: MapSection[] = [
   // player had done anything worth dividing.
   { label: 'Logic gates', startRow: 0 },
   { label: 'Components', startRow: 7 },
-  { label: 'Arithmetic', startRow: 8 },
-  { label: 'Memory', startRow: 10 },
+  // Arithmetic and memory used to be two bands stacked one above the other.
+  // They run side by side now, and a band is a horizontal strip, so two labels
+  // would sit on the same rows and fight. One band covers the fork instead.
+  { label: 'Arithmetic and memory', startRow: 8 },
 ];
 
 /**
@@ -133,8 +172,10 @@ const SECTION_PAD_BOTTOM = 30;
  * Build the graph.
  *
  * Y is inverted because React Flow's axis grows downward and the map reads
- * upward: the first row gets the largest Y so it sits at the bottom. Edges run
- * from a row to the one above it, which is the direction of progress.
+ * upward: the first row gets the largest Y so it sits at the bottom. Rows place
+ * the nodes; `MAP_REQUIRES` draws the edges. Keeping those apart is what lets a
+ * branch be shorter than its sibling without acquiring a link to whatever
+ * happens to sit on the same rank.
  *
  * `solved` is the set of completed level ids, read from stored progress by the
  * map page. It is empty for the first frame after mount, because storage can
@@ -173,17 +214,15 @@ export function buildMapGraph(solved: ReadonlySet<string> = new Set()): {
         },
       });
     });
-
-    // Join every level in this row to every level in the row above. With one
-    // level per row that is a plain chain; with a cluster it fans out.
-    const above = MAP_ROWS[rowIndex + 1];
-    if (!above) return;
-    for (const source of row) {
-      for (const target of above) {
-        edges.push({ id: `${source}->${target}`, source, target });
-      }
-    }
   });
+
+  // Edges come from the dependency graph, not from row adjacency, so two
+  // branches of different lengths do not acquire a link they never had.
+  for (const [levelId, requires] of Object.entries(MAP_REQUIRES)) {
+    for (const source of requires) {
+      edges.push({ id: `${source}->${levelId}`, source, target: levelId });
+    }
+  }
 
   /**
    * Each band spans from the row it opens on up to the row below the next

--- a/apps/game/src/game/solutions/counter.ts
+++ b/apps/game/src/game/solutions/counter.ts
@@ -1,0 +1,33 @@
+/** Reference solution for `counter`. Proven by `__tests__/levels.test.ts`. */
+
+import { circuit } from '@simten/core/circuit';
+import { DFlipFlop, Led, Nand } from '@simten/core/std';
+
+export const Counter2 = circuit('Counter2', {
+  // Synchronous, not ripple. Simten wires one clock to every flip-flop, so the
+  // second cannot be clocked off the first; both tick together and the logic
+  // decides which of them changes. bit0 flips every tick, and bit1 flips only
+  // when bit0 is already set, which is the XOR of the two.
+  nodes: {
+    dff0: DFlipFlop(),
+    dff1: DFlipFlop(),
+    n1: Nand,
+    n2: Nand,
+    n3: Nand,
+    n4: Nand,
+    bit0: Led,
+    bit1: Led,
+  },
+  connect: ({ nodes: { dff0, dff1, n1, n2, n3, n4, bit0, bit1 } }) => [
+    // bit0: hold the opposite of what you hold, so it alternates.
+    dff0.q_bar.to(dff0.d),
+    dff0.q.to(bit0.in, n1.a, n2.a),
+
+    // bit1: XOR(bit0, bit1), built from four NANDs.
+    dff1.q.to(bit1.in, n1.b, n3.b),
+    n1.out.to(n2.b, n3.a),
+    n2.out.to(n4.a),
+    n3.out.to(n4.b),
+    n4.out.to(dff1.d),
+  ],
+});

--- a/apps/game/src/game/solutions/index.ts
+++ b/apps/game/src/game/solutions/index.ts
@@ -29,6 +29,7 @@
  */
 
 import andGate from './and.ts?raw';
+import counter from './counter.ts?raw';
 import dLatch from './d-latch.ts?raw';
 import firstWire from './first-wire.ts?raw';
 import fullAdder from './full-adder.ts?raw';
@@ -55,5 +56,6 @@ export const SOLUTIONS: Record<string, string> = {
   'd-latch': dLatch,
   latch,
   toggle,
+  counter,
   'full-adder': fullAdder,
 };


### PR DESCRIPTION
The campaign was a straight line of thirteen levels ending on a flip-flop. It now forks and closes on something that counts.

```
        ┌── half-adder ── full-adder ──┐
trunk ──┤                              ├── counter
        └── latch ── d-latch ── toggle ┘
```

## Why it could not branch before

`MAP_ROWS` carried both layout and dependency: edges were derived from adjacency, "everything on this row feeds everything on the row above". That reads a straight campaign correctly and cannot describe a branching one — arithmetic is two levels and memory is three, so the shorter branch ends on a rank where the longer one is still going, and the adjacency rule invents a dependency between two levels that have nothing to do with each other.

Rows are now layout only. `MAP_REQUIRES` is the graph, and both `buildMapGraph` and `buildMapCircuit` read it instead of adjacency.

That first commit changed no behaviour — the requires map initially encoded exactly the chain the rows described, and all 145 tests passed untouched. The fork went in after.

## Where the fork sits

After `making-a-component`, which is the level where the last gate is earned. That placement is load-bearing: if it split earlier, a player could skip `nor` and then meet a level whose `allowed` set hands them `Nor` anyway, and the gate collection on the completion card would be advertising something they never built.

Arithmetic and memory are genuinely independent — an adder needs no flip-flop and a latch needs no carry — so the line the map used to draw through them was never real.

## The capstone

A 2-bit counter, reachable only with both branches finished. `counter: ['full-adder', 'toggle']`, and the AND is honest: a counter is memory holding the number and logic working out the next one.

It is **synchronous, not ripple**. Simten wires one clock to every sequential component, so the second flip-flop cannot be clocked off the first — both tick together and the logic decides which changes. `bit0` alternates every tick; `bit1` flips only when `bit0` is already set, which is the XOR of the two. Six nodes: four NANDs and two flip-flops.

`toggle`'s outro already set this up ("flip a second one every time the first falls and you are counting in binary"), so the trailing "that's the last level for now" came off.

A clock would have been the better destination but it is not one level — it needs a divider, counters, BCD decode and a display. The counter is the first rung of that arc and works with the existing truth-table grader.

## Verification

`tsc --noEmit` clean. Tests went 145 to **152**, the seven new ones being `levels.test.ts` running the counter through the real grader: a reference solution passes, constant answers fail, completion copy exists. Every level is still reachable from `first-wire`.

## Not done

`nextLevel` is still positional. It happens to walk a sensible route (`full-adder` leads to `latch`, which starts the other branch) but it does not know the graph exists, so it works by accident of ordering rather than by design.
